### PR TITLE
Standardize frontend labels and tooltips

### DIFF
--- a/packages/frontend/src/client/AdminPage.js
+++ b/packages/frontend/src/client/AdminPage.js
@@ -82,14 +82,14 @@ function CacheSection(){
     let cacheInfo;
     cacheInfo =(
         <div className="cache-info">
-            <div className="cache-info-row"> {`thumbnail: ${thumbCount || 0}`} </div>
-            <div className="cache-info-row">{`cache size: ${size}`} </div>
-            <div className="cache-info-row">{`cache file number: ${cacheNum}`} </div>
+            <div className="cache-info-row"> {`Thumbnail: ${thumbCount || 0}`} </div>
+            <div className="cache-info-row">{`Cache Size: ${size}`} </div>
+            <div className="cache-info-row">{`Cache File Number: ${cacheNum}`} </div>
         </div>);
 
     return (
         <div className="admin-section">
-        <div className="admin-section-title" title="only keep thumbnail and delete other files"> Cache Usage (Restart ShiguReader will delete the cache)</div>
+        <div className="admin-section-title" title="Only Keep Thumbnails and Delete Other Files"> Cache Usage (Restart ShiguReader will delete the cache)</div>
         <div className="admin-section-content">
             {cacheInfo}
                 {/* <div className="submit-button" onClick={cleanCache}>clean</div> */}

--- a/packages/frontend/src/client/ExplorerPage.js
+++ b/packages/frontend/src/client/ExplorerPage.js
@@ -823,7 +823,7 @@ export default class ExplorerPage extends Component {
         // 本质就range slider的max不超过300的，超过和到达的时候有额外逻辑
         return (
             <div className='page-number-range-slider-wrapper'>
-                <div className='small-text-title no-wrap' >Page Range：</div>
+                <div className='small-text-title no-wrap' >Page Range:</div>
                 <div className='small-text-title'>{pageNumRange[0]} </div>
                 <RangeSlider className="page-number-range-slider" 
                 min={this.minPageNum} max={maxForSilder} step={1} 
@@ -920,7 +920,7 @@ export default class ExplorerPage extends Component {
     }
 
     renderShowVideoButton() {
-        const text2 = this.state.showVideo ? "Hide video" : "Show video";
+        const text2 = this.state.showVideo ? "Hide Video" : "Show Video";
         return (
             <span className="show-video-button exp-top-button" onClick={this.toggleShowVideo.bind(this)}>
                 <span className="fas fa-video" />
@@ -930,7 +930,7 @@ export default class ExplorerPage extends Component {
     }
 
     renderLevelButton() {
-        const text = this.state.isRecursive ? "Show only one level" : "Show subfolder's files";
+        const text = this.state.isRecursive ? "Show Only One Level" : "Show Files in Subfolders";
         return (
             <span className="recursive-button exp-top-button" onClick={this.toggleRecursively.bind(this)}>
                 <span className="fas fa-glasses" />
@@ -968,7 +968,7 @@ export default class ExplorerPage extends Component {
 
     renderPregenerateButton() {
         if (this.getMode() === MODE_EXPLORER) {
-            const text = "Generate thumbnail"
+            const text = "Generate Thumbnail"
             return (
                 <span key="thumbnail-button" className="thumbnail-button exp-top-button" onClick={() => AdminUtil.askPregenerate(this.getPathFromQuery(), true)}>
                     <span className="fas fa-tools" />
@@ -1216,10 +1216,10 @@ export default class ExplorerPage extends Component {
         });
 
         return (<div className={cn}>
-            <div className="side-menu-radio-title"> Special Filter </div>
+            <div className="side-menu-radio-title"> Special Filters </div>
             <div className="row info-row">
-                <div className="col-3">{`filterText: ${filterText || "-"}`} </div>
-                <div className="col-3">{`filterType: ${filterType || "-"}`} </div>
+                <div className="col-3">{`Filter Text: ${filterText || "-"}`} </div>
+                <div className="col-3">{`Filter Type: ${filterType || "-"}`} </div>
             </div>
             {tagContainer}
         </div>)
@@ -1244,7 +1244,7 @@ export default class ExplorerPage extends Component {
         const filters = [
             { id: 'FILTER_HAS_MUSIC', label: 'Has Music' },
             { id: 'FILTER_HAS_VIDEO', label: 'Has Video' },
-            { id: 'FILTER_IMG_FOLDER', label: 'Only Image Folder' }
+            { id: 'FILTER_IMG_FOLDER', label: 'Image Folders Only' }
         ];
 
         // Map over the filters array to create checkbox components

--- a/packages/frontend/src/client/ExplorerPageUI.js
+++ b/packages/frontend/src/client/ExplorerPageUI.js
@@ -207,10 +207,10 @@ export const SingleZipItem = ({ filePath, info }) => {
                     {imgDiv}
                 </Link>
                 <div className={fileInfoRowCn}>
-                    {fileSizeStr && <span title="file size">{fileSizeStr}</span>}
+                    {fileSizeStr && <span title="File Size">{fileSizeStr}</span>}
                     <span>{`${pageNum} pages`}</span>
                     {hasMusic && <span>{`${musicNum} songs`}</span>}
-                    {avgSizeStr && <span title="average img size"> {avgSizeStr} </span>}
+                    {avgSizeStr && <span title="Average Image Size"> {avgSizeStr} </span>}
                 </div>
                 <FileChangeToolbar isFolder={isImgFolder} hasMusic={hasMusic} className="explorer-file-change-toolbar" file={fp} />
             </div>

--- a/packages/frontend/src/client/ExplorerPageUI.js
+++ b/packages/frontend/src/client/ExplorerPageUI.js
@@ -89,7 +89,7 @@ export const NoScanAlertArea = ({ filePath }) => {
     return (
         <div className="alert alert-warning" role="alert" >
             <div>{`${filePath} is not included in config-path`}</div>
-            <div style={{ marginBottom: "5px" }}>{`It is usable, but it lacks some important features, such as tags and search.`}</div>
+            <div style={{ marginBottom: "5px" }}>{`It's usable but still missing important features like tags and search.`}</div>
             <div className="scan-button" onClick={askSendScan}>Scan this Folder (but it will take time)</div>
         </div>)
 }

--- a/packages/frontend/src/client/HomePage.js
+++ b/packages/frontend/src/client/HomePage.js
@@ -64,7 +64,7 @@ const HomePage = () => {
         return (
             <div className="home-page container">
 
-                {dirItems && <div className="home-section-title"> Scanned And Under Watch </div>} 
+                {dirItems && <div className="home-section-title"> Watched Folders </div>}
                 <ItemsContainer items={dirItems} />
 
                 {quickAccessItems && <div className="home-section-title"> Quick Access </div>} 

--- a/packages/frontend/src/client/HomePage.js
+++ b/packages/frontend/src/client/HomePage.js
@@ -73,7 +73,7 @@ const HomePage = () => {
                 {recentAccessItems && <div className="home-section-title"> Recent Access </div>} 
                 <ItemsContainer items={recentAccessItems} />
 
-                {hddItems && <div className="home-section-title"> Hard Drivers </div>} 
+                {hddItems && <div className="home-section-title"> Hard Drives </div>}
                 <ItemsContainer items={hddItems} />
             </div>)
     }

--- a/packages/frontend/src/client/OneBook.js
+++ b/packages/frontend/src/client/OneBook.js
@@ -445,7 +445,7 @@ export default class OneBook extends Component {
   }
 
   onClickPagination(event) {
-    let index = prompt("Which page to go ");
+    let index = prompt("Which page would you like to go to?");
     index = parseInt(index);
     if (_.isNumber(index) && !isNaN(index)) {
       //the real index 
@@ -537,7 +537,7 @@ export default class OneBook extends Component {
       onClick={this.onClickPagination.bind(this)} >
       {`${index + 1}/${this.getImageLength()}`}  </div>);
 
-    const videoNum = this.hasVideo() && (<div className="video-num"> {` video: ${videoFiles.length}`}  </div>);
+    const videoNum = this.hasVideo() && (<div className="video-num"> {` Video: ${videoFiles.length}`}  </div>);
     return (<div className={"one-book-file-stat"}>{texts} {mobilePageNum} {videoNum} </div>);
   }
 
@@ -816,8 +816,8 @@ export default class OneBook extends Component {
     if (!isMobile()) {
       content = (
         <React.Fragment>
-          <div className="two-page-mode-button fas fa-arrows-alt-h" onClick={this.toggleTwoPageMode.bind(this)} title="two page mode"></div>
-          <div className="fas fa-sync-alt rotate-button" title="rotate image" onClick={this.rotateImg.bind(this)}></div>
+          <div className="two-page-mode-button fas fa-arrows-alt-h" onClick={this.toggleTwoPageMode.bind(this)} title="Two Page Mode"></div>
+          <div className="fas fa-sync-alt rotate-button" title="Rotate Image" onClick={this.rotateImg.bind(this)}></div>
         </React.Fragment>);
     }
     return (<div className="one-book-second-toolbar">

--- a/packages/frontend/src/client/subcomponent/FileChangeToolbar.js
+++ b/packages/frontend/src/client/subcomponent/FileChangeToolbar.js
@@ -165,7 +165,7 @@ class MoveMenu extends Component {
              </span>
              <span className="mv-btn-small" onClick={()=> {
                 onPathSelect && onPathSelect(e)
-             }}> select </span>
+             }}> Select </span>
              </div>)
         })
 

--- a/packages/frontend/src/client/subcomponent/FileChangeToolbar.js
+++ b/packages/frontend/src/client/subcomponent/FileChangeToolbar.js
@@ -415,7 +415,7 @@ export default class FileChangeToolbar extends Component {
         const { file, className, header, hasMusic, bigFont } = this.props;
         // const showMinifyZip = util.isCompress(file);
         if (!this.isInMinifiedFolder()) {
-            return (<div tabIndex="0" className="fas fa-hand-scissors" title="minify img"
+            return (<div tabIndex="0" className="fas fa-hand-scissors" title="Minify Image"
                 onClick={this.handleMinifyZip.bind(this)}></div>)
         }
     }
@@ -429,22 +429,22 @@ export default class FileChangeToolbar extends Component {
         const { file, hasMusic } = this.props;
         const showMinifyZip = util.isCompress(file) && !hasMusic;
         if (showMinifyZip && this.isInMinifiedFolder()) {
-            return (<div tabIndex="0" className="fas fa-cut" title="overwrite the original file"
+            return (<div tabIndex="0" className="fas fa-cut" title="Overwrite the Original File"
                 onClick={this.handleOverwrite.bind(this)}></div>)
         }
     }
 
     renderRenameButton() {
-        return (<div tabIndex="0" className="fas fa-pen raname-button" title="rename file"
+        return (<div tabIndex="0" className="fas fa-pen raname-button" title="Rename File"
             onClick={this.handleRename.bind(this, "rename")}></div>)
 
     }
 
     renderMoveButton() {
-        // return (<div tabIndex="0" className="fas fa-pen move-button" title="move file"
+        // return (<div tabIndex="0" className="fas fa-pen move-button" title="Move File"
         //     onClick={this.handleRename.bind(this, "move")}></div>)
 
-        return (<div tabIndex="0" className="fas fa-pen move-button" title="move file"
+        return (<div tabIndex="0" className="fas fa-pen move-button" title="Move File"
             onClick={() => this.switchMode("move_menu")}></div>)
     }
 
@@ -483,7 +483,7 @@ export default class FileChangeToolbar extends Component {
         if (this.isImgFolder()) {
             const toUrl = clientUtil.getExplorerLink(filePath);
             explorerLink = (<div className="section with-bottom-margin">
-                <Link target="_blank" to={toUrl} >open in explorer</Link>
+                <Link target="_blank" to={toUrl} >Open in Explorer</Link>
             </div>);
         }
 
@@ -515,7 +515,7 @@ export default class FileChangeToolbar extends Component {
             content = (<div className="move_menu_wrap"> 
                 <div className="section with-bottom-margin">
                     <div className="move_menu-back-btn" onClick={()=>this.switchMode("default")}>
-                        <i className="fas fa-long-arrow-alt-left"></i> back 
+                        <i className="fas fa-long-arrow-alt-left"></i> Back
                     </div>
                 </div>
 
@@ -529,7 +529,7 @@ export default class FileChangeToolbar extends Component {
             <Modal
                 isOpen={this.state.showModal}
                 ariaHideApp={false}
-                contentLabel="Move to which path"
+                contentLabel="Move to Which Path"
                 className="file-change-toolbar-move-modal"
                 onRequestClose={this.handleCloseModal.bind(this)}
             >
@@ -541,7 +541,7 @@ export default class FileChangeToolbar extends Component {
     renderModalButton() {
         return (
             <div tabIndex="0" className="fas fa-bars"
-                title="open move-path windows"
+                title="Open Move Path Window"
                 onClick={this.handleOpenModal.bind(this)}>
             </div>
         );

--- a/packages/frontend/src/client/subcomponent/Pagination.js
+++ b/packages/frontend/src/client/subcomponent/Pagination.js
@@ -79,8 +79,8 @@ export default class Pagination extends Component {
       return null;
     }
 
-    const prevButton = (<div className="pagination-item page-link prev" onClick={this.prev}> prev </div>)
-    const nextButton = (<div className="pagination-item page-link next" onClick={this.next}> next </div>)
+    const prevButton = (<div className="pagination-item page-link prev" onClick={this.prev}> Prev </div>)
+    const nextButton = (<div className="pagination-item page-link next" onClick={this.next}> Next </div>)
 
     let right = Math.max(currentPage - BUFFER_SIZE, 1);
     let left = Math.min(currentPage + BUFFER_SIZE, totalPage);
@@ -151,7 +151,7 @@ export default class Pagination extends Component {
 
     const extraButton = (<div className="pagination-extra-button"
       onClick={onExtraButtonClick}
-      title="click to show more">
+      title="Click to Show More">
       {`${itemPerPage} per page`}
     </div>)
 

--- a/packages/frontend/src/client/subcomponent/SortHeader.js
+++ b/packages/frontend/src/client/subcomponent/SortHeader.js
@@ -9,7 +9,7 @@ const KEY_CONFIG = {
     'by latest work': { label: 'Latest Work', icon: '🆕', group: 'Time', title: 'Latest Work' },
     'file size': { label: 'File Size', icon: '📁', group: 'File' },
     'avg page size': { label: 'Average Page Size', icon: '📐', group: 'File' },
-    'page num': { label: 'Page Num', icon: '📄', group: 'File' },
+    'page num': { label: 'Page Number', icon: '📄', group: 'File' },
     'file number': { label: 'File Count', icon: '🔢', group: 'File' },
     filename: { label: 'Filename', icon: '🔤', group: 'File' },
     'tag name': { label: 'Tag Name', icon: '🏷️', group: 'File' },


### PR DESCRIPTION
## Summary
- polish Explorer toolbar text and pagination controls for consistent Title Case labels
- clean up OneBook prompts, video counters, and the Home page heading to fix grammar and spelling
- update admin cache information labels and file operations modal tooltips for clarity

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4fc1ad3e08325898ad0c9160f3f36