### PR TITLE
Track reading progress before updating history

### DIFF
--- a/packages/backend/src/server/index.js
+++ b/packages/backend/src/server/index.js
@@ -932,8 +932,6 @@ app.post('/api/extract', asyncWrapper(async (req, res) => {
         extract_result_cache[filePath] = result;
         result = serverUtil.checkOneBookRes(result);
         res.send(result);
-
-        historyDb.addOneRecord(filePath);
     }
 
     const outputPath = path.join(cachePath, getHash(filePath));
@@ -957,7 +955,6 @@ app.post('/api/extract', asyncWrapper(async (req, res) => {
     // 这样zip内容改变对应不了，但我很少这么操作
     if(extract_result_cache[filePath]){
         res.send(extract_result_cache[filePath]);
-        historyDb.addOneRecord(filePath);
         return;
     }
 

--- a/packages/backend/src/server/routes/getHistory.js
+++ b/packages/backend/src/server/routes/getHistory.js
@@ -39,4 +39,14 @@ router.post("/api/getFileHistory", serverUtil.asyncWrapper(async (req, res) => {
     }
 }));
 
+router.post('/api/addHistoryRecord', serverUtil.asyncWrapper(async (req, res) => {
+    const filePath = req.body && req.body.filePath;
+    if (!filePath) {
+        res.send({ failed: true, reason: "No Parameter" });
+        return;
+    }
+    historyDb.addOneRecord(filePath);
+    res.send({ failed: false });
+}));
+
 module.exports = router;

--- a/packages/backend/src/server/routes/lsdir.js
+++ b/packages/backend/src/server/routes/lsdir.js
@@ -222,7 +222,6 @@ router.post('/api/listImageFolderContent', serverUtil.asyncWrapper(async (req, r
     }
     result = serverUtil.checkOneBookRes(result);
     res.send(result);
-    historyDb.addOneRecord(filePath);
 }));
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add `/api/addHistoryRecord` endpoint to update read history
- stop logging history when a book is opened
- record history only after reading several pages on the client

## Testing
- `npm test` (backend, failed: Path Util Test directory expectations)
- `npm test` (frontend, failed: _sortFileNames alphabetical sort)


------
https://chatgpt.com/codex/tasks/task_e_68bd2ccbb71c8325ade95e5773334a2d