### PR TITLE
Improve book comparison heuristics

### DIFF
--- a/src/server/BookCompareUtil.js
+++ b/src/server/BookCompareUtil.js
@@ -32,19 +32,26 @@ function isTwoBookTheSame(fn1, fn2) {
         }
     }
 
-    if (_clean(r1.author) !== _clean(r2.author)) {
-        return TOTALLY_DIFFERENT;
+    const author1 = _clean(r1.author);
+    const author2 = _clean(r2.author);
+    const group1 = _clean(r1.group);
+    const group2 = _clean(r2.group);
+
+    if (author1 && author2) {
+        const authorSimilar = __isHighlySimilar(author1, author2);
+        const crossSimilar = __isHighlySimilar(author1, group2) || __isHighlySimilar(author2, group1);
+        if (!authorSimilar && !crossSimilar) {
+            return TOTALLY_DIFFERENT;
+        }
     }
 
-    let result = SAME_AUTHOR;
+    let result = author1 && author2 ? SAME_AUTHOR : TOTALLY_DIFFERENT;
     //e.g one is c97, the other is c96. cannot be the same
     if (r1.comiket && r2.comiket && r1.comiket !== r2.comiket) {
         return result;
     }
 
     let isSimilarGroup;
-    let group1 = _clean(r1.group);
-    let group2 = _clean(r2.group);
     if ((group1 && !group2) || (!group1 && group2)) {
         isSimilarGroup = true;
     } else {

--- a/src/test/BookCompareUtil.test.js
+++ b/src/test/BookCompareUtil.test.js
@@ -42,6 +42,12 @@ describe('isTwoBookTheSame', () => {
     assert.strictEqual(result, LIKELY_IN_PC);
   });
 
+  it('should handle missing author by comparing group and title', () => {
+    const result = isTwoBookTheSame('(C101) [灯夜工房] 破魔のミズキは終われない',
+                                    '(C101) [灯夜工房 (灯ひでかず)] 破魔のミズキは終われない');
+    assert.strictEqual(result, IS_IN_PC);
+  });
+
 });
 
 


### PR DESCRIPTION
## Summary
- refine `isTwoBookTheSame` to compare authors more flexibly and account for missing author information
- add regression test for cases where a filename lacks explicit author but shares group/title

## Testing
- `npm test` *(fails: Path Util Test expects Windows-style paths)*

------
https://chatgpt.com/codex/tasks/task_e_68a28dffef8c83258e3cae7ab4303889