### PR TITLE
重构sortheader

### DIFF
--- a/packages/backend/src/common/util.js
+++ b/packages/backend/src/common/util.js
@@ -116,7 +116,7 @@ module.exports._sortFileNames = function (files, getBaseName, getDirName) {
             return "";
         })();
 
-        // 先按路径部分排序
+        // 先按路径部分排序，确保不同子目录下的同名文件不会混在一起
         if (dirA !== dirB) {
             return dirA.localeCompare(dirB);
         }else{

--- a/packages/frontend/src/client/style/SortHeader.scss
+++ b/packages/frontend/src/client/style/SortHeader.scss
@@ -12,27 +12,16 @@ $sb-hover: lighten($bacground_level_two, 6%);
 
 .sb-bar {
   display: flex;
-  align-items: flex-start;
-  gap: 16px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
   padding: 12px 14px;
   border-radius: 14px;
   background: $sb-panel;
   color: $sb-text;
   border: 1px solid $sb-pill-border;
   overflow: auto;
-  flex-wrap: wrap;
-  row-gap: 12px;
   margin-bottom: 12px;
-}
-
-.sb-left {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 14px;
-  row-gap: 10px;
-  flex: 1 1 auto;
-  min-width: 0;
 }
 
 .sb-group {
@@ -46,20 +35,13 @@ $sb-hover: lighten($bacground_level_two, 6%);
   color: $sb-muted;
   font-weight: 600;
   letter-spacing: 0.2px;
-  margin-right: 2px;
+  margin-right: 6px;
 }
 
 @media (max-width: 720px) {
   .sb-label {
     display: none;
   }
-}
-
-.sb-divider {
-  width: 1px;
-  align-self: stretch;
-  background: $sb-divider;
-  margin: 0 6px;
 }
 
 .sb-pill {
@@ -88,16 +70,6 @@ $sb-hover: lighten($bacground_level_two, 6%);
   }
 }
 
