### PR TITLE
thumbnail performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cache
 *.log
 yarn.lock
 shigureader_local_file_info.json
+shigureader_zip_file_content_info.json
 unzip_cache
 compress_cache
 executables

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "react-click-outside": "^3.0.1",
     "react-dom": "^16.5.2",
     "react-router-dom": "^4.3.1",
-    "react-visibility-sensor": "^5.0.2",
     "screenfull": "^4.0.0",
     "string-hash": "^1.1.3",
     "sweetalert2": "^8.0.7",

--- a/src/client/ExplorerPage.js
+++ b/src/client/ExplorerPage.js
@@ -418,7 +418,13 @@ export default class ExplorerPage extends Component {
                     <div className="file-cell">
                         <Link  target="_blank" to={toUrl}  key={item} className={"file-cell-inner"}>
                             <center className={"file-cell-title"} title={text}>{text}</center>
-                            <LoadingImage isThumbnail className={"file-cell-thumbnail"} title={item} fileName={item}   url={this.thumbnails[item]} />
+                            <LoadingImage 
+                                    isThumbnail 
+                                    className={"file-cell-thumbnail"} 
+                                    title={item} fileName={item}   
+                                    url={this.thumbnails[item]}
+                                    onReceiveUr={url => {this.thumbnails[item] = url;}} 
+                                    />
                         </Link>
                         <FileChangeToolbar header={fileSize} file={item} />
                     </div>

--- a/src/client/ExplorerPage.js
+++ b/src/client/ExplorerPage.js
@@ -423,7 +423,7 @@ export default class ExplorerPage extends Component {
                                     className={"file-cell-thumbnail"} 
                                     title={item} fileName={item}   
                                     url={this.thumbnails[item]}
-                                    onReceiveUr={url => {this.thumbnails[item] = url;}} 
+                                    onReceiveUrl={url => {this.thumbnails[item] = url;}} 
                                     />
                         </Link>
                         <FileChangeToolbar header={fileSize} file={item} />

--- a/src/client/ExplorerPage.js
+++ b/src/client/ExplorerPage.js
@@ -147,7 +147,7 @@ export default class ExplorerPage extends Component {
     handleRes(res){
         if (!res.failed) {
             this.loadedHash = this.getHash();
-            let {dirs, files, path, tag, author, fileInfos} = res;
+            let {dirs, files, path, tag, author, fileInfos, thumbnails} = res;
             this.loadedHash = this.getHash();
             files = files || [];
             this.videoFiles = files.filter(util.isVideo) || []
@@ -157,6 +157,7 @@ export default class ExplorerPage extends Component {
             this.tag = tag || "";
             this.author = author || "";
             this.fileInfos = fileInfos || {};
+            this.thumbnails = thumbnails || {};
             this.res = res;
 
             //check pageindex
@@ -417,7 +418,7 @@ export default class ExplorerPage extends Component {
                     <div className="file-cell">
                         <Link  target="_blank" to={toUrl}  key={item} className={"file-cell-inner"}>
                             <center className={"file-cell-title"} title={text}>{text}</center>
-                            <LoadingImage isThumbnail className={"file-cell-thumbnail"} title={item} fileName={item} />
+                            <LoadingImage isThumbnail className={"file-cell-thumbnail"} title={item} fileName={item}   url={this.thumbnails[item]} />
                         </Link>
                         <FileChangeToolbar header={fileSize} file={item} />
                     </div>

--- a/src/client/LoadingImage.js
+++ b/src/client/LoadingImage.js
@@ -26,77 +26,96 @@ export default class LoadingImage extends Component {
   }
 
   onChange(isVisible){
-    const {onChange, url, mode, fileName} = this.props;
+    const {onChange, url} = this.props;
 
     if(isVisible){
       onChange && onChange();
     }
 
-    if(isVisible && !this.state.loaded & !this.loading){
+    if(isVisible && !this.state.url & !this.loading){
       if(url){
         this.setState({ url: url }); 
       } else {
-        const api = (mode === "author" || mode === "tag") ? Constant.TAG_THUMBNAIL_PATH_API :  '/api/firstImage';
-        const body = {};
-
-        if(mode === "author" || mode === "tag"){
-          body[mode] = fileName;
-        }else{
-          body["fileName"] = fileName;
-        }
-
-        this.loading = true;
-
-        // fetch(api, {
-        //   method: 'POST',
-        //   headers: {
-        //       Accept: 'application/json',
-        //       'Content-Type': 'application/json',
-        //   },
-        //   body: JSON.stringify(body)
-        // })
-        // .then((res) => {
-        //   if(res.status === 200){
-        //     return res.blob();
-        //   }else{
-        //     this.setState({ failed: true }); 
-        //     return null;
-        //   }
-        // })
-        // .then((res) => { 
-        //   if(!this.isUnmounted && res){
-        //     this.url = URL.createObjectURL(res);
-        //     this.setState({ loaded: true }); 
-        //   }
-        // });
-
-        Sender.post(api, body, res => {
-          if(this.isUnmounted){
-            return;
-          }
-          if (res.failed) {
-            this.setState({ failed: true }); 
-          }else{
-            this.props.onReceiveUrl && this.props.onReceiveUrl(res.url);
-            this.setState({ url: res.url }); 
-          }
-        });
+        this.requestThumbnail()
       }
+    }
+  }
+
+  requestThumbnail(){
+    const { mode, fileName } = this.props;
+    const api = (mode === "author" || mode === "tag") ? Constant.TAG_THUMBNAIL_PATH_API :  '/api/firstImage';
+    const body = {};
+
+    if(mode === "author" || mode === "tag"){
+      body[mode] = fileName;
+    }else{
+      body["fileName"] = fileName;
+    }
+
+    this.loading = true;
+
+    // fetch(api, {
+    //   method: 'POST',
+    //   headers: {
+    //       Accept: 'application/json',
+    //       'Content-Type': 'application/json',
+    //   },
+    //   body: JSON.stringify(body)
+    // })
+    // .then((res) => {
+    //   if(res.status === 200){
+    //     return res.blob();
+    //   }else{
+    //     this.setState({ failed: true }); 
+    //     return null;
+    //   }
+    // })
+    // .then((res) => { 
+    //   if(!this.isUnmounted && res){
+    //     this.url = URL.createObjectURL(res);
+    //     this.setState({ loaded: true }); 
+    //   }
+    // });
+
+    Sender.post(api, body, res => {
+      if(this.isUnmounted){
+        return;
+      }
+      if (res.failed) {
+        this.setState({ failed: this.state.failed+1 }); 
+      }else{
+        this.props.onReceiveUrl && this.props.onReceiveUrl(res.url);
+        this.setState({ url: res.url }); 
+      }
+    });
+  }
+
+  Error(){
+    if(this.state.failed < 3){
+      this.setState({
+        url: null,
+      }, ()=> {
+        this.requestThumbnail()
+      });
     }
   }
 
   render() {
     let content;
-    const {className, fileName, url, bottomOffet, topOffet, title, isThumbnail, onGetUrl, ...others} = this.props;
+    const {className, fileName, url, bottomOffet, topOffet, title, isThumbnail, onReceiveUrl, ...others} = this.props;
     const cn = "loading-image  " + className;
     let active = true;
+
     if (this.state.failed) {
       content = (<img key={fileName} ref={e=>{this.dom = e && e.node}} className={cn} src={notAvailable} title={title || fileName} {...others}/>);
     } else if (!this.state.url) {
       content = (<img key={fileName} className={cn} src={loading} title={title || fileName} {...others}/>);
     } else if (this.state.url) {
       active = false;
-      content = (<img key={fileName} className={className} src={this.state.url} title={title || fileName} {...others}/>);
+      content = (<img key={fileName} ref={e=>{this.dom = e && e.node}} 
+                      className={className} src={this.state.url} title={title || fileName} 
+                      onError={this.Error.bind(this)} 
+                      {...others}/>);
     }
 
     return (

--- a/src/client/LoadingImage.js
+++ b/src/client/LoadingImage.js
@@ -10,6 +10,7 @@ export default class LoadingImage extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      failed: 0
     };
   }
 
@@ -91,13 +92,18 @@ export default class LoadingImage extends Component {
   }
 
   Error(){
-    if(this.state.failed < 3){
+    if(!this.isTotalFailed()){
       this.setState({
         url: null,
+        failed: this.state.failed+1
       }, ()=> {
         this.requestThumbnail()
       });
     }
+  }
+
+  isTotalFailed(){
+    return this.state.failed > 2;
   }
 
   render() {
@@ -106,16 +112,16 @@ export default class LoadingImage extends Component {
     const cn = "loading-image  " + className;
     let active = true;
 
-    if (this.state.failed) {
+    if (this.isTotalFailed()) {
       content = (<img key={fileName} ref={e=>{this.dom = e && e.node}} className={cn} src={notAvailable} title={title || fileName} {...others}/>);
-    } else if (!this.state.url) {
-      content = (<img key={fileName} className={cn} src={loading} title={title || fileName} {...others}/>);
     } else if (this.state.url) {
       active = false;
       content = (<img key={fileName} ref={e=>{this.dom = e && e.node}} 
                       className={className} src={this.state.url} title={title || fileName} 
                       onError={this.Error.bind(this)} 
                       {...others}/>);
+    } else {
+      content = (<img key={fileName} className={cn} src={loading} title={title || fileName} {...others}/>);
     }
 
     return (

--- a/src/client/LoadingImage.js
+++ b/src/client/LoadingImage.js
@@ -77,6 +77,7 @@ export default class LoadingImage extends Component {
           if (res.failed) {
             this.setState({ failed: true }); 
           }else{
+            this.props.onReceiveUrl && this.props.onReceiveUrl(res.url);
             this.setState({ url: res.url }); 
           }
         });
@@ -86,7 +87,7 @@ export default class LoadingImage extends Component {
 
   render() {
     let content;
-    const {className, fileName, url, bottomOffet, topOffet, title, isThumbnail, ...others} = this.props;
+    const {className, fileName, url, bottomOffet, topOffet, title, isThumbnail, onGetUrl, ...others} = this.props;
     const cn = "loading-image  " + className;
     let active = true;
     if (this.state.failed) {

--- a/src/client/LoadingImage.js
+++ b/src/client/LoadingImage.js
@@ -71,6 +71,9 @@ export default class LoadingImage extends Component {
         // });
 
         Sender.post(api, body, res => {
+          if(this.isUnmounted){
+            return;
+          }
           if (res.failed) {
             this.setState({ failed: true }); 
           }else{

--- a/src/client/LoadingImage.js
+++ b/src/client/LoadingImage.js
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import loading from './images/loading.png';
 import notAvailable from './images/not-available.png';
 const VisibilitySensor = require('react-visibility-sensor').default;
-
+import Sender from './Sender';
 const Constant = require("../constant");
-
 
 export default class LoadingImage extends Component {
   constructor(props) {
@@ -50,25 +49,34 @@ export default class LoadingImage extends Component {
 
         this.loading = true;
 
-        fetch(api, {
-          method: 'POST',
-          headers: {
-              Accept: 'application/json',
-              'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(body)
-        })
-        .then((res) => {
-          if(res.status === 200){
-            return res.blob();
-          }else{
+        // fetch(api, {
+        //   method: 'POST',
+        //   headers: {
+        //       Accept: 'application/json',
+        //       'Content-Type': 'application/json',
+        //   },
+        //   body: JSON.stringify(body)
+        // })
+        // .then((res) => {
+        //   if(res.status === 200){
+        //     return res.blob();
+        //   }else{
+        //     this.setState({ failed: true }); 
+        //     return null;
+        //   }
+        // })
+        // .then((res) => { 
+        //   if(!this.isUnmounted && res){
+        //     this.url = URL.createObjectURL(res);
+        //     this.setState({ loaded: true }); 
+        //   }
+        // });
+
+        Sender.post(api, body, res => {
+          if (res.failed) {
             this.setState({ failed: true }); 
-            return null;
-          }
-        })
-        .then((res) => { 
-          if(!this.isUnmounted && res){
-            this.url = URL.createObjectURL(res);
+          }else{
+            this.url = res.url;
             this.setState({ loaded: true }); 
           }
         });

--- a/src/client/LoadingImage.js
+++ b/src/client/LoadingImage.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import loading from './images/loading.png';
 import notAvailable from './images/not-available.png';
-const VisibilitySensor = require('react-visibility-sensor').default;
 import Sender from './Sender';
 const Constant = require("../constant");
 
@@ -18,7 +16,7 @@ export default class LoadingImage extends Component {
     if(this.props.isThumbnail){
       setTimeout(()=>{
         this.onChange(true)
-      }, 2*1000);
+      }, 200);
     }
   }
 
@@ -110,29 +108,19 @@ export default class LoadingImage extends Component {
     let content;
     const {className, fileName, url, bottomOffet, topOffet, title, isThumbnail, onReceiveUrl, ...others} = this.props;
     const cn = "loading-image  " + className;
-    let active = true;
 
     if (this.isTotalFailed()) {
       content = (<img key={fileName} ref={e=>{this.dom = e && e.node}} className={cn} src={notAvailable} title={title || fileName} {...others}/>);
     } else if (this.state.url) {
-      active = false;
       content = (<img key={fileName} ref={e=>{this.dom = e && e.node}} 
                       className={className} src={this.state.url} title={title || fileName} 
                       onError={this.Error.bind(this)} 
                       {...others}/>);
     } else {
-      content = (<img key={fileName} className={cn} src={loading} title={title || fileName} {...others}/>);
+      content = (<img key={fileName} className={cn}  title={title || fileName} {...others}/>);
     }
 
-    return (
-      <VisibilitySensor 
-          active={active}
-          key={fileName||url}
-          offset={{bottom: bottomOffet || -200, top: topOffet || -200}} 
-          onChange={this.onChange.bind(this)}>
-        {content}
-      </VisibilitySensor>
-    );
+    return content;
   }
 }
 

--- a/src/client/LoadingImage.js
+++ b/src/client/LoadingImage.js
@@ -8,7 +8,8 @@ export default class LoadingImage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      failed: 0
+      failed: 0,
+      url: props.url
     };
   }
 
@@ -16,7 +17,7 @@ export default class LoadingImage extends Component {
     if(this.props.isThumbnail){
       setTimeout(()=>{
         this.onChange(true)
-      }, 200);
+      }, 0);
     }
   }
 
@@ -24,19 +25,9 @@ export default class LoadingImage extends Component {
     this.isUnmounted = true;
   }
 
-  onChange(isVisible){
-    const {onChange, url} = this.props;
-
-    if(isVisible){
-      onChange && onChange();
-    }
-
-    if(isVisible && !this.state.url & !this.loading){
-      if(url){
-        this.setState({ url: url }); 
-      } else {
+  onChange(){
+    if(!this.state.url & !this.loading){
         this.requestThumbnail()
-      }
     }
   }
 
@@ -52,30 +43,6 @@ export default class LoadingImage extends Component {
     }
 
     this.loading = true;
-
-    // fetch(api, {
-    //   method: 'POST',
-    //   headers: {
-    //       Accept: 'application/json',
-    //       'Content-Type': 'application/json',
-    //   },
-    //   body: JSON.stringify(body)
-    // })
-    // .then((res) => {
-    //   if(res.status === 200){
-    //     return res.blob();
-    //   }else{
-    //     this.setState({ failed: true }); 
-    //     return null;
-    //   }
-    // })
-    // .then((res) => { 
-    //   if(!this.isUnmounted && res){
-    //     this.url = URL.createObjectURL(res);
-    //     this.setState({ loaded: true }); 
-    //   }
-    // });
-
     Sender.post(api, body, res => {
       if(this.isUnmounted){
         return;

--- a/src/client/LoadingImage.js
+++ b/src/client/LoadingImage.js
@@ -10,7 +10,6 @@ export default class LoadingImage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      loaded: false
     };
   }
 
@@ -35,8 +34,7 @@ export default class LoadingImage extends Component {
 
     if(isVisible && !this.state.loaded & !this.loading){
       if(url){
-        this.url = url;
-        this.setState({ loaded: true }); 
+        this.setState({ url: url }); 
       } else {
         const api = (mode === "author" || mode === "tag") ? Constant.TAG_THUMBNAIL_PATH_API :  '/api/firstImage';
         const body = {};
@@ -76,8 +74,7 @@ export default class LoadingImage extends Component {
           if (res.failed) {
             this.setState({ failed: true }); 
           }else{
-            this.url = res.url;
-            this.setState({ loaded: true }); 
+            this.setState({ url: res.url }); 
           }
         });
       }
@@ -91,11 +88,11 @@ export default class LoadingImage extends Component {
     let active = true;
     if (this.state.failed) {
       content = (<img key={fileName} ref={e=>{this.dom = e && e.node}} className={cn} src={notAvailable} title={title || fileName} {...others}/>);
-    } else if (this.state.loaded === false) {
+    } else if (!this.state.url) {
       content = (<img key={fileName} className={cn} src={loading} title={title || fileName} {...others}/>);
-    } else if (this.url) {
+    } else if (this.state.url) {
       active = false;
-      content = (<img key={fileName} className={className} src={this.url} title={title || fileName} {...others}/>);
+      content = (<img key={fileName} className={className} src={this.state.url} title={title || fileName} {...others}/>);
     }
 
     return (

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -92,9 +92,9 @@ const db = {
     hashTable: {},
 };
 
-app.use(express.static('dist'),{
+app.use(express.static('dist', {
     maxAge: (1000*3600*5).toString()
-});
+}));
 app.use(express.static(rootPath, {
     maxAge: (1000*3600*24*30).toString() // uses milliseconds per docs
 }));

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -631,18 +631,6 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
     const sendable = !isPregenerateMode;
 
     const contentInfo = zip_content_db.getData("/");
-    if(!isPregenerateMode && contentInfo[fileName]){
-        if(contentInfo[fileName].thumbnail) {
-            const img = contentInfo[fileName].thumbnail;
-            if(img){
-                sendImage(img);
-                return;
-            }
-        }else if(!contentInfo[fileName].thumbnail){
-            return;
-        }
-    }
- 
     const outputPath = getOutputPath(fileName);
  
     function sendImage(img){

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -92,9 +92,11 @@ const db = {
     hashTable: {},
 };
 
-app.use(express.static('dist'));
+app.use(express.static('dist'),{
+    maxAge: (1000*3600*5).toString
+});
 app.use(express.static(rootPath, {
-    maxAge: '12096000000' // uses milliseconds per docs
+    maxAge: (1000*3600*24*30).toString // uses milliseconds per docs
 }));
 
 //  to consume json request body

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -622,6 +622,16 @@ function fullPathToUrl(img){
     return turnPathSepToWebSep("..\\"+ path.relative(rootPath, fullpath));
 }
 
+function get7zipOption(fileName, outputPath, one){
+    //https://sevenzip.osdn.jp/chm/cmdline/commands/extract.htm
+    //e make folder as one level
+    if(one){
+        return ['e', fileName, `-o${outputPath}`, one, "-aos"];
+    }else{
+        return ['e', fileName, `-o${outputPath}`, "-aos"];
+    }
+}
+
 async function getFirstImageFromZip(fileName, res, mode, counter) {
     if(!util.isCompress(fileName)){
         return;
@@ -678,7 +688,7 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
         }
 
         //Overwrite mode: -aos	Skip extracting of existing files.
-        const opt = ['e', fileName, `-o${outputPath}`, one, "-aos"];
+        const opt = get7zipOption(fileName, outputPath, one);
         const {stderrForThumbnail} = await execa(sevenZip, opt);
         if (!stderrForThumbnail) {
             // send path to client
@@ -786,8 +796,8 @@ app.post('/api/extract', async (req, res) => {
 
     (async () => {
         try{
-            const all = ['e', fileName, `-o${outputPath}`, "-aos"];
-            const {stdout, stderr} = await execa(sevenZip, all);
+            const opt = get7zipOption(fileName, outputPath);
+            const {stdout, stderr} = await execa(sevenZip, opt);
             if (!stderr) {
                 fs.readdir(outputPath, (error, results) => {
                     const temp = generateContentUrl(results, outputPath);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -664,6 +664,11 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
         zip_content_db.push("/", contentInfo);
     }
 
+    function handleFail(){
+        sendable && res.sendStatus(404);
+        updateZipDb(null, 0);
+    }
+
     try{
         //https://superuser.com/questions/1020232/list-zip-files-contents-using-7zip-command-line-with-non-verbose-machine-friend
         let {stdout, stderr} = await limit(() => execa(sevenZip, ['l', '-r', '-ba' ,'-slt', fileName]));
@@ -671,8 +676,7 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
         
         if (!text) {
             console.error("[getFirstImageFromZip]", "no text");
-            sendable && res.send("404 fail");
-            updateZipDb(null, 0);
+            handleFail();
             return;
         }
 
@@ -681,8 +685,7 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
         
         if (!one) {
             console.error("[getFirstImageFromZip]", fileName,  "no files from output");
-            sendable && res.sendStatus(404);
-            updateZipDb(null, 0);
+            shandleFail();
             return;
         }
 
@@ -702,11 +705,11 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
             }
         } else {
             console.error("[getFirstImageFromZip extract exec failed]", code);
-            sendable && res.sendStatus(404);
+            handleFail();
         }
     } catch(e) {
         console.error("[getFirstImageFromZip] exception", e);
-        sendable && res.sendStatus(404);
+        handleFail();
     }
 }
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -93,10 +93,10 @@ const db = {
 };
 
 app.use(express.static('dist', {
-    maxAge: (1000*3600*5).toString()
+    maxAge: (1000*3600).toString()
 }));
 app.use(express.static(rootPath, {
-    maxAge: (1000*3600*24*30).toString() // uses milliseconds per docs
+    maxAge: (1000*3600*24).toString() // uses milliseconds per docs
 }));
 
 //  to consume json request body
@@ -631,7 +631,7 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
     const sendable = !isPregenerateMode;
 
     const contentInfo = zip_content_db.getData("/");
-    if(contentInfo[fileName]){
+    if(!isPregenerateMode && contentInfo[fileName]){
         if(contentInfo[fileName].thumbnail) {
             const img = contentInfo[fileName].thumbnail;
             if(img){
@@ -661,6 +661,7 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
             thumbnail: thumbnail,
             pageNum: pageNum
         };
+        zip_content_db.push("/", contentInfo);
     }
 
     try{

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -679,8 +679,8 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
 
         //Overwrite mode: -aos	Skip extracting of existing files.
         const opt = ['x', fileName, `-o${outputPath}`, one, "-aos"];
-        const {stdout2, stderr2} = await execa(sevenZip, opt);
-        if (!stderr2) {
+        const {stderrForThumbnail} = await execa(sevenZip, opt);
+        if (!stderrForThumbnail) {
             // send path to client
             let temp = path.join(outputPath, one);
             temp = turnPathSepToWebSep(temp);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -93,10 +93,10 @@ const db = {
 };
 
 app.use(express.static('dist'),{
-    maxAge: (1000*3600*5).toString
+    maxAge: (1000*3600*5).toString()
 });
 app.use(express.static(rootPath, {
-    maxAge: (1000*3600*24*30).toString // uses milliseconds per docs
+    maxAge: (1000*3600*24*30).toString() // uses milliseconds per docs
 }));
 
 //  to consume json request body

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -678,11 +678,11 @@ async function getFirstImageFromZip(fileName, res, mode, counter) {
         }
 
         //Overwrite mode: -aos	Skip extracting of existing files.
-        const opt = ['x', fileName, `-o${outputPath}`, one, "-aos"];
+        const opt = ['e', fileName, `-o${outputPath}`, one, "-aos"];
         const {stderrForThumbnail} = await execa(sevenZip, opt);
         if (!stderrForThumbnail) {
             // send path to client
-            let temp = path.join(outputPath, one);
+            let temp = path.join(outputPath, path.basename(one));
             temp = turnPathSepToWebSep(temp);
             sendImage(temp);
             updateZipDb(temp, files.length);

--- a/src/tools/cleanCache.js
+++ b/src/tools/cleanCache.js
@@ -52,6 +52,7 @@ function cleanCache(cachePath){
 
 function _clean(cachePath){
     const folders1 = fs.readdirSync(cachePath);
+    //check each file/dir in level 1
     folders1.forEach(p1 => {
         try {
             p1 = path.resolve(cachePath, p1);


### PR DESCRIPTION
utlize browser cache
use server-side cache to send less /api/firstImage request

用url载入thumbnail才可以利用浏览器的cache机制
服务器lsdir的时候把thumbnail的地址发给前端。前端可以先尝试去render。

但如果那个thumbnail却被删除。
前端找后端再要一次thumbnail 同时后端更新thumbnail地址

感谢熊猫网给我这次优化很多实践参考。
