### PR TITLE
Fix avg image size when zips contain videos

### DIFF
--- a/src/client/ExplorerPage.js
+++ b/src/client/ExplorerPage.js
@@ -397,13 +397,10 @@ export default class ExplorerPage extends Component {
             return 0;
         }
 
-        let total;
-        if (this.getFileSize(fp) === 0) {
-            total = this.getTotalImgSize(fp);
-        } else {
-            total = Math.min(this.getFileSize(fp), this.getTotalImgSize(fp))
-        }
-        return total / pageNum;
+        const totalImgSize = this.getTotalImgSize(fp);
+        const videoNum = this.getVideoNum(fp);
+
+        return util.calcAvgImgSize({ pageNum, totalImgSize, videoNum });
     }
 
     async handleKeyDown(event) {

--- a/src/client/OneBook.js
+++ b/src/client/OneBook.js
@@ -470,21 +470,18 @@ export default class OneBook extends Component {
 
   //may not be reliable
   getPageAvgSize() {
-      const { fileStat, imageFiles, index, zipInfo, videoFiles } = this.state;
-      const fileSize = (fileStat?.size) || null;
-      const fileDate = (fileStat?.mtimeMs) || null;
+      const { zipInfo, videoFiles } = this.state;
 
-      let avgFileSize = 0; // 和explore的getPageAvgSize(e)是重复逻辑？
-      if(this.hasImage()){
-        if (zipInfo) {
-          avgFileSize = zipInfo.totalImgSize / zipInfo.pageNum;
-        } else if(fileSize) {
-          avgFileSize = fileSize / this.getImageLength();
-        }
-        if(avgFileSize == Infinity){
-          avgFileSize = 0;
-        }
-      };
+      if (!this.hasImage()) {
+        return 0;
+      }
+
+      const pageNum = zipInfo?.pageNum || (this.getImageLength() + videoFiles.length);
+      const totalImgSize = zipInfo?.totalImgSize || 0;
+      const videoNum = zipInfo?.videoNum || videoFiles.length;
+
+      const avgFileSize = util.calcAvgImgSize({ pageNum, totalImgSize, videoNum });
+
       return avgFileSize;
   }
 

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -177,11 +177,29 @@ module.exports.getAverage = function(intArray) {
     if (intArray.length === 0) {
       return 0;
     }
-  
+
     const sum = intArray.reduce((acc, val) => acc + val);
     const avg = sum / intArray.length;
-  
+
     return avg;
+}
+
+/**
+ * Calculate average image size for a zip/folder.
+ *
+ * @param {Object} param0
+ * @param {number} param0.pageNum    total number of files reported
+ * @param {number} [param0.totalImgSize] summed size of image files
+ * @param {number} [param0.videoNum] number of video files included
+ * @returns {number} average size of image files
+ */
+module.exports.calcAvgImgSize = function({ pageNum, totalImgSize = 0, videoNum = 0 }) {
+    const imgCount = Math.max(0, pageNum - videoNum);
+    if (imgCount === 0) {
+        return 0;
+    }
+
+    return totalImgSize / imgCount;
 }
 
 

--- a/src/test/util.test.js
+++ b/src/test/util.test.js
@@ -18,6 +18,7 @@ const {
   escapeRegExp,
   isWindowsPath,
   getAverage,
+  calcAvgImgSize,
   truncateString,
 } = require("../common/util.js");
 
@@ -229,6 +230,18 @@ describe("ut for js util functions", () => {
   describe("#getAverage()", () => {
     it("should return the mean of the input array", () => {
       assert.strictEqual(getAverage([1, 2, 3, 4]), 2.5);
+    });
+  });
+
+  describe("#calcAvgImgSize()", () => {
+    it("should ignore video files when computing average", () => {
+      const avg = calcAvgImgSize({ pageNum: 6, totalImgSize: 40, videoNum: 2 });
+      assert.strictEqual(avg, 10);
+    });
+
+    it("should return 0 when total image size is missing", () => {
+      const avg = calcAvgImgSize({ pageNum: 2 });
+      assert.strictEqual(avg, 0);
     });
   });
 


### PR DESCRIPTION
## Summary
- remove fileSize fallback from calcAvgImgSize util
- update Explorer and OneBook to pass only image and video info
- adjust unit tests for new util behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689549e6fbf88325a5c760b1b7d26023