-.sb-right {
-  margin-left: auto;
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  flex-wrap: wrap;
-  row-gap: 8px;
-  flex: 0 0 auto;
-}
-
 .sb-btn {
   display: inline-flex;
   align-items: center;
@@ -114,22 +86,7 @@ $sb-hover: lighten($bacground_level_two, 6%);
   &:hover {
     background: $sb-hover;
   }
-}
-
-.sb-caret {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-
-  &.up {
-    border-bottom: 7px solid currentColor;
-  }
-
-  &.down {
-    border-top: 7px solid currentColor;
-  }
+  min-height: 34px;
 }
 
 .sb-more {
@@ -156,6 +113,43 @@ $sb-hover: lighten($bacground_level_two, 6%);
 .sb-row {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  row-gap: 8px;
+}
+
+.sb-row--controls {
+  align-items: center;
+  gap: 12px;
+}
+
+.sb-row-option {
+  display: flex;
+  align-items: center;
   gap: 8px;
   padding: 6px 0;
+}
+
+.sb-btn--order {
+  margin-left: auto;
+  width: 40px;
+  justify-content: center;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.sb-arrow {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+
+  &.up {
+    border-bottom: 9px solid currentColor;
+  }
+
+  &.down {
+    border-top: 9px solid currentColor;
+  }
 }

--- a/packages/frontend/src/client/style/SortHeader.scss
+++ b/packages/frontend/src/client/style/SortHeader.scss
@@ -1,48 +1,145 @@
 @import "vars.scss";
 
+$sb-panel: $bacground_level_two;
+$sb-text: $font_color_white_one;
+$sb-muted: rgba($sb-text, 0.7);
+$sb-pill: lighten($bacground_level_two, 3%);
+$sb-pill-border: rgba(0, 0, 0, 0.3);
+$sb-active: #2f6feb;
+$sb-active-text: #ffffff;
+$sb-divider: rgba(255, 255, 255, 0.08);
+$sb-hover: lighten($bacground_level_two, 6%);
 
-.sort-header-container {
-  margin-top: 10px;
-  margin-bottom: 10px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  background-color: #99a2b5;
-  border-radius: 5px;
-  font-weight: 500;
-  
-  .sort-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-size: 10px;
+.sb-bar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: $sb-panel;
+  color: $sb-text;
+  border: 1px solid $sb-pill-border;
+  overflow: auto;
+}
 
+.sb-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
 
-    @media screen and (min-width: 1000px) {
-      font-size: 16px;
-    }
+.sb-label {
+  color: $sb-muted;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  margin-right: 2px;
+}
 
-    @media screen and (min-width: 1200px) {
-      font-size: 14px;
-      padding-left: 50px;
-      padding-right: 50px;
-    }
-
-    width: 100%;
-
-    .sort-item {
-      color: #212529;
-
-      .fas {
-        color: #212529;
-      }
-
-      background: unset;
-      cursor: pointer;
-      vertical-align: baseline;
-
-      &:hover {
-        @include third_hover_effect;
-      }
-    }
+@media (max-width: 720px) {
+  .sb-label {
+    display: none;
   }
+}
+
+.sb-divider {
+  width: 1px;
+  align-self: stretch;
+  background: $sb-divider;
+  margin: 0 6px;
+}
+
+.sb-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: $sb-pill;
+  color: inherit;
+  border: 1px solid $sb-pill-border;
+  padding: 8px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease;
+  white-space: nowrap;
+  font-size: 14px;
+
+  &:hover {
+    background: $sb-hover;
+  }
+
+  &[aria-pressed='true'] {
+    background: $sb-active;
+    color: $sb-active-text;
+    border-color: transparent;
+  }
+}
+
+.sb-right {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.sb-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid $sb-pill-border;
+  background: $sb-pill;
+  cursor: pointer;
+  transition: background 0.16s ease;
+  color: inherit;
+  font-size: 14px;
+
+  &:hover {
+    background: $sb-hover;
+  }
+}
+
+.sb-caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+
+  &.up {
+    border-bottom: 7px solid currentColor;
+  }
+
+  &.down {
+    border-top: 7px solid currentColor;
+  }
+}
+
+.sb-more {
+  position: relative;
+
+  summary {
+    list-style: none;
+  }
+}
+
+.sb-menu {
+  position: absolute;
+  right: 0;
+  margin-top: 8px;
+  width: 210px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid $sb-pill-border;
+  background: $sb-panel;
+  color: $sb-text;
+  z-index: 20;
+}
+
+.sb-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
 }

--- a/packages/frontend/src/client/style/SortHeader.scss
+++ b/packages/frontend/src/client/style/SortHeader.scss
@@ -22,6 +22,11 @@ $sb-hover: lighten($bacground_level_two, 6%);
   border: 1px solid $sb-pill-border;
   overflow: auto;
   margin-bottom: 12px;
