### PR TITLE
fix: limit scanning to configured folders

### DIFF
--- a/src/server/pathUtil.js
+++ b/src/server/pathUtil.js
@@ -204,8 +204,8 @@ module.exports.filterPathConfig = async (path_config, skipScan) => {
 
     // scan path
     let temp_scan_path = [].concat(scan_folder_pathes);
+    // Do not automatically scan good_folder or not_good_folder; only scan specified paths
     // temp_scan_path = temp_scan_path.concat(good_folder, good_folder_root, not_good_folder_root, not_good_folder);
-    temp_scan_path = temp_scan_path.concat(good_folder, not_good_folder);
 
 
     let scan_path = [];


### PR DESCRIPTION
## Summary
- avoid scanning `good_folder` and `not_good_folder` during startup scanning so only `scan_folder_pathes` are scanned

## Testing
- `npm test` *(fails: 29 passing, 10 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a289c19e888325b3e4912b2c6f63e4