### PR TITLE
Refine thumbnail popup styling and positioning

### DIFF
--- a/packages/frontend/src/client/style/ThumbnailPopup.scss
+++ b/packages/frontend/src/client/style/ThumbnailPopup.scss
@@ -18,24 +18,20 @@
     .thumbnail-popup-content {
       display: flex;
       justify-content: start;
-      padding-top: 5px;
-      align-items: center;
-      position: absolute;
+      align-items: flex-start;
+      position: fixed;
       flex-direction: column;
       z-index: 10;
-      
-      top: -50px;
-      left: -250px;
-      @media screen and (max-width: 1600px) {
-        right: 100px;
-        left: unset;
-      }
+      top: 0;
+      left: 0;
 
-      background: rgb(124, 117, 117);
-      width: 240px;
-      height: 220px;
+      background: rgba(67, 70, 78, 0.95);
+      padding: 8px 10px 12px;
       border-radius: 3px;
       box-shadow: 4px 4px 7px rgba(0, 0, 0, 0.59);
+      pointer-events: none;
+      max-width: 360px;
+      max-height: 320px;
 
       .thumbnail-popup-title {
         color: $font_color_white_one;
@@ -43,8 +39,8 @@
         line-height: 1em;
         height: 2em;
         overflow: hidden;
-        padding-bottom: 5px;
-        margin-bottom: 5px;
+        padding-bottom: 6px;
+        margin-bottom: 6px;
         width: 100%;
         padding-left: 10px;
         padding-right: 10px;
@@ -55,14 +51,16 @@
       }
 
       .thumbnail-video-preview {
-        margin-top: 15px;
-        max-width: 95%;
-        max-height: 180px;
+        margin-top: 6px;
+        max-width: 100%;
+        max-height: 260px;
+        border-radius: 2px;
       }
 
       img {
-        max-width: 95%;
-        max-height: 180px;
+        max-width: 100%;
+        max-height: 260px;
+        border-radius: 2px;
       }
     }
   }

--- a/packages/frontend/src/client/subcomponent/ThumbnailPopup.js
+++ b/packages/frontend/src/client/subcomponent/ThumbnailPopup.js
@@ -16,8 +16,17 @@ class ThumbnailPopup extends Component {
         super(prop);
         this.url = prop.url;
         this.isHovering = false;
-        this.state = {};
+        this.state = {
+            popupPosition: null,
+            rerenderTick: false
+        };
         this.useVideoPreviewForFolder = false;
+        this.popupRef = React.createRef();
+        this.popupDimensions = {
+            width: 240,
+            height: 220
+        };
+        this.lastMousePosition = null;
 
         // a throttled function that can only call the func parameter maximally once per every wait milliseconds. 
         this.throttleGet = _.throttle(()=> {
@@ -31,12 +40,23 @@ class ThumbnailPopup extends Component {
             url: this.props.url
           });
         }
+        if (this.popupRef.current && this.isHovering) {
+            const rect = this.popupRef.current.getBoundingClientRect();
+            const width = Math.round(rect.width);
+            const height = Math.round(rect.height);
+            if (width && height && (width !== this.popupDimensions.width || height !== this.popupDimensions.height)) {
+                this.popupDimensions = { width, height };
+                if (this.lastMousePosition) {
+                    this.updatePopupPosition(this.lastMousePosition.x, this.lastMousePosition.y, false);
+                }
+            }
+        }
       }
 
     askRerender(){
-        this.setState({
-            rerenderTick: !this.state.rerenderTick
-        })
+        this.setState((prevState) => ({
+            rerenderTick: !prevState.rerenderTick
+        }))
     }
 
     async fetchData ()  {
@@ -59,14 +79,55 @@ class ThumbnailPopup extends Component {
         } 
     }
 
-    onMouseMove(){
+    updatePopupPosition(clientX, clientY, rememberMouse = true) {
+        if (rememberMouse) {
+            this.lastMousePosition = { x: clientX, y: clientY };
+        }
+        const offset = 12;
+        const contentWidth = this.popupDimensions.width || 240;
+        const contentHeight = this.popupDimensions.height || 220;
+        let left = clientX - contentWidth - offset;
+        if(left < offset){
+            left = clientX + offset;
+        }
+        let top = clientY - contentHeight / 2;
+        const minTop = offset;
+        const maxTop = window.innerHeight - contentHeight - offset;
+        if(top < minTop){
+            top = minTop;
+        }
+        if(top > maxTop){
+            top = maxTop;
+        }
+        const { popupPosition } = this.state;
+        if (popupPosition && popupPosition.top === top && popupPosition.left === left) {
+            return;
+        }
+        this.setState({
+            popupPosition: {
+                top,
+                left
+            }
+        });
+    }
+
+    onMouseMove(e){
         this.isHovering = true;
         this.throttleGet();
-        this.askRerender();
+        if(!e){
+            this.askRerender();
+            return;
+        }
+        const { clientX, clientY } = e;
+        this.updatePopupPosition(clientX, clientY);
     }
 
     onMouseOut(){
         this.isHovering = false;
+        this.setState({
+            popupPosition: null
+        });
+        this.lastMousePosition = null;
         this.askRerender();
     }
 
@@ -80,6 +141,11 @@ class ThumbnailPopup extends Component {
         let extraDom = null;
         let titleStr = clientUtil.getBaseName(filePath);
         titleStr = util.truncateString(titleStr, 35);
+        const popupStyle = this.state.popupPosition ? {
+            top: this.state.popupPosition.top,
+            left: this.state.popupPosition.left
+        } : null;
+
         if(this.isHovering){
             if(isVideo(filePath)|| (this.useVideoPreviewForFolder && this.url)){
                 let src;
@@ -89,7 +155,7 @@ class ThumbnailPopup extends Component {
                     src = this.url;
                 }
 
-                extraDom = (<div className='thumbnail-popup-content'>
+                extraDom = (<div className='thumbnail-popup-content' style={popupStyle} ref={this.popupRef}>
                 <div className='thumbnail-popup-title'>{titleStr}</div>
                     <video className={"thumbnail-video-preview"} src={src} autoPlay={true} muted>
                         Your browser does not support the video tag.
@@ -97,12 +163,12 @@ class ThumbnailPopup extends Component {
                 </div>)
 
             } else if(url){
-                extraDom = (<div className='thumbnail-popup-content'>
+                extraDom = (<div className='thumbnail-popup-content' style={popupStyle} ref={this.popupRef}>
                 <div className='thumbnail-popup-title'>{titleStr}</div>
                 <img className='thumbnail-popup-img' src={url}></img>
                 </div>)
             }else{
-                extraDom = (<div className='thumbnail-popup-content'>
+                extraDom = (<div className='thumbnail-popup-content' style={popupStyle} ref={this.popupRef}>
                 <div className='thumbnail-popup-title'>{titleStr}</div>
                 <div className='thumbnail-popup-text'>NO_THUMBNAIL_AVAILABLE</div>
              </div>)


### PR DESCRIPTION
## Summary
- measure the popup content after render so its position hugs the cursor based on actual dimensions
- refresh the thumbnail popup styling with theme-matching background and compact, responsive padding for media previews

## Testing
- npm --prefix packages/frontend test *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d513769b448325bafb923221c86429