+
+  
+  button:focus {
+    outline: none;
+  }
 }
 
 .sb-group {
@@ -137,10 +142,6 @@ $sb-hover: lighten($bacground_level_two, 6%);
   justify-content: center;
   padding-left: 0;
   padding-right: 0;
-
-  &:focus {
-    outline: none;
-  }
 }
 
 .sb-arrow {

--- a/packages/frontend/src/client/style/SortHeader.scss
+++ b/packages/frontend/src/client/style/SortHeader.scss
@@ -12,14 +12,27 @@ $sb-hover: lighten($bacground_level_two, 6%);
 
 .sb-bar {
   display: flex;
-  align-items: center;
-  gap: 14px;
+  align-items: flex-start;
+  gap: 16px;
   padding: 12px 14px;
   border-radius: 14px;
   background: $sb-panel;
   color: $sb-text;
   border: 1px solid $sb-pill-border;
   overflow: auto;
+  flex-wrap: wrap;
+  row-gap: 12px;
+  margin-bottom: 12px;
+}
+
+.sb-left {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 14px;
+  row-gap: 10px;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .sb-group {
@@ -80,6 +93,9 @@ $sb-hover: lighten($bacground_level_two, 6%);
   display: flex;
   gap: 8px;
   align-items: center;
+  flex-wrap: wrap;
+  row-gap: 8px;
+  flex: 0 0 auto;
 }
 
 .sb-btn {

--- a/packages/frontend/src/client/style/SortHeader.scss
+++ b/packages/frontend/src/client/style/SortHeader.scss
@@ -133,6 +133,7 @@ $sb-hover: lighten($bacground_level_two, 6%);
 .sb-btn--order {
   margin-left: auto;
   width: 40px;
+  min-width: 40px;
   justify-content: center;
   padding-left: 0;
   padding-right: 0;

--- a/packages/frontend/src/client/style/SortHeader.scss
+++ b/packages/frontend/src/client/style/SortHeader.scss
@@ -132,11 +132,15 @@ $sb-hover: lighten($bacground_level_two, 6%);
 
 .sb-btn--order {
   margin-left: auto;
-  width: 40px;
+  width: 60px;
   min-width: 40px;
   justify-content: center;
   padding-left: 0;
   padding-right: 0;
+
+  &:focus {
+    outline: none;
+  }
 }
 
 .sb-arrow {

--- a/packages/frontend/src/client/subcomponent/SortHeader.js
+++ b/packages/frontend/src/client/subcomponent/SortHeader.js
@@ -127,25 +127,27 @@ export default function SortHeader({
 
     return (
         <div className={`sb-bar ${className || ''}`} role="toolbar" aria-label="Sorting bar">
-            {grouped.map((section, index) => (
-                <React.Fragment key={section.group}>
-                    {index > 0 ? <div className="sb-divider" /> : null}
-                    <Group label={section.group}>
-                        {section.items.map((item) => (
-                            <button
-                                key={item.key}
-                                className="sb-pill"
-                                aria-pressed={state.key === item.key}
-                                title={item.title}
-                                onClick={() => handleSelect(item.key)}
-                            >
-                                <span style={{ opacity: 0.9 }}>{item.icon}</span>
-                                <span>{item.label}</span>
-                            </button>
-                        ))}
-                    </Group>
-                </React.Fragment>
-            ))}
+            <div className="sb-left">
+                {grouped.map((section, index) => (
+                    <React.Fragment key={section.group}>
+                        {index > 0 ? <div className="sb-divider" /> : null}
+                        <Group label={section.group}>
+                            {section.items.map((item) => (
+                                <button
+                                    key={item.key}
+                                    className="sb-pill"
+                                    aria-pressed={state.key === item.key}
+                                    title={item.title}
+                                    onClick={() => handleSelect(item.key)}
+                                >
+                                    <span style={{ opacity: 0.9 }}>{item.icon}</span>
+                                    <span>{item.label}</span>
+                                </button>
+                            ))}
+                        </Group>
+                    </React.Fragment>
+                ))}
+            </div>
 
             <div className="sb-right">
                 <button className="sb-btn" aria-label="切换升降序" onClick={toggleOrder}>

--- a/packages/frontend/src/client/subcomponent/SortHeader.js
+++ b/packages/frontend/src/client/subcomponent/SortHeader.js
@@ -1,48 +1,199 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import '../style/SortHeader.scss';
-const classNames = require('classnames');
 
+const KEY_CONFIG = {
+    time: { label: 'Time', icon: '🕒', group: '时间', title: '创建时间' },
+    mtime: { label: 'Mtime', icon: '📅', group: '时间', title: '修改时间' },
+    'last read time': { label: 'Last Read', icon: '📖', group: '时间', title: '最近阅读' },
+    'read count': { label: 'Read Count', icon: '📚', group: '时间', title: '阅读次数' },
+    'by latest work': { label: 'Latest Work', icon: '🆕', group: '时间', title: '最新作品' },
+    'file size': { label: 'File Size', icon: '📁', group: '文件' },
+    'avg page size': { label: 'Avg Page', icon: '📐', group: '文件' },
+    'page num': { label: 'Page Num', icon: '📄', group: '文件' },
+    'file number': { label: 'File Count', icon: '🔢', group: '文件' },
+    filename: { label: 'Filename', icon: '🔤', group: '文件' },
+    'tag name': { label: 'Tag Name', icon: '🏷️', group: '文件' },
+    score: { label: 'Score', icon: '⭐', group: '文件' },
+    random: { label: 'Random', icon: '🎲', group: '其他' },
+    'by folder name': { label: 'Folder', icon: '🗂️', group: '文件' },
+};
 
+const DEFAULT_OPTIONS = {
+    stickyFolders: false,
+    naturalSort: true,
+};
 
-
-export default class SortHeader extends PureComponent {
-    static defaultProps = {
-
+function getMeta(key) {
+    if (!key && key !== 0) {
+        return null;
+    }
+    const normalized = String(key).toLowerCase();
+    const meta = KEY_CONFIG[normalized] || {};
+    const label = meta.label || key;
+    return {
+        key,
+        label,
+        group: meta.group || '其他',
+        icon: meta.icon || '⬤',
+        title: meta.title,
     };
-
-    onClick(key){
-        const { onChange, isSortAsc, selected } = this.props;
-        let newSortOrder = !isSortAsc;
-        if(key !== selected){
-            newSortOrder = false;
-        }
-        onChange(key, newSortOrder);
-    }
-
-    render() {
-        let { sortOptions, onChange, selected, isSortAsc, className } = this.props;
-
-        if(!selected){
-            selected = sortOptions[0];
-        }
-
-        console.assert(sortOptions.includes(selected));
-
-        const items = sortOptions.map((item) => {
-            let icon;
-            if (item === selected) {
-                if (isSortAsc) {
-                    icon = <i className="fas fa-arrow-up"></i>;
-                } else {
-                    icon = <i className="fas fa-arrow-down"></i>;
-                }
-            }
-            return (<div key={item} className="sort-item" onClick={() => this.onClick(item)}> {icon} {item} </div>)
-        })
-
-        return (<div className={classNames("sort-header", className)}>{items}</div>)
-
-    }
 }
 
+function useSortState({ sortOptions, selected, isSortAsc, options }) {
+    const optionsKey = React.useMemo(() => sortOptions.join('|'), [sortOptions]);
+    const initialKey = React.useMemo(() => {
+        if (selected && sortOptions.includes(selected)) {
+            return selected;
+        }
+        return sortOptions[0] || '';
+    }, [selected, sortOptions, optionsKey]);
 
+    const [state, setState] = React.useState({
+        key: initialKey,
+        order: isSortAsc ? 'asc' : 'desc',
+        options: { ...DEFAULT_OPTIONS, ...options },
+    });
+
+    React.useEffect(() => {
+        setState((prev) => ({
+            key: initialKey || prev.key,
+            order: isSortAsc ? 'asc' : 'desc',
+            options: { ...DEFAULT_OPTIONS, ...options },
+        }));
+    }, [initialKey, isSortAsc, optionsKey, options]);
+
+    return [state, setState];
+}
+
+export default function SortHeader({
+    sortOptions = [],
+    selected,
+    isSortAsc = false,
+    onChange,
+    className,
+    showOptions = false,
+    options,
+}) {
+    const [state, setState] = useSortState({ sortOptions, selected, isSortAsc, options });
+
+    const emit = React.useCallback(
+        (next) => {
+            setState(next);
+            if (onChange) {
+                onChange(next.key, next.order === 'asc', next);
+            }
+        },
+        [onChange, setState],
+    );
+
+    const handleSelect = React.useCallback(
+        (key) => {
+            emit({
+                key,
+                order: key === state.key ? (state.order === 'asc' ? 'desc' : 'asc') : 'desc',
+                options: state.options,
+            });
+        },
+        [emit, state.key, state.options, state.order],
+    );
+
+    const toggleOrder = React.useCallback(() => {
+        emit({ ...state, order: state.order === 'desc' ? 'asc' : 'desc' });
+    }, [emit, state]);
+
+    const setOption = React.useCallback(
+        (key, value) => {
+            emit({ ...state, options: { ...state.options, [key]: value } });
+        },
+        [emit, state],
+    );
+
+    const grouped = React.useMemo(() => {
+        const map = new Map();
+        const order = [];
+        sortOptions.forEach((key) => {
+            const meta = getMeta(key);
+            if (!meta) {
+                return;
+            }
+            if (!map.has(meta.group)) {
+                map.set(meta.group, []);
+                order.push(meta.group);
+            }
+            map.get(meta.group).push(meta);
+        });
+        return order.map((group) => ({ group, items: map.get(group) }));
+    }, [sortOptions]);
+
+    return (
+        <div className={`sb-bar ${className || ''}`} role="toolbar" aria-label="Sorting bar">
+            {grouped.map((section, index) => (
+                <React.Fragment key={section.group}>
+                    {index > 0 ? <div className="sb-divider" /> : null}
+                    <Group label={section.group}>
+                        {section.items.map((item) => (
+                            <button
+                                key={item.key}
+                                className="sb-pill"
+                                aria-pressed={state.key === item.key}
+                                title={item.title}
+                                onClick={() => handleSelect(item.key)}
+                            >
+                                <span style={{ opacity: 0.9 }}>{item.icon}</span>
+                                <span>{item.label}</span>
+                            </button>
+                        ))}
+                    </Group>
+                </React.Fragment>
+            ))}
+
+            <div className="sb-right">
+                <button className="sb-btn" aria-label="切换升降序" onClick={toggleOrder}>
+                    <span>Order</span>
+                    <span className={`sb-caret ${state.order === 'asc' ? 'up' : 'down'}`} aria-hidden="true" />
+                    <span
+                        style={{ opacity: 0.8, letterSpacing: '.04em', fontVariant: 'all-small-caps' }}
+                    >
+                        {state.order.toUpperCase()}
+                    </span>
+                </button>
+
+                {showOptions ? (
+                    <details className="sb-more">
+                        <summary className="sb-btn">
+                            <span>More</span>
+                            <span style={{ opacity: 0.7 }}>▾</span>
+                        </summary>
+                        <div className="sb-menu">
+                            <label className="sb-row">
+                                <input
+                                    type="checkbox"
+                                    checked={!!state.options.stickyFolders}
+                                    onChange={(e) => setOption('stickyFolders', e.currentTarget.checked)}
+                                />
+                                置顶文件夹
+                            </label>
+                            <label className="sb-row">
+                                <input
+                                    type="checkbox"
+                                    checked={!!state.options.naturalSort}
+                                    onChange={(e) => setOption('naturalSort', e.currentTarget.checked)}
+                                />
+                                自然排序 (1&lt;10&lt;100)
+                            </label>
+                        </div>
+                    </details>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function Group({ label, children }) {
+    return (
+        <div className="sb-group" role="group" aria-label={label}>
+            <span className="sb-label">{label}</span>
+            {children}
+        </div>
+    );
+}

--- a/packages/frontend/src/client/subcomponent/SortHeader.js
+++ b/packages/frontend/src/client/subcomponent/SortHeader.js
@@ -2,20 +2,20 @@ import React from 'react';
 import '../style/SortHeader.scss';
 
 const KEY_CONFIG = {
-    time: { label: 'Time', icon: '🕒', group: '时间', title: '创建时间' },
-    mtime: { label: 'Mtime', icon: '📅', group: '时间', title: '修改时间' },
-    'last read time': { label: 'Last Read', icon: '📖', group: '时间', title: '最近阅读' },
-    'read count': { label: 'Read Count', icon: '📚', group: '时间', title: '阅读次数' },
-    'by latest work': { label: 'Latest Work', icon: '🆕', group: '时间', title: '最新作品' },
-    'file size': { label: 'File Size', icon: '📁', group: '文件' },
-    'avg page size': { label: 'Avg Page', icon: '📐', group: '文件' },
-    'page num': { label: 'Page Num', icon: '📄', group: '文件' },
-    'file number': { label: 'File Count', icon: '🔢', group: '文件' },
-    filename: { label: 'Filename', icon: '🔤', group: '文件' },
-    'tag name': { label: 'Tag Name', icon: '🏷️', group: '文件' },
-    score: { label: 'Score', icon: '⭐', group: '文件' },
-    random: { label: 'Random', icon: '🎲', group: '其他' },
-    'by folder name': { label: 'Folder', icon: '🗂️', group: '文件' },
+    time: { label: 'Time', icon: '🕒', group: 'Time', title: 'Created Time' },
+    mtime: { label: 'Mtime', icon: '📅', group: 'Time', title: 'Modified Time' },
+    'last read time': { label: 'Last Read', icon: '📖', group: 'Time', title: 'Last Read Time' },
+    'read count': { label: 'Read Count', icon: '📚', group: 'Time', title: 'Read Count' },
+    'by latest work': { label: 'Latest Work', icon: '🆕', group: 'Time', title: 'Latest Work' },
+    'file size': { label: 'File Size', icon: '📁', group: 'File' },
+    'avg page size': { label: 'Avg Page', icon: '📐', group: 'File' },
+    'page num': { label: 'Page Num', icon: '📄', group: 'File' },
+    'file number': { label: 'File Count', icon: '🔢', group: 'File' },
+    filename: { label: 'Filename', icon: '🔤', group: 'File' },
+    'tag name': { label: 'Tag Name', icon: '🏷️', group: 'File' },
+    score: { label: 'Score', icon: '⭐', group: 'File' },
+    random: { label: 'Random', icon: '🎲', group: 'Other' },
+    'by folder name': { label: 'Folder', icon: '🗂️', group: 'File' },
 };
 
 const DEFAULT_OPTIONS = {
@@ -33,7 +33,7 @@ function getMeta(key) {
     return {
         key,
         label,
-        group: meta.group || '其他',
+        group: meta.group || 'Other',
         icon: meta.icon || '⬤',
         title: meta.title,
     };
@@ -116,23 +116,64 @@ export default function SortHeader({
             if (!meta) {
                 return;
             }
-            if (!map.has(meta.group)) {
-                map.set(meta.group, []);
-                order.push(meta.group);
+            const groupKey = meta.group;
+            if (!map.has(groupKey)) {
+                map.set(groupKey, []);
+                order.push(groupKey);
             }
-            map.get(meta.group).push(meta);
+            map.get(groupKey).push(meta);
         });
         return order.map((group) => ({ group, items: map.get(group) }));
     }, [sortOptions]);
 
+    const { primarySections, otherSection } = React.useMemo(() => {
+        const primary = [];
+        const others = [];
+
+        grouped.forEach((section) => {
+            if (section.group.toLowerCase() === 'other') {
+                others.push(section);
+            } else {
+                primary.push(section);
+            }
+        });
+
+        const mergedOther = others.length
+            ? {
+                  group: 'Other',
+                  items: others.flatMap((section) => section.items),
+              }
+            : null;
+
+        return { primarySections: primary, otherSection: mergedOther };
+    }, [grouped]);
+
     return (
         <div className={`sb-bar ${className || ''}`} role="toolbar" aria-label="Sorting bar">
-            <div className="sb-left">
-                {grouped.map((section, index) => (
-                    <React.Fragment key={section.group}>
-                        {index > 0 ? <div className="sb-divider" /> : null}
-                        <Group label={section.group}>
-                            {section.items.map((item) => (
+            {primarySections.map((section) => (
+                <div className="sb-row" key={section.group}>
+                    <Group label={section.group}>
+                        {section.items.map((item) => (
+                            <button
+                                key={item.key}
+                                className="sb-pill"
+                                aria-pressed={state.key === item.key}
+                                title={item.title}
+                                onClick={() => handleSelect(item.key)}
+                            >
+                                <span style={{ opacity: 0.9 }}>{item.icon}</span>
+                                <span>{item.label}</span>
+                            </button>
+                        ))}
+                    </Group>
+                </div>
+            ))}
+
+            {(otherSection || showOptions) && (
+                <div className="sb-row sb-row--controls">
+                    {otherSection ? (
+                        <Group label={otherSection.group}>
+                            {otherSection.items.map((item) => (
                                 <button
                                     key={item.key}
                                     className="sb-pill"
@@ -145,48 +186,44 @@ export default function SortHeader({
                                 </button>
                             ))}
                         </Group>
-                    </React.Fragment>
-                ))}
-            </div>
+                    ) : null}
 
-            <div className="sb-right">
-                <button className="sb-btn" aria-label="切换升降序" onClick={toggleOrder}>
-                    <span>Order</span>
-                    <span className={`sb-caret ${state.order === 'asc' ? 'up' : 'down'}`} aria-hidden="true" />
-                    <span
-                        style={{ opacity: 0.8, letterSpacing: '.04em', fontVariant: 'all-small-caps' }}
+                    {showOptions ? (
+                        <details className="sb-more">
+                            <summary className="sb-btn">
+                                <span>More</span>
+                                <span style={{ opacity: 0.7 }}>▾</span>
+                            </summary>
+                            <div className="sb-menu">
+                                <label className="sb-row-option">
+                                    <input
+                                        type="checkbox"
+                                        checked={!!state.options.stickyFolders}
+                                        onChange={(e) => setOption('stickyFolders', e.currentTarget.checked)}
+                                    />
+                                    Pin folders to top
+                                </label>
+                                <label className="sb-row-option">
+                                    <input
+                                        type="checkbox"
+                                        checked={!!state.options.naturalSort}
+                                        onChange={(e) => setOption('naturalSort', e.currentTarget.checked)}
+                                    />
+                                    Natural sort (1&lt;10&lt;100)
+                                </label>
+                            </div>
+                        </details>
+                    ) : null}
+
+                    <button
+                        className="sb-btn sb-btn--order"
+                        aria-label={`Toggle sort order (currently ${state.order === 'asc' ? 'ascending' : 'descending'})`}
+                        onClick={toggleOrder}
                     >
-                        {state.order.toUpperCase()}
-                    </span>
-                </button>
-
-                {showOptions ? (
-                    <details className="sb-more">
-                        <summary className="sb-btn">
-                            <span>More</span>
-                            <span style={{ opacity: 0.7 }}>▾</span>
-                        </summary>
-                        <div className="sb-menu">
-                            <label className="sb-row">
-                                <input
-                                    type="checkbox"
-                                    checked={!!state.options.stickyFolders}
-                                    onChange={(e) => setOption('stickyFolders', e.currentTarget.checked)}
-                                />
-                                置顶文件夹
-                            </label>
-                            <label className="sb-row">
-                                <input
-                                    type="checkbox"
-                                    checked={!!state.options.naturalSort}
-                                    onChange={(e) => setOption('naturalSort', e.currentTarget.checked)}
-                                />
-                                自然排序 (1&lt;10&lt;100)
-                            </label>
-                        </div>
-                    </details>
-                ) : null}
-            </div>
+                        <span className={`sb-arrow ${state.order === 'asc' ? 'up' : 'down'}`} aria-hidden="true" />
+                    </button>
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- replace the legacy SortHeader component with a modern pill-style sort bar that injects its own CSS
- group available sort options with icons and retain the order toggle behaviour
- keep optional controls for sticky folders and natural sort behind a collapsible menu
- move the toolbar styling into `SortHeader.scss` so it reuses the shared theme variables instead of injecting a `<style>` block

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4e28323b4832598b3563fe242f2a2