### PR TITLE
Docker 启动问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 # 基于node:alpine
 FROM node:alpine
 # 安装 node-sass 需要 python build-base，解压工具 p7zip
-RUN apk add --update-cache python build-base imagemagick p7zip
+RUN apk add --no-cache python build-base imagemagick p7zip
 
 # js文件存放目录
 WORKDIR /usr/src/app
-
-#打包复制js代码
-COPY package*.json ./
-COPY . .
+COPY package.json ./
 
 #安装node依赖
 RUN npm install 
@@ -19,9 +16,11 @@ RUN npm install
 VOLUME /data
 
 #网页端口
-EXPOSE 8080
 EXPOSE 3000
+
+#安装程序
+COPY . .
+RUN mkdir thumbnails cache
 RUN chown -R node /usr/src/app
 USER node
-#启用服务
 CMD [ "npm", "run","dev" ]


### PR DESCRIPTION
在不创建 thumbnails cache 这两个子目录的情况下,程序无法启动。

```
[0] [nodemon] starting `node src/server/index.js`
[0] [zipInfoDb] number of entries in database : 0
[0] (node:207720) UnhandledPromiseRejectionWarning: /home/liwufan/codes/debug/ShiguReader2/thumbnails
[0] (Use `node --trace-warnings ...` to show where the warning was created)
[0] (node:207720) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
[0] (node:207720) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
[1] clean-webpack-plugin: /home/liwufan/codes/debug/ShiguReader2/dist has been removed.
[1] ℹ ｢wds｣: Project is running at http://0.0.0.0:3000/
[1] ℹ ｢wds｣: webpack output is served from /
[1] ℹ ｢wds｣: Content not from webpack is served from /home/liwufan/codes/debug/ShiguReader2
[1] ℹ ｢wds｣: 404s will fallback to /index.html

```