### PR TITLE
Remove obsolete skip-db-clean option

### DIFF
--- a/GUI/server_gui.py
+++ b/GUI/server_gui.py
@@ -31,7 +31,6 @@ class ExpressServerGUI:
             self.root.iconbitmap(icon_path)
 
         self.skip_scan = tk.BooleanVar()
-        self.skip_db_clean = tk.BooleanVar()
         self.port = tk.StringVar(value="3000")
 
         self.load_settings()
@@ -50,8 +49,6 @@ class ExpressServerGUI:
         self.chk_skip_scan = tk.Checkbutton(frame, text="[快速启动] 跳过起始扫描 ", variable=self.skip_scan)
         self.chk_skip_scan.pack(anchor='w', pady=2)
 
-        self.chk_skip_db_clean = tk.Checkbutton(frame, text="[高级功能] 不清理上次的DB缓存, 直接启动。", variable=self.skip_db_clean)
-        self.chk_skip_db_clean.pack(anchor='w', pady=2)
 
         port_frame = tk.Frame(frame)
         port_frame.pack(anchor='w', pady=5)
@@ -80,8 +77,6 @@ class ExpressServerGUI:
         options = []
         if self.skip_scan.get():
             options.append("--skip-scan")
-        if self.skip_db_clean.get():
-            options.append("--skip-db-clean")
 
         options.append("--port")
         options.append(self.port.get())
@@ -161,14 +156,12 @@ class ExpressServerGUI:
         config.read(SETTING_Cache_FN)
         if 'Settings' in config:
             self.skip_scan.set(config.getboolean('Settings', 'skip_scan', fallback=True))
-            self.skip_db_clean.set(config.getboolean('Settings', 'skip_db_clean', fallback=False))
             self.port.set(config.get('Settings', 'port', fallback="3000"))
 
     def save_settings(self):
         config = configparser.ConfigParser()
         config['Settings'] = {
             'skip_scan': self.skip_scan.get(),
-            'skip_db_clean': self.skip_db_clean.get(),
             'port': self.port.get()
         }
         with open(SETTING_Cache_FN, 'w') as configfile:

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -81,7 +81,6 @@ program
     .option('-p, --port <number>', 'Specify the port',  portConfig.default_http_port)
     .option('--skip-scan', 'skip initial scan for startup fasted', false)
     .option('--skip-cache-clean', 'skip initial cache clean', false)
-    .option('--skip-db-clean', '[Advanced Feature] skip clean previous file_table db record', false)
     .option('--print-qr-code [boolean]', '', true);
 
 program.parse(process.argv);
@@ -89,7 +88,6 @@ const options = program.opts();
 const port = _.isString(options.port)? parseInt(options.port): options.port; // 懒得细看commander，不是最正确写法
 const skipScan = options.skipScan;
 const skipCacheClean = options.skipCacheClean;
-const skipDbClean = options.skipDbClean;
 const printQrCode = options.printQrCode === "false" ? false : options.printQrCode;
 // console.log("port: ", port);
 // console.log("skipScan: ", skipScan);
@@ -195,7 +193,7 @@ async function init() {
         logger.warn("[Error] You may need to run npm run build");
     }
 
-    const sqldb = await db.init(skipDbClean);
+    const sqldb = await db.init();
     await thumbnailDb.init(sqldb);
     await historyDb.init(sqldb);
     await zipInfoDb.init(sqldb);

--- a/src/server/models/db.js
+++ b/src/server/models/db.js
@@ -57,18 +57,14 @@ module.exports.runSync  = async (sql, params) => {
 }
 
 let sqldb;
-module.exports.init = async (skipDbClean)=> {
+module.exports.init = async () => {
     const SQLWrapper = require("./SQLWrapper");
     const backup_db_path = path.join(pathUtil.getWorkSpacePath(), "shigureader_internal_db.sqlite");
     sqldb = new SQLWrapper(backup_db_path);
 
-    // 开发用： 这样就不会删除上次的file table。    
-    const _SKP_INIT = skipDbClean;
+    console.log("remove previous db cache")
 
-    if(!_SKP_INIT){
-        console.log("remove previous db cache")
-
-        await sqldb.execSync( `
+    await sqldb.execSync( `
 
         PRAGMA journal_mode = OFF;
         PRAGMA synchronous = OFF; 
@@ -136,7 +132,6 @@ module.exports.init = async (skipDbClean)=> {
          CREATE INDEX IF NOT EXISTS ft_dirPath_index ON file_table (dirPath); 
          CREATE INDEX IF NOT EXISTS ft_dirName_index ON file_table (dirName); 
       `);
-    }
     return sqldb;
 }
 


### PR DESCRIPTION
## Summary
- drop deprecated --skip-db-clean CLI argument
- always clean internal DB on startup
- update GUI launcher to stop exposing skip-db-clean

## Testing
- `python -m py_compile GUI/server_gui.py`
- `npm test` *(fails: Path Util Test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ff065e9c8325890bb4b7209d453d