### PR TITLE
Remove first-time author filter and align explorer controls

### DIFF
--- a/packages/frontend/src/client/ExplorerPage.js
+++ b/packages/frontend/src/client/ExplorerPage.js
@@ -56,7 +56,6 @@ const { MODE_TAG,
     MODE_EXPLORER } = Constant;
 
 
-const FILTER_FIRST_TIME_AUTHOR = "FILTER_FIRST_TIME_AUTHOR";
 const FILTER_HAS_MUSIC = "FILTER_HAS_MUSIC";
 const FILTER_HAS_VIDEO = "FILTER_HAS_VIDEO";
 const FILTER_IMG_FOLDER = "FILTER_IMG_FOLDER";
@@ -494,7 +493,7 @@ export default class ExplorerPage extends Component {
     getFilteredFiles() {
         let files = [...this.compressFiles, ...(_.keys(this.imgFolderInfo))];
 
-        const { authorInfo, pageNumRange } = this.state;
+        const { pageNumRange } = this.state;
 
         const maxPage =  pageNumRange[1] >= this.getMaxPageForSlider()? Infinity:  pageNumRange[1];
         files = files.filter(e => {
@@ -505,15 +504,6 @@ export default class ExplorerPage extends Component {
                 return true;
             }
         })
-
-        if (this.isOn(FILTER_FIRST_TIME_AUTHOR) && authorInfo) {
-            files = files.filter(e => {
-                const count = this.getAuthorCountForFP(e);
-                if (count && (count.total_count) === 1) {
-                    return true;
-                }
-            })
-        }
 
         if (this.isOn(FILTER_HAS_MUSIC)) {
             files = files.filter(e => {
@@ -689,8 +679,7 @@ export default class ExplorerPage extends Component {
                 const str = this.getMode() === MODE_EXPLORER ? "This folder is empty" : "Empty Result";
                 return (
                     <div>
-                        {this.renderPageRangeSilder()}
-                        {this.renderCheckboxPanel()}
+                        {this.renderFilterControls()}
                         <div className="one-book-nothing-available">
                             <div className="alert alert-secondary" role="alert">{str}</div>
                         </div>
@@ -811,8 +800,7 @@ export default class ExplorerPage extends Component {
 
                 {videoDivGroup}
                 {this.renderPagination(filteredFiles, filteredVideos)}
-                {this.renderPageRangeSilder()}
-                {this.renderCheckboxPanel()}
+                {this.renderFilterControls()}
                 {zipfileItems.length > 0 && this.renderSortHeader()}
                 <div className={"file-grid container"}>
                     <div className={rowCn}>
@@ -1253,7 +1241,6 @@ export default class ExplorerPage extends Component {
     renderCheckboxPanel() {
         // Define a list of filters with their descriptions
         const filters = [
-            { id: 'FILTER_FIRST_TIME_AUTHOR', label: 'First Time Author' },
             { id: 'FILTER_HAS_MUSIC', label: 'Has Music' },
             { id: 'FILTER_HAS_VIDEO', label: 'Has Video' },
             { id: 'FILTER_IMG_FOLDER', label: 'Only Image Folder' }
@@ -1261,9 +1248,9 @@ export default class ExplorerPage extends Component {
 
         // Map over the filters array to create checkbox components
         const checkboxes = filters.map(filter => (
-            <Checkbox 
+            <Checkbox
                 key={filter.id}
-                onChange={this.toggleFilter.bind(this, filter.id)} 
+                onChange={this.toggleFilter.bind(this, filter.id)}
                 checked={this.isOn(filter.id)}
             >
                 {filter.label}
@@ -1272,8 +1259,17 @@ export default class ExplorerPage extends Component {
 
         // Return the container with all checkboxes
         return (
-            <div className="aji-checkbox-container container">
+            <div className="aji-checkbox-container">
                 {checkboxes}
+            </div>
+        );
+    }
+
+    renderFilterControls() {
+        return (
+            <div className="explorer-filter-controls container">
+                {this.renderPageRangeSilder()}
+                {this.renderCheckboxPanel()}
             </div>
         );
     }

--- a/packages/frontend/src/client/style/Explorer.scss
+++ b/packages/frontend/src/client/style/Explorer.scss
@@ -239,20 +239,33 @@
   }
 }
 
+.explorer-filter-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  column-gap: 20px;
+}
+
+.explorer-filter-controls .aji-checkbox-container {
+  flex: 0 1 auto;
+  margin: 15px 0;
+}
+
 .page-number-range-slider-wrapper {
-  width: 100%;
+  flex: 1 1 320px;
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 15px;
-  margin-bottom: 15px;
+  margin: 15px 0;
 
   .small-text-title {
     color: $font_color_white_one;
   }
 
   .page-number-range-slider {
-    width: 500px;
+    width: 100%;
+    max-width: 500px;
     margin-left: 10px;
     margin-right: 10px;
     height: 4px;


### PR DESCRIPTION
## Summary
- remove the unused first-time author filter and related filtering logic from the explorer page
- group the page range slider with the remaining filter checkboxes in a shared toolbar container
- adjust explorer styles so the slider and checkboxes sit on one row and the slider scales responsively

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4d74e64288325ac55d7ec5d554445