### PR TITLE
docs: clarify environment setup and deprecate English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [<img src="https://img.shields.io/github/v/release/hjyssg/ShiguReader?label=latest%20release">](https://github.com/hjyssg/ShiguReader/releases)
 
 
-[English Version](https://github.com/hjyssg/ShiguReader/blob/Dev_Frontend/README_English.md)
+[English Version (outdated)](README_English.md)
 
 
 ShiguReader是一款可在电脑或iPad上使用的漫画浏览器，它还支持整理资源、播放音乐和观看视频等多种功能。只需前往[Release](https://github.com/hjyssg/ShiguReader/releases)，下载后便可立即开始使用。
@@ -31,7 +31,7 @@ ShiguReader是一款可在电脑或iPad上使用的漫画浏览器，它还支�
 * 可移动、删除文件。
 * 可制作统计图表，统计文件大小和各时期的文件数量。
 * 接近于旧版熊猫网的配色，让你感受亲切熟悉。
-* 同时支持Windows和lunix系统。
+* 同时支持Windows和Linux系统。
 
 ##### 支持的文件格式
 
@@ -57,13 +57,13 @@ g：快速跳页
 
 
 ##### 第三方依赖
-linux系统强烈建议安装[image magick](https://imagemagick.org)。这样可以使用它来压缩图片，提高软件的性能。
+Linux系统强烈建议安装[ImageMagick](https://imagemagick.org)。这样可以使用它来压缩图片，提高软件的性能。
 
 ##### 注意事项
 
 部分文件名带汉字或日语假名的图片无法正常加载，你可能需要进行以下语言设置。请注意，这可能会导致其他非Unicode软件出现乱码问题。
 
-Windows 语言设置如下所示：:  
+Windows 语言设置如下所示：
 <img src="screenshot/unicode-setting.png" alt="Unicode Setting" width="600"/>
 
 ##### 压缩包内图片压缩功能
@@ -94,7 +94,7 @@ Windows 语言设置如下所示：:
 
 ##### 开发环境设置
 
-开发人员请阅读[Readme_Env_Setup](https://github.com/hjyssg/ShiguReader/blob/Dev_Frontend/Readme_Env_Setup.md)
+开发人员请阅读[Readme_Env_Setup](Readme_Env_Setup.md)
 
 ##### 反馈与建议
 

--- a/README_English.md
+++ b/README_English.md
@@ -1,10 +1,12 @@
 <h1 align="center">ShiguReader</h1>
 
+> ⚠️ This English README is outdated. Please refer to the [Chinese README](README.md) for the latest information.
+
 [<img src="https://img.shields.io/github/v/release/hjyssg/ShiguReader?label=latest%20release">](https://github.com/hjyssg/ShiguReader/releases)
 [<img src="https://img.shields.io/docker/v/liwufan/shigureader?label=docker%20version">](https://hub.docker.com/r/liwufan/shigureader)
 [<img src="https://img.shields.io/docker/pulls/liwufan/shigureader.svg">](https://hub.docker.com/r/liwufan/shigureader)
 
-ShiguReader is a manga browser that can be used on computers or iPads. It also supports various features such as organizing resources, playing music, and watching videos. Simply go to [Release](https://github.com/hjyssg/ShiguReader/releasesx) and download it to start using immediately.
+ShiguReader is a manga browser that can be used on computers or iPads. It also supports various features such as organizing resources, playing music, and watching videos. Simply go to [Release](https://github.com/hjyssg/ShiguReader/releases) and download it to start using immediately.
 
 ##### Screenshots
 
@@ -70,7 +72,7 @@ If you like our software and would like to treat us to a cup of milk tea, you ca
 
 ##### Development Environment Setup
 
-please refer to [Readme_Env_Setup](https://github.com/hjyssg/ShiguReader/blob/Dev_Frontend/Readme_Env_Setup.md).
+please refer to [Readme_Env_Setup](Readme_Env_Setup.md).
 
 ##### Feedback and Suggestions
 

--- a/Readme_Env_Setup.md
+++ b/Readme_Env_Setup.md
@@ -51,6 +51,6 @@ npm run start
 | Software      | Must Have | Note                           |
 |---------------|-----------|--------------------------------|
 | Node.js       | Yes       | Version 16 is recommended.      |
-| image magick  | No        | Nice to have.                   |
-| 7-Zip         | *      | Windows does not need to install. Must-have for *nix. |
-| git bash      | *         | Must-have for Windows, not required for *nix. |
+| ImageMagick   | No        | Nice to have.                   |
+| 7-Zip         | Conditional | Windows does not need to install. Must-have for *nix. |
+| git bash      | Conditional | Must-have for Windows, not required for *nix. |


### PR DESCRIPTION
## Summary
- mark English README as outdated and point to Chinese version
- fix links and Linux naming in Chinese README
- clarify development dependency requirements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b94d4acfb48325a3b6af8203b82dc0