### PR TITLE
Improve home page layout

### DIFF
--- a/packages/frontend/src/client/HomePage.js
+++ b/packages/frontend/src/client/HomePage.js
@@ -1,6 +1,5 @@
 // @flow
-import React, { Component, useState, useEffect } from 'react';
-// import _ from "underscore";
+import React, { useState, useEffect } from 'react';
 import './style/HomePage.scss';
 import Sender from './Sender';
 import { Link } from 'react-router-dom';
@@ -10,14 +9,12 @@ import CenterSpinner from './subcomponent/CenterSpinner';
 import ItemsContainer from './subcomponent/ItemsContainer';
 import ThumbnailPopup from './subcomponent/ThumbnailPopup';
 
-const util = require("@common/util");
-const classNames = require('classnames');
 const clientUtil = require("./clientUtil");
 
 function getOneLineListItem(icon, fileName, filePath) {
     return (
         <ThumbnailPopup filePath={filePath}>
-            <li className="explorer-one-line-list-item" key={fileName} title={filePath}>
+            <li className="explorer-one-line-list-item" key={filePath} title={filePath}>
                 {icon}
                 <span className="explorer-one-line-list-item-text">{fileName}</span>
             </li>
@@ -28,12 +25,25 @@ function getOneLineListItem(icon, fileName, filePath) {
 function getPathItems(items){
     const result = (items||[]).map(item => {
         const toUrl = clientUtil.getExplorerLink(item);
-        const text = item;
+        const text = clientUtil.getBaseName(item) || item;
         const result = getOneLineListItem(<i className="far fa-folder"></i>, text, item);
         return <Link to={toUrl} key={item}>{result}</Link>;
     })
     return result;
 }
+
+const HomeSection = ({ title, items }) => {
+    if (!items || items.length === 0) {
+        return null;
+    }
+
+    return (
+        <section className="home-section-panel">
+            <div className="home-section-title"> {title} </div>
+            <ItemsContainer items={items} className="home-section-items" noContainerPadding />
+        </section>
+    );
+};
 
 const HomePage = () => {
     const [res, setRes] = useState(null)
@@ -62,19 +72,11 @@ const HomePage = () => {
         const recentAccessItems = getPathItems(recentAccess);
 
         return (
-            <div className="home-page container">
-
-                {dirItems && <div className="home-section-title"> Watched Folders </div>}
-                <ItemsContainer items={dirItems} />
-
-                {quickAccessItems && <div className="home-section-title"> Quick Access </div>} 
-                <ItemsContainer items={quickAccessItems} />
-
-                {recentAccessItems && <div className="home-section-title"> Recent Access </div>} 
-                <ItemsContainer items={recentAccessItems} />
-
-                {hddItems && <div className="home-section-title"> Hard Drives </div>}
-                <ItemsContainer items={hddItems} />
+            <div className="home-page">
+                <HomeSection title="Watched Folders" items={dirItems} />
+                <HomeSection title="Quick Access" items={quickAccessItems} />
+                <HomeSection title="Recent Access" items={recentAccessItems} />
+                <HomeSection title="Hard Drives" items={hddItems} />
             </div>)
     }
 }

--- a/packages/frontend/src/client/style/HomePage.scss
+++ b/packages/frontend/src/client/style/HomePage.scss
@@ -1,6 +1,17 @@
 @import "vars.scss";
 
 .home-page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  .home-section-panel {
+    background: $bacground_level_one;
+    border-radius: 8px;
+    padding: 18px 20px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  }
+
   @media only screen and (min-width: 1200px) {
     .explorer-one-line-list-item {
       font-size: 1rem;
@@ -13,9 +24,14 @@
   }
 
   .home-section-title {
-    // margin-bottom: 5px;
     font-weight: bold;
     color: $font_color_white_one;
+    margin-bottom: 10px;
+  }
+
+  .home-section-items {
+    padding-left: 0;
+    margin: 0;
   }
 }
 

--- a/packages/frontend/src/client/subcomponent/ItemsContainer.js
+++ b/packages/frontend/src/client/subcomponent/ItemsContainer.js
@@ -5,12 +5,16 @@ var classNames = require('classnames');
 
 export default function ItemsContainer(props) {
     const [ open, setOpen ] = useState(false);
-    const { className, items, neverCollapse } = props;
+    const { className, items, neverCollapse, noContainerPadding } = props;
     const TOO_MUCH = 15;
 
     if (neverCollapse || items.length <= TOO_MUCH) {
         return (
-            <ul className={classNames("item-container container", className)}>
+            <ul className={classNames(
+                "item-container",
+                { container: !noContainerPadding },
+                className,
+            )}>
                 {items}
             </ul>);
     } else {
@@ -24,9 +28,13 @@ export default function ItemsContainer(props) {
         })
 
         return (
-            <ul className={"item-container container"}>
+            <ul className={classNames(
+                "item-container",
+                { container: !noContainerPadding },
+                className,
+            )}>
                 {_items}
-                <div className={cn} onClick={() => { setOpen(!open) }} > 
+                <div className={cn} onClick={() => { setOpen(!open) }} >
                     <span>...</span>
                     <i className={arrowCn} />
                 </div>


### PR DESCRIPTION
## Summary
- wrap each home page section in a dedicated panel and remove container padding for a tighter layout
- show only the folder name in home page lists while keeping the full path available on hover
- allow ItemsContainer to opt out of bootstrap container spacing for contexts like the home page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5078c30c88325926d8dad7c9572ca