### PR TITLE
Add folder thumbnail request fallback

### DIFF
--- a/packages/frontend/src/client/LoadingImage.js
+++ b/packages/frontend/src/client/LoadingImage.js
@@ -67,27 +67,18 @@ export default class LoadingImage extends Component {
 
   async requestThumbnail() {
     const { mode, fileName } = this.props;
-    let api;
+    let res;
     if (this.isAuthorTagMode()) {
-      api = "/api/getTagThumbnail"
-    } else if (mode === "folder") {
-      api = "/api/getFolderThumbnail";
-    } else {
-      api = '/api/getZipThumbnail'
-    }
-
-    const body = {};
-    if (this.isAuthorTagMode()) {
+      const body = {};
       body[mode] = fileName;
+      res = await Sender.postWithPromise("/api/getTagThumbnail", body);
+    } else if (mode === "folder") {
+      const query = encodeURIComponent(fileName);
+      res = await Sender.getWithPromise(`/api/folderThumbnailFromDisk?filePath=${query}`);
     } else {
-      body["filePath"] = fileName;
+      res = await Sender.postWithPromise('/api/getZipThumbnail', { filePath: fileName });
     }
 
-    if (!api) {
-      return;
-    }
-
-    const res = await Sender.postWithPromise(api, body);
     if (!this.isUnmounted) {
       if (res.isFailed()) {
         this.setState({ url: "NO_THUMBNAIL_AVAILABLE" })

--- a/packages/frontend/src/client/LoadingImage.js
+++ b/packages/frontend/src/client/LoadingImage.js
@@ -71,7 +71,7 @@ export default class LoadingImage extends Component {
     if (this.isAuthorTagMode()) {
       api = "/api/getTagThumbnail"
     } else if (mode === "folder") {
-      // TODO backend need to support?
+      api = "/api/getFolderThumbnail";
     } else {
       api = '/api/getZipThumbnail'
     }


### PR DESCRIPTION
## Summary
- enable the folder mode LoadingImage component to request thumbnails from the backend
- add a backend API that locates or extracts a thumbnail for folders using contained archives

## Testing
- npm test (backend) *(fails: Windows path expectations in pathUtil tests on Linux)*
- npm test (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d521e815108325b5eb29743ffb3b77