### PR TITLE
feat: trigger history logging from frontend thresholds

### DIFF
--- a/packages/backend/src/app.js
+++ b/packages/backend/src/app.js
@@ -799,7 +799,6 @@ app.post('/api/extract/extract_zip', asyncWrapper(async (req, res) => {
         result = serverUtil.checkOneBookRes(result);
         res.send(result);
 
-        historyDb.addOneRecord(filePath);
     }
 
     const outputPath = path.join(cachePath, getHash(filePath));
@@ -823,7 +822,6 @@ app.post('/api/extract/extract_zip', asyncWrapper(async (req, res) => {
     // 这样zip内容改变对应不了，但我很少这么操作
     if(extract_result_cache[filePath]){
         res.send(extract_result_cache[filePath]);
-        historyDb.addOneRecord(filePath);
         return;
     }
 

--- a/packages/backend/src/models/history-db.js
+++ b/packages/backend/src/models/history-db.js
@@ -35,18 +35,28 @@ function noNeedRecord(filePath){
     return cachePath && pathUtil.isSub(cachePath, filePath);
 }
 
-module.exports.addOneRecord = function (filePath) {
-    if(noNeedRecord(filePath)){
-        return;
+module.exports.getLatestRecordForFilePath = async function (filePath) {
+    if (!filePath) {
+        return null;
     }
 
-    const time = util.getCurrentTime()
+    const sql = `SELECT time FROM history_table WHERE filePath = ? ORDER BY time DESC LIMIT 1`;
+    return await sqldb.getSync(sql, [filePath]);
+}
+
+module.exports.addOneRecord = async function (filePath, recordTime) {
+    if(noNeedRecord(filePath)){
+        return false;
+    }
+
+    const time = recordTime || util.getCurrentTime()
     const fileName = path.basename(filePath);
     const dirPath = path.dirname(filePath);
 
-    sqldb.insertOneRow("history_table", {
+    await sqldb.insertOneRow("history_table", {
         filePath, dirPath, fileName, time
     });
+    return true;
 }
 
 module.exports.addOneLsDirRecord = function (filePath) {

--- a/packages/backend/src/models/history-db.js
+++ b/packages/backend/src/models/history-db.js
@@ -44,8 +44,6 @@ async function getLatestRecordForFilePath(filePath) {
     return await sqldb.getSync(sql, [filePath]);
 }
 
-module.exports.getLatestRecordForFilePath = getLatestRecordForFilePath;
-
 module.exports.addOneRecord = async function (filePath, recordTime) {
     if(noNeedRecord(filePath)){
         return false;

--- a/packages/backend/src/routes/file-move-delete.js
+++ b/packages/backend/src/routes/file-move-delete.js
@@ -39,10 +39,6 @@ router.post("/api/file/get_info", serverUtil.asyncWrapper(async (req, res) => {
     res.send({
         stat,
     });
-
-    if (util.isVideo(filePath)) {
-        historyDb.addOneRecord(filePath);
-    }
 }));
 
 

--- a/packages/backend/src/routes/history.js
+++ b/packages/backend/src/routes/history.js
@@ -33,16 +33,12 @@ router.post('/api/history/add', serverUtil.asyncWrapper(async (req, res) => {
 
     try {
         const now = util.getCurrentTime();
-        const lastRecord = await historyDb.getLatestRecordForFilePath(filePath);
-        const lastTime = lastRecord && typeof lastRecord.time === 'number' ? lastRecord.time : null;
-        const FIVE_MINUTES = 5 * 60 * 1000;
-
-        if (lastTime && now - lastTime < FIVE_MINUTES) {
+        const inserted = await historyDb.addOneRecord(filePath, now);
+        if (!inserted) {
             res.send({ failed: false, skipped: true });
             return;
         }
 
-        await historyDb.addOneRecord(filePath, now);
         res.send({ failed: false });
     } catch (err) {
         res.send({ failed: true, reason: err?.message || String(err) });

--- a/packages/backend/src/routes/history.js
+++ b/packages/backend/src/routes/history.js
@@ -24,6 +24,21 @@ router.post('/api/history/list', serverUtil.asyncWrapper(async (req, res) => {
     res.send(history);
 }));
 
+router.post('/api/history/add', serverUtil.asyncWrapper(async (req, res) => {
+    const filePath = req.body && req.body.filePath;
+    if (!filePath) {
+        res.send({ failed: true, reason: "No parameter" });
+        return;
+    }
+
+    try {
+        historyDb.addOneRecord(filePath);
+        res.send({ failed: false });
+    } catch (err) {
+        res.send({ failed: true, reason: err?.message || String(err) });
+    }
+}));
+
 router.post("/api/history/get_file_history", serverUtil.asyncWrapper(async (req, res) => {
     const all_pathes = req.body && req.body.all_pathes;
     if (!all_pathes) {

--- a/packages/backend/src/routes/list-dir.js
+++ b/packages/backend/src/routes/list-dir.js
@@ -221,7 +221,6 @@ router.post('/api/folder/list_image_content', serverUtil.asyncWrapper(async (req
     
     result = serverUtil.checkOneBookRes(result);
     res.send(result);
-    historyDb.addOneRecord(filePath);
 }));
 
 module.exports = router;

--- a/packages/frontend/src/api/history.js
+++ b/packages/frontend/src/api/history.js
@@ -5,3 +5,6 @@ export const getFileHistory = (filePath) =>
 
 export const listHistory = (page) =>
   Sender.postWithPromise('/api/history/list', { page });
+
+export const addHistoryRecord = (filePath) =>
+  Sender.postWithPromise('/api/history/add', { filePath });

--- a/packages/frontend/src/pages/OneBook.js
+++ b/packages/frontend/src/pages/OneBook.js
@@ -448,7 +448,10 @@ export default class OneBook extends Component {
     }
 
     const currentPage = index + 1;
-    if (currentPage / totalPages < (1 / 3)) {
+    const reachedProgressThreshold = currentPage / totalPages >= (1 / 3);
+    const reachedPageThreshold = currentPage > 8;
+
+    if (!reachedProgressThreshold && !reachedPageThreshold) {
       return;
     }
 

--- a/packages/frontend/src/pages/OneBook.js
+++ b/packages/frontend/src/pages/OneBook.js
@@ -6,6 +6,7 @@ import ReactDOM from 'react-dom';
 import { Link } from 'react-router-dom';
 import { listImageFolderContent } from '@api/folder';
 import { extractZip } from '@api/extract';
+import { addHistoryRecord } from '@api/history';
 import '@styles/OneBook.scss';
 import ErrorPage from '@pages/ErrorPage';
 import Spinner from '@components/common/Spinner';
@@ -39,6 +40,7 @@ export default class OneBook extends Component {
     super(props);
 
     this.zoom_scale = null;
+    this.bookHistoryRecorded = false;
 
     this.state = {
       imageFiles: [],
@@ -81,6 +83,20 @@ export default class OneBook extends Component {
 
     this._adjustImageSize = this.adjustImageSize.bind(this);
     window.addEventListener("resize", this._adjustImageSize);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.path && this.state.path !== prevState.path) {
+      this.bookHistoryRecorded = false;
+    }
+
+    if (this.state.path && (
+      this.state.index !== prevState.index ||
+      this.state.imageFiles !== prevState.imageFiles ||
+      this.state.path !== prevState.path
+    )) {
+      this.maybeRecordBookHistory();
+    }
   }
 
   updateScrollPos(e) {
@@ -416,6 +432,31 @@ export default class OneBook extends Component {
 
   getImageLength() {
     return this.state.imageFiles.length;
+  }
+
+  maybeRecordBookHistory() {
+    if (this.bookHistoryRecorded) {
+      return;
+    }
+
+    const { imageFiles, index, path, zipInfo } = this.state;
+    const parsedPageNum = zipInfo && parseInt(zipInfo.pageNum, 10);
+    const totalPages = parsedPageNum > 0 ? parsedPageNum : imageFiles.length;
+
+    if (!path || totalPages === 0) {
+      return;
+    }
+
+    const currentPage = index + 1;
+    if (currentPage / totalPages < (1 / 3)) {
+      return;
+    }
+
+    this.bookHistoryRecorded = true;
+    addHistoryRecord(path).catch((e) => {
+      console.error(e);
+      this.bookHistoryRecorded = false;
+    });
   }
 
   next(event) {

--- a/packages/frontend/src/pages/VideoPlayer.js
+++ b/packages/frontend/src/pages/VideoPlayer.js
@@ -7,6 +7,7 @@ const clientUtil = require("@utils/clientUtil");
 const { getDir, getBaseName, filesizeUitl } = clientUtil;
 import { Link } from 'react-router-dom';
 import { getInfo as getFileInfo } from '@api/file';
+import { addHistoryRecord } from '@api/history';
 const queryString = require('query-string');
 const Cookie = require("js-cookie");
 import DPlayer from "react-dplayer";
@@ -18,6 +19,7 @@ export default class VideoPlayer extends Component {
     super(props);
     this.state = {
     };
+    this.videoHistoryRecorded = false;
   }
 
   componentDidMount() {
@@ -37,6 +39,12 @@ export default class VideoPlayer extends Component {
 
 
     document.addEventListener('keydown', this.handleKeyDown.bind(this));
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.getTextFromQuery(prevProps) !== this.getTextFromQuery()) {
+      this.videoHistoryRecorded = false;
+    }
   }
 
   componentWillUnmount() {
@@ -105,6 +113,32 @@ export default class VideoPlayer extends Component {
     }catch(e){
       console.error(e);
     }
+    this.maybeRecordVideoHistory();
+  }
+
+  maybeRecordVideoHistory() {
+    if (this.videoHistoryRecorded) {
+      return;
+    }
+
+    if (!this.dp || !this.dp.video) {
+      return;
+    }
+
+    if (this.dp.video.currentTime < 10) {
+      return;
+    }
+
+    const filePath = this.getTextFromQuery();
+    if (!filePath) {
+      return;
+    }
+
+    this.videoHistoryRecorded = true;
+    addHistoryRecord(filePath).catch((e) => {
+      console.error(e);
+      this.videoHistoryRecorded = false;
+    });
   }
 
  adjustHW(){


### PR DESCRIPTION
## Summary
- add an API endpoint for clients to record history entries and stop automatic insertion in backend routes
- trigger history creation from the reader after reaching one-third progress and from the video player after 10 seconds of playback
- expose a frontend helper for recording history and reuse it across book and video views

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d76cacb2c88325b932c4aedb1224c0