### PR TITLE
Linux下手动整理会报错😭

### DIFF
--- a/src/server/fileChangeHandler.js
+++ b/src/server/fileChangeHandler.js
@@ -28,7 +28,7 @@ module.exports.init = function(app, logger){
                     err = await pfs.mkdir(dest);
                 }
                 if (!err) {
-                    const {stdout, stderr} = await execa("move", [src, dest]);
+                    const {stdout, stderr} = await execa("mv", [src, dest]);
                     err = stderr;
                     // err = await pfs.rename(src, dest);
                 }


### PR DESCRIPTION
*nix里移动文件的命令是mv，与Windows里面的move不同。

> Error: spawn move ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:268:19)
    at onErrorNT (internal/child_process.js:468:16)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn move',
  path: 'move',
  spawnargs: [
    'dirA',
    'dirB'
  ],
  stdout: '',
  stderr: '',
  failed: true,
  signal: null,
  cmd: 'move dirA dirB',
  timedOut: false,
  killed: false
}