### PR TITLE
Save zip archives alongside source folder

### DIFF
--- a/src/config/user-config.js
+++ b/src/config/user-config.js
@@ -12,7 +12,6 @@ config.thumbnail_folder_name = "thumbnails";
 
 config.img_convert_cache = "minified_zip_cache"
 
-config.zip_output_cache = "zip_output";
 
 //delete or move to recyle bin
 //删除操作是真的彻底删除还是丢进回收站

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -65,7 +65,6 @@ mkdirSync(workspacePath);
 mkdirSync(thumbnailFolderPath);
 mkdirSync(cachePath);
 mkdirSync(pathUtil.getImgConverterCachePath());
-mkdirSync(pathUtil.getZipOutputCachePath());
 
 const logger = require("./logger");
 logger.init();

--- a/src/server/pathUtil.js
+++ b/src/server/pathUtil.js
@@ -211,14 +211,12 @@ module.exports.filterPathConfig = async (path_config, skipScan) => {
     let scan_path = [];
     if(skipScan){
         scan_path.push(getImgConverterCachePath());
-        scan_path.push(getZipOutputCachePath());
         //没scan的时候，把scan path加到quick access
         quick_access_pathes = [...temp_scan_path,  ...quick_access_pathes, downloadFolder];
         quick_access_pathes = _.uniq(quick_access_pathes);
     }else{
         scan_path = temp_scan_path.slice();
         scan_path.push(getImgConverterCachePath());
-        scan_path.push(getZipOutputCachePath());
         scan_path = _.uniq(scan_path);
 
         quick_access_pathes = [...quick_access_pathes, downloadFolder];
@@ -253,9 +251,6 @@ const getImgConverterCachePath = module.exports.getImgConverterCachePath = () =>
     return imgConvertFolder;
 }
 
-const getZipOutputCachePath = module.exports.getZipOutputCachePath = () => {
-    return path.join(getWorkSpacePath(), userConfig.zip_output_cache);
-}
 
 // get file extension
 const getExt = module.exports.getExt = function (p) {

--- a/src/server/routes/moveOrDelete.js
+++ b/src/server/routes/moveOrDelete.js
@@ -9,10 +9,7 @@ const thumbnailDb = require("../models/thumbnailDb");
 const zipInfoDb = require("../models/zipInfoDb");
 
 const pathUtil = require("../pathUtil");
-const {
-    isExist,
-    getZipOutputCachePath
-} = pathUtil;
+const { isExist } = pathUtil;
 
 const util = global.requireUtil();
 
@@ -194,8 +191,7 @@ router.post('/api/zipFolder', serverUtil.asyncWrapper(async (req, res) => {
     //     return;
     // }
 
-    const outputRoot = getZipOutputCachePath();
-    const _resultZipPath = path.resolve(outputRoot, path.basename(src) + ".zip");
+    const _resultZipPath = path.resolve(path.dirname(src), path.basename(src) + ".zip");
     try {
         let { stdout, stderr, resultZipPath } = await sevenZipHelp.zipOneFolder(src, _resultZipPath);
         if (stderr) {


### PR DESCRIPTION
## Summary
- zip folder output now placed beside the source directory instead of workspace `zip_output`
- drop unused zip output cache path and startup directory creation

## Testing
- `npm test` *(fails: Path Util Test assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a2e700848325a63b5fcc4e036177