### PR TITLE
docs: add usage guide and rename dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,100 @@
+# ShiguReader
 
-<h1 align="center"><img src="/screenshot/favicon-96x96.png" alt="icon" width="90"/>ShiguReader</h1>
+![icon](screenshot/favicon-96x96.png)
 
-
-[<img src="https://img.shields.io/github/v/release/hjyssg/ShiguReader?label=latest%20release">](https://github.com/hjyssg/ShiguReader/releases)
-
+[![Latest Release](https://img.shields.io/github/v/release/hjyssg/ShiguReader?label=latest%20release)](https://github.com/hjyssg/ShiguReader/releases)
 
 [English Version (outdated)](README_English.md)
 
+ShiguReader是一款可在电脑或iPad上使用的漫画浏览器，它还支持整理资源、播放音乐和观看视频等功能。下载 [Release](https://github.com/hjyssg/ShiguReader/releases) 后便可立即开始使用。
 
-ShiguReader是一款可在电脑或iPad上使用的漫画浏览器，它还支持整理资源、播放音乐和观看视频等多种功能。只需前往[Release](https://github.com/hjyssg/ShiguReader/releases)，下载后便可立即开始使用。
+## 文档
 
-##### Screenshots
+- [使用说明](Readme_Usage.md)
+- [开发环境设置](Readme_Dev_Setup.md)
 
-<img src="screenshot/01.png" alt="screenshot-01" width="600"/>
-<img src="screenshot/02.png" alt="screenshot-02" width="600"/>
-<img src="screenshot/02.5.png" alt="screenshot-02.5" width="600"/>
-<img src="screenshot/03.png" alt="screenshot-03" width="600"/>
-<img src="screenshot/04.png" alt="screenshot-04" width="600"/>
-<img src="screenshot/05.png" alt="screenshot-05" width="600"/>
-<img src="screenshot/06.png" alt="screenshot-06" width="600"/>
+## 截图
 
-##### 功能特色
+![screenshot-01](screenshot/01.png)
+![screenshot-02](screenshot/02.png)
+![screenshot-02.5](screenshot/02.5.png)
+![screenshot-03](screenshot/03.png)
+![screenshot-04](screenshot/04.png)
+![screenshot-05](screenshot/05.png)
+![screenshot-06](screenshot/06.png)
 
-* 可在电脑和iPad上使用。
-* 显示每个漫画压缩包的封面，方便浏览。
-* 支持播放音乐和视频。
-* 提供各种排序和筛选功能。包括根据喜欢排序。
-* 可一键压缩压缩包内的图片，节约硬盘空间。
-* 进行特定作者或同人类型的全部文件展示。
-* 可移动、删除文件。
-* 可制作统计图表，统计文件大小和各时期的文件数量。
-* 接近于旧版熊猫网的配色，让你感受亲切熟悉。
-* 同时支持Windows和Linux系统。
+## 功能特色
 
-##### 支持的文件格式
+- 可在电脑和iPad上使用
+- 显示每个漫画压缩包的封面，方便浏览
+- 支持播放音乐和视频
+- 提供各种排序和筛选功能，包括根据喜欢排序
+- 可一键压缩压缩包内的图片，节约硬盘空间
+- 进行特定作者或同人类型的全部文件展示
+- 可移动、删除文件
+- 可制作统计图表，统计文件大小和各时期的文件数量
+- 接近于旧版熊猫网的配色，让你感受亲切熟悉
+- 同时支持Windows和Linux系统
+
+## 支持的文件格式
 
 支持的压缩包格式取决于7Zip。支持常见的zip、rar、7z。图片、音乐和视频的支持格式取决于浏览器。图片格式常见的包括jpg、png和gif，视频格式常见的包括mp4和avi，音乐格式支持mp3和wav等多种格式。
 
-##### 演示视频
+## 演示视频
 
-ShiguReader的演示视频有些过时了，不过我们会尽快更新新版本的演示视频。你可以通过以下链接找到过去的演示视频  
-[iPad使用](https://www.bilibili.com/video/BV1Mt4y1m7qU)  
-[PC使用](https://www.bilibili.com/video/BV1t64y1u729/)   
-[iPhone使用](https://www.bilibili.com/video/BV1xt4y1U73L/)    
+- [iPad使用](https://www.bilibili.com/video/BV1Mt4y1m7qU)
+- [PC使用](https://www.bilibili.com/video/BV1t64y1u729/)
+- [iPhone使用](https://www.bilibili.com/video/BV1xt4y1U73L/)
 
-##### 快捷键
+## 快捷键
 
-漫画页面  
-enter: 全屏  
-A、D、左右方向键: 翻页  
-W、S、上下方向键: 上下  
-+和-: 缩放图片   
-x：移动到no good文件夹  
-v：移到good文件夹   
-g：快速跳页  
+**漫画页面**
 
+- `Enter`: 全屏
+- `A` / `D` 或左右方向键: 翻页
+- `W` / `S` 或上下方向键: 上下
+- `+` 和 `-`: 缩放图片
+- `x`: 移动到 no good 文件夹
+- `v`: 移动到 good 文件夹
+- `g`: 快速跳页
 
-##### 第三方依赖
-Linux系统强烈建议安装[ImageMagick](https://imagemagick.org)。这样可以使用它来压缩图片，提高软件的性能。
+## 第三方依赖
 
-##### 注意事项
+Linux系统强烈建议安装 [ImageMagick](https://imagemagick.org)。这样可以使用它来压缩图片，提高软件的性能。
+
+## 注意事项
 
 部分文件名带汉字或日语假名的图片无法正常加载，你可能需要进行以下语言设置。请注意，这可能会导致其他非Unicode软件出现乱码问题。
 
 Windows 语言设置如下所示：
-<img src="screenshot/unicode-setting.png" alt="Unicode Setting" width="600"/>
 
-##### 压缩包内图片压缩功能
+![Unicode Setting](screenshot/unicode-setting.png)
 
-[介绍视频](https://www.bilibili.com/video/BV1pi4y147Gu?from=search&seid=13429520178852889848/)     
-一些漫画图片过于庞大，比如下载了一本24页共640MB的漫画，但关键画面与一本仅30MB的漫画并没有太大区别。因此，我们添加了压缩包内图片压缩功能。首先，你需要确认是否可以通过cmd运行magick命令。然后就可以通过网页以启动压缩程序，压缩后的文件默认保存在workspace\minified_zip_cache目录里。
+## 压缩包内图片压缩功能
 
-##### 配合TamperMonkey使用
+[介绍视频](https://www.bilibili.com/video/BV1pi4y147Gu?from=search&seid=13429520178852889848/)
 
-    把EhentaiHighighliger.js添加到TamperMonkey。
-    在你上绅士网的时候，该脚本会与后端服务器通信。显示文件下载过与否。
+一些漫画图片过于庞大，比如下载了一本24页共640MB的漫画，但关键画面与一本仅30MB的漫画并没有太大区别。因此，我们添加了压缩包内图片压缩功能。首先，你需要确认是否可以通过cmd运行magick命令。然后就可以通过网页以启动压缩程序，压缩后的文件默认保存在 `workspace\\minified_zip_cache` 目录里。
 
-##### FAQ
+## 配合TamperMonkey使用
 
-    问： 点击exe后软件无法启动，怎么办？
-    答:  默认的3000端口可能已被占用，请尝试更改端口号。  
-         比如 ShiguReader_Backend.exe --port 5000   
-    
-    问：某些视频无法播放，怎么办？
-    答：视频只是附件功能，支持的格式有限
-  
-    问：电脑可以正常使用，但是扫描二维码后无法在手机上打开，请问如何解决？
-    答：请首先确认电脑和手机是否在同一局域网Wifi下。如果仍然无法打开，请检查电脑防火墙设置。
+把 `EhentaiHighighliger.js` 添加到 TamperMonkey。在你上绅士网的时候，该脚本会与后端服务器通信，显示文件下载过与否。
 
-    问： ShiguReader是啥意思？
-    答： Shigure(しぐれ) + Reader。当年的舰C的同人可真好看。
+## FAQ
 
+**问：** 点击 exe 后软件无法启动，怎么办？  
+**答：** 默认的 3000 端口可能已被占用，请尝试更改端口号。例如 `ShiguReader_Backend.exe --port 5000`。
 
-##### 开发环境设置
+**问：** 某些视频无法播放，怎么办？  
+**答：** 视频只是附件功能，支持的格式有限。
 
-开发人员请阅读[Readme_Env_Setup](Readme_Env_Setup.md)
+**问：** 电脑可以正常使用，但是扫描二维码后无法在手机上打开，请问如何解决？  
+**答：** 请首先确认电脑和手机是否在同一局域网 Wi-Fi 下。如果仍然无法打开，请检查电脑防火墙设置。
 
-##### 反馈与建议
+**问：** ShiguReader 是啥意思？  
+**答：** Shigure(しぐれ) + Reader。当年的舰C的同人可真好看。
 
-如果你仍有疑问或者需要帮助，请在Github上反馈issue。同时，我们也欢迎任何关于改善ShiguReader的建议。
+## 反馈与建议
+
+如果你仍有疑问或者需要帮助，请在 Github 上反馈 issue。同时，我们也欢迎任何关于改善 ShiguReader 的建议。
 

--- a/README_English.md
+++ b/README_English.md
@@ -72,7 +72,7 @@ If you like our software and would like to treat us to a cup of milk tea, you ca
 
 ##### Development Environment Setup
 
-please refer to [Readme_Env_Setup](Readme_Env_Setup.md).
+please refer to [Readme_Dev_Setup](Readme_Dev_Setup.md).
 
 ##### Feedback and Suggestions
 

--- a/Readme_Dev_Setup.md
+++ b/Readme_Dev_Setup.md
@@ -1,16 +1,13 @@
-##### Dev Environment Setup
+# Dev Environment Setup
 
-
-###### Short Version:
+## Short Version
 
 ```bash
-
 npm i
 npm run start
-
 ```
 
-###### Detailed Version:
+## Detailed Version
 ```bash
 # Node.js 16 is recommended.
 
@@ -47,10 +44,10 @@ npm run start
 
 ```
 
-
 | Software      | Must Have | Note                           |
 |---------------|-----------|--------------------------------|
 | Node.js       | Yes       | Version 16 is recommended.      |
 | ImageMagick   | No        | Nice to have.                   |
 | 7-Zip         | Conditional | Windows does not need to install. Must-have for *nix. |
 | git bash      | Conditional | Must-have for Windows, not required for *nix. |
+

--- a/Readme_Usage.md
+++ b/Readme_Usage.md
@@ -1,0 +1,13 @@
+# 使用说明
+
+## 下载并运行
+
+1. 前往 [Release](https://github.com/hjyssg/ShiguReader/releases) 下载最新版本。
+2. 解压缩后运行 `ShiguReader_Backend.exe`（或适用于你平台的可执行文件）。
+3. 请修改同目录下的 `config-path.ini` 与 `config-etc.ini` 以满足你的环境需求。
+
+## 开发模式
+
+1. 在项目目录执行 `npm i` 安装依赖。
+2. 之后通过 `npm run start` 启动，或双击仓库中提供的一键 `.bat` 脚本。
+


### PR DESCRIPTION
## Summary
- add user usage instructions
- rename environment setup to `Readme_Dev_Setup.md`
- restructure README for easier reading

## Testing
- `npm test` (backend) *(fails: 10 failing)*
- `npm test` (frontend) *(fails: 1 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9536e03248325954518cb31249fdb