### PR TITLE
解压文件的时候，保持子文件夹结构

### DIFF
--- a/packages/backend/src/common/util.js
+++ b/packages/backend/src/common/util.js
@@ -84,8 +84,9 @@ const hasDuplicate = module.exports.hasDuplicate = (arr) => {
 
 /**
  * 用来排序图片和mp3的。files既可能是filename也可能是filepath
+ * getDirName is optional and should return the directory portion used for sorting
  */
-module.exports._sortFileNames = function (files, getBaseName) {
+module.exports._sortFileNames = function (files, getBaseName, getDirName) {
     // files.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
     // return;
 
@@ -95,8 +96,25 @@ module.exports._sortFileNames = function (files, getBaseName) {
         const fileNameB = getBaseName(b);
 
         // 获取路径部分（去掉文件名部分后的内容）
-        const dirA = a.slice(0, a.length - fileNameA.length);
-        const dirB = b.slice(0, b.length - fileNameB.length);
+        const dirA = (() => {
+            if (getDirName) {
+                return getDirName(a) || "";
+            }
+            if (typeof fileNameA === "string" && a.endsWith(fileNameA)) {
+                return a.slice(0, a.length - fileNameA.length) || "";
+            }
+            return "";
+        })();
+
+        const dirB = (() => {
+            if (getDirName) {
+                return getDirName(b) || "";
+            }
+            if (typeof fileNameB === "string" && b.endsWith(fileNameB)) {
+                return b.slice(0, b.length - fileNameB.length) || "";
+            }
+            return "";
+        })();
 
         // 先按路径部分排序
         if (dirA !== dirB) {

--- a/packages/backend/src/server/index.js
+++ b/packages/backend/src/server/index.js
@@ -26,6 +26,16 @@ const filewatch = require("./own_chokidar/filewatch");
 const thumbnailUtil = require("./getThumbnailUtil");
 
 const { isHiddenFile, splitFilesByType, isExist, filterPathConfig, isSub, estimateIfFolder } = pathUtil;
+
+const resolveExtractedEntry = (baseOutputPath, entryPath) => {
+    if (!entryPath) {
+        return null;
+    }
+    const normalizedBase = path.resolve(baseOutputPath);
+    const normalizedEntry = path.normalize(entryPath);
+    const candidate = path.resolve(normalizedBase, normalizedEntry);
+    return isSub(normalizedBase, candidate) ? candidate : null;
+};
 const { isImage, isCompress, isVideo, isMusic, 
     getCurrentTime, isDisplayableInExplorer, isDisplayableInOnebook } = util;
 
@@ -716,13 +726,21 @@ let extractThumbnailFromZip = async (filePath, res, mode, config) => {
         }
         
         // send original img path to client as thumbnail
-        let original_thumb = path.join(outputPath, path.basename(thumbInnerPath));
-        sendImage(original_thumb);
+        const resolvedThumb = resolveExtractedEntry(outputPath, thumbInnerPath);
+        if (!resolvedThumb) {
+            sendError("Cannot locate thumbnail inside cache");
+            return;
+        }
+        sendImage(resolvedThumb);
         sendable = false;
 
 
         //compress into real thumbnail
-        const outputFilePath = await thumbnailGenerator(thumbnailFolderPath, outputPath, path.basename(thumbInnerPath));
+        const outputFilePath = await thumbnailGenerator(
+            thumbnailFolderPath,
+            path.dirname(resolvedThumb),
+            path.basename(resolvedThumb)
+        );
         if (outputFilePath) {
             thumbnailDb.addNewThumbnail(filePath, outputFilePath);
             // 想删除除了要使用的文件，但不行。各种文件系统错误
@@ -1018,8 +1036,11 @@ app.post('/api/extract', asyncWrapper(async (req, res) => {
 
             const stderr = await unzip_limit(()=> extractByRange(filePath, outputPath, firstRange));
             if (!stderr) {
-                const unzipOutputPathes = totalRange.map(e => path.resolve(outputPath,  path.basename(e)));
-                const contentUrls = splitFilesByType(unzipOutputPathes, outputPath);
+                const resolvedOutputPath = path.resolve(outputPath);
+                const unzipOutputPathes = totalRange
+                    .map(e => resolveExtractedEntry(outputPath, e))
+                    .filter(Boolean);
+                const contentUrls = splitFilesByType(unzipOutputPathes, resolvedOutputPath);
                 sendBack(contentUrls, filePath, stat);
                 // const time2 = getCurrentTime();
                 // const timeUsed = (time2 - time1);

--- a/packages/backend/src/server/index.js
+++ b/packages/backend/src/server/index.js
@@ -727,7 +727,7 @@ let extractThumbnailFromZip = async (filePath, res, mode, config) => {
         }
         
         // send original img path to client as thumbnail
-        // 这里必须重新解析一次，避免七牛返回的相对路径逃离缓存目录
+        // 这里必须重新解析一次，避免 7-Zip 的返回路径逃离缓存目录
         const resolvedThumb = resolveExtractedEntry(outputPath, thumbInnerPath);
         if (!resolvedThumb) {
             sendError("Cannot locate thumbnail inside cache");

--- a/packages/backend/src/server/index.js
+++ b/packages/backend/src/server/index.js
@@ -27,6 +27,7 @@ const thumbnailUtil = require("./getThumbnailUtil");
 
 const { isHiddenFile, splitFilesByType, isExist, filterPathConfig, isSub, estimateIfFolder } = pathUtil;
 
+// 将压缩文件内的条目路径解析成解压后的绝对路径，并确保不会跳出目标目录
 const resolveExtractedEntry = (baseOutputPath, entryPath) => {
     if (!entryPath) {
         return null;
@@ -726,6 +727,7 @@ let extractThumbnailFromZip = async (filePath, res, mode, config) => {
         }
         
         // send original img path to client as thumbnail
+        // 这里必须重新解析一次，避免七牛返回的相对路径逃离缓存目录
         const resolvedThumb = resolveExtractedEntry(outputPath, thumbInnerPath);
         if (!resolvedThumb) {
             sendError("Cannot locate thumbnail inside cache");
@@ -1037,6 +1039,7 @@ app.post('/api/extract', asyncWrapper(async (req, res) => {
             const stderr = await unzip_limit(()=> extractByRange(filePath, outputPath, firstRange));
             if (!stderr) {
                 const resolvedOutputPath = path.resolve(outputPath);
+                // 将压缩包内的相对路径转为绝对路径，同时过滤掉不合法的项目
                 const unzipOutputPathes = totalRange
                     .map(e => resolveExtractedEntry(outputPath, e))
                     .filter(Boolean);

--- a/packages/backend/src/server/serverUtil.js
+++ b/packages/backend/src/server/serverUtil.js
@@ -34,6 +34,7 @@ const getHash = function (filePath) {
 
 
 const sortFileNames = function (files) {
+    // 复用前端的排序逻辑，既比较目录也比较文件名，保证服务端返回顺序一致
     util._sortFileNames(
         files,
         e => path.basename(e, path.extname(e)),

--- a/packages/backend/src/server/serverUtil.js
+++ b/packages/backend/src/server/serverUtil.js
@@ -34,7 +34,14 @@ const getHash = function (filePath) {
 
 
 const sortFileNames = function (files) {
-    util._sortFileNames(files, e => path.basename(e, path.extname(e)));
+    util._sortFileNames(
+        files,
+        e => path.basename(e, path.extname(e)),
+        e => {
+            const dir = path.dirname(e);
+            return dir === '.' ? '' : dir;
+        }
+    );
 }
 
 /** 从图片中挑一张封面 */

--- a/packages/backend/src/server/sevenZipHelp.js
+++ b/packages/backend/src/server/sevenZipHelp.js
@@ -102,7 +102,7 @@ const getExtractOption = module.exports.getExtractOption = function (filePath, o
     //https://sevenzip.osdn.jp/chm/cmdline/commands/extract.htm
     //e make folder as one level
     //x different level
-    levelFlag = levelFlag || "e";
+    levelFlag = levelFlag || "x";
     if (file_specifier) {
         let specifier = _.isArray(file_specifier) ? file_specifier : [file_specifier];
         specifier = specifier.map(e => {
@@ -204,7 +204,7 @@ module.exports.extractByRange = async function (filePath, outputPath, range) {
             //cut into parts
             //when range is too large, will cause OS level error
             let subRange = range.slice(ii, ii + DISTANCE);
-            let opt = getExtractOption(filePath, outputPath, subRange);
+            let opt = getExtractOption(filePath, outputPath, subRange, "x");
             let { stderr, stdout } = await execa(sevenZip, opt);
             if (stderr) {
                 error = stderr;
@@ -235,7 +235,7 @@ module.exports.extractByExtension = async function(filePath, outputPath, extensi
 
     let error, pathes = [];
     try {
-        const opt = getExtractOption(filePath, outputPath, extensions);
+        const opt = getExtractOption(filePath, outputPath, extensions, "x");
         const { stderr, stdout } = await execa(sevenZip, opt);
         if (stderr) {
             throw stderr;
@@ -251,22 +251,21 @@ module.exports.extractByExtension = async function(filePath, outputPath, extensi
 
 
 
-// isRecursive: 保持原来的文件夹结构
+// isRecursive 参数已经保留兼容性，但现在始终保持原来的文件夹结构
 module.exports.extractAll = async function (filePath, outputPath, isRecursive) {
     if (!global._has_7zip_) {
         throw "this computer did not install 7z"
     }
 
-    const levelFlag = isRecursive? "x" : null;
-    const opt = getExtractOption(filePath, outputPath, null, levelFlag);
+    const opt = getExtractOption(filePath, outputPath, null, "x");
     let error, pathes = [];
     try {
         const { stderr } = await execa(sevenZip, opt);
         if (stderr) {
             throw stderr;
         }
-        
-        pathes = (await pathUtil.readDirForFileAndFolder(outputPath, isRecursive)).pathes;
+
+        pathes = (await pathUtil.readDirForFileAndFolder(outputPath, true)).pathes;
     } catch (e) {
         error = e;
         logger.error('[extractAll] exit: ', e);

--- a/packages/frontend/src/client/clientUtil.js
+++ b/packages/frontend/src/client/clientUtil.js
@@ -101,7 +101,7 @@ module.exports.getPerPageItemNumber = function () {
 }
 
 module.exports.sortFileNames = function (files) {
-    util._sortFileNames(files, getBaseName);
+    util._sortFileNames(files, getBaseName, getDir);
 }
 
 module.exports.isLocalHost = function () {

--- a/packages/frontend/src/common/util.js
+++ b/packages/frontend/src/common/util.js
@@ -84,8 +84,9 @@ const hasDuplicate = module.exports.hasDuplicate = (arr) => {
 
 /**
  * 用来排序图片和mp3的。files既可能是filename也可能是filepath
+ * getDirName is optional and should return the directory portion used for sorting
  */
-module.exports._sortFileNames = function (files, getBaseName) {
+module.exports._sortFileNames = function (files, getBaseName, getDirName) {
     // files.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
     // return;
 
@@ -95,8 +96,25 @@ module.exports._sortFileNames = function (files, getBaseName) {
         const fileNameB = getBaseName(b);
 
         // 获取路径部分（去掉文件名部分后的内容）
-        const dirA = a.slice(0, a.length - fileNameA.length);
-        const dirB = b.slice(0, b.length - fileNameB.length);
+        const dirA = (() => {
+            if (getDirName) {
+                return getDirName(a) || "";
+            }
+            if (typeof fileNameA === "string" && a.endsWith(fileNameA)) {
+                return a.slice(0, a.length - fileNameA.length) || "";
+            }
+            return "";
+        })();
+
+        const dirB = (() => {
+            if (getDirName) {
+                return getDirName(b) || "";
+            }
+            if (typeof fileNameB === "string" && b.endsWith(fileNameB)) {
+                return b.slice(0, b.length - fileNameB.length) || "";
+            }
+            return "";
+        })();
 
         // 先按路径部分排序
         if (dirA !== dirB) {

--- a/packages/frontend/src/common/util.js
+++ b/packages/frontend/src/common/util.js
@@ -116,7 +116,7 @@ module.exports._sortFileNames = function (files, getBaseName, getDirName) {
             return "";
         })();
 
-        // 先按路径部分排序
+        // 先按路径部分排序，确保不同子目录下的同名文件不会混在一起
         if (dirA !== dirB) {
             return dirA.localeCompare(dirB);
         }else{

--- a/packages/frontend/src/test/util.test.js
+++ b/packages/frontend/src/test/util.test.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const path = require("path");
 
 const {
   isGif,
@@ -123,6 +124,22 @@ describe("ut for js util functions", () => {
         "12.mp4",
         "a.mp4",
         "b.mp4",
+      ]);
+    });
+
+    it("should prioritize directory path before filename when sorting", () => {
+      const files = [
+        "dirB/1.jpg",
+        "dirA/2.jpg",
+        "dirA/1.jpg",
+        "dirB/10.jpg",
+      ];
+      _sortFileNames(files, (fName) => path.basename(fName));
+      assert.deepStrictEqual(files, [
+        "dirA/1.jpg",
+        "dirA/2.jpg",
+        "dirB/1.jpg",
+        "dirB/10.jpg",
       ]);
     });
   });


### PR DESCRIPTION
## Summary
- ensure archive extraction keeps nested folder structure by forcing 7zip to use `x`, reading directories recursively, and resolving extracted paths safely for responses and thumbnail generation
- update shared sort helpers and their callers so onebook views sort media using full paths instead of just basenames
- add a unit test that verifies sorting respects directory components

## Testing
- npm test (packages/frontend)

解压文件的时候，要保持文件在压缩文件夹的子文件夹结构，然后在onebook、onebookWaterfall和onebookOverview排序图片的时候，原来是只看文件名，现在要拿完整子文件夹path，这样才能避免文件夹1/1.jpg和文件夹2/1.jpg在排序后并列在一起。


------
https://chatgpt.com/codex/tasks/task_e_68ce9bf5bb88832595695cc41ebda8c3