### PR TITLE
Close pop up message after 3 seconds

### DIFF
--- a/src/client/subcomponent/FileChangeToolbar.js
+++ b/src/client/subcomponent/FileChangeToolbar.js
@@ -41,7 +41,9 @@ export default class FileChangeToolbar extends Component {
                         spop({
                             style: "success",
                             template: 'Deleted ' + this.props.file,
-                            position:  this.props.popPosition
+                            position:  this.props.popPosition,
+                            autoclose: 3000
+
                         });
                     }else{
                         spop({
@@ -74,7 +76,8 @@ export default class FileChangeToolbar extends Component {
                             spop({
                                 style: "success",
                                 template: template, // ['Moved', this.props.file, "to", path, 'Successfully'].join(" "),
-                                position:  this.props.popPosition
+                                position:  this.props.popPosition,
+                                autoclose: 3000
                             });
                         }else{
                             spop({


### PR DESCRIPTION
不手动点掉操作成功消息的时候，太多消息会把页面按钮都挡住

![fix](https://user-images.githubusercontent.com/32187698/81156116-3558fc00-8fb8-11ea-8411-41d383539281.png)
