### PR TITLE
Fix music player active indicator and author link layout

### DIFF
--- a/packages/frontend/src/components/MusicPlayer.js
+++ b/packages/frontend/src/components/MusicPlayer.js
@@ -45,10 +45,21 @@ export default class MusicPlayer extends Component {
         const { audioFiles, className } = this.props;
         const { index } = this.state;
         const audioItems = audioFiles.map((e, ii) => {
+            const isActive = ii === index;
             const cn = classNames("aji-music-player-item", {
-                "aji-music-player-active  fas fa-volume-up": ii === index
-            })
-            return (<div key={e} className={cn} onClick={this.handleIndexChange.bind(this, ii)} title={getBaseName(e)}> {getBaseName(e)} </div>)
+                "aji-music-player-active": isActive
+            });
+            return (
+                <div
+                    key={e}
+                    className={cn}
+                    onClick={this.handleIndexChange.bind(this, ii)}
+                    title={getBaseName(e)}
+                >
+                    {isActive && <i className="fas fa-volume-up aji-music-player-icon" aria-hidden="true"></i>}
+                    <span className="aji-music-player-title">{getBaseName(e)}</span>
+                </div>
+            )
         });
 
         if (audioFiles.length === 0) {

--- a/packages/frontend/src/pages/AdminPage.js
+++ b/packages/frontend/src/pages/AdminPage.js
@@ -314,7 +314,10 @@ export default class AdminPage extends Component {
                 <LogoutSection />
 
                 <div className="author-link">
-                    <a className="fab fa-github" title="Aji47's Github" href="https://github.com/hjyssg/ShiguReader" target="_blank"> Created By Aji47 </a>
+                    <a className="author-link-item" title="Aji47's Github" href="https://github.com/hjyssg/ShiguReader" target="_blank" rel="noreferrer">
+                        <i className="fab fa-github author-link-icon" aria-hidden="true"></i>
+                        <span className="author-link-text">Created By Aji47</span>
+                    </a>
                 </div>
             </div>)
 

--- a/packages/frontend/src/pages/LoginPage.js
+++ b/packages/frontend/src/pages/LoginPage.js
@@ -56,7 +56,10 @@ class LoginPage extends Component {
                 <button onClick={this.setPasswordCookie.bind(this)}> Login </button>
                 <div id="log-err"> {this.state.errMessage} </div>
                 <div className="author-link">
-                    <a className="fab fa-github" title="Aji47's Github" href="https://github.com/hjyssg/ShiguReader" target="_blank"> Created By Aji47 </a>
+                    <a className="author-link-item" title="Aji47's Github" href="https://github.com/hjyssg/ShiguReader" target="_blank" rel="noreferrer">
+                        <i className="fab fa-github author-link-icon" aria-hidden="true"></i>
+                        <span className="author-link-text">Created By Aji47</span>
+                    </a>
                 </div>
             </div>
         </React.Fragment>);

--- a/packages/frontend/src/styles/AdminPage.scss
+++ b/packages/frontend/src/styles/AdminPage.scss
@@ -71,9 +71,18 @@
     margin-top: 10px;
     margin-bottom: 10px;
 
-    a {
+    .author-link-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
       font-size: 1.2rem;
       color: $font_color_black_two;
+      text-decoration: none;
+      white-space: nowrap;
+
+      .author-link-icon {
+        color: inherit;
+      }
     }
   }
 }

--- a/packages/frontend/src/styles/App.scss
+++ b/packages/frontend/src/styles/App.scss
@@ -167,8 +167,17 @@ a {
     .author-link {
       margin-top: 100px;
 
-      .fab {
-        color: unset;
+      .author-link-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        color: inherit;
+        text-decoration: none;
+        white-space: nowrap;
+      }
+
+      .author-link-icon {
+        color: inherit;
       }
     }
   }

--- a/packages/frontend/src/styles/MusicPlayer.scss
+++ b/packages/frontend/src/styles/MusicPlayer.scss
@@ -16,20 +16,29 @@
         color: $font_color_white_one;
         cursor: pointer;
         margin-bottom: 10px;
-        // overflow-x: visible;
-
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        flex-shrink: 1;
+        display: flex;
+        align-items: center;
+        gap: 6px;
         font-size: 12px;
 
         &:hover {
             @include third_hover_effect;
         }
 
+        .aji-music-player-icon {
+            flex-shrink: 0;
+            color: $font_color_white_one;
+        }
+
+        .aji-music-player-title {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            flex: 1;
+        }
+
         &.aji-music-player-active {
-            &::before {
+            .aji-music-player-icon {
                 color: chartreuse;
             }
         }


### PR DESCRIPTION
## Summary
- restructure the music player active item markup to render the volume icon separately so the track title stays visible
- align the music player icon and title with new flexbox styles for a consistent layout
- update the admin and login author link markup and styles so the GitHub icon no longer forces the credit text onto a new line

## Testing
- CI=true npm test *(fails: `mocha: not found` because dependencies are not installed in the environment)*
- npm install *(fails: dependency conflict between css-loader@2.1.1 and webpack@5.101.3)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c381adbc83258a99ac074d036eb5