### PR TITLE
Preserve estimate file table during initialization

### DIFF
--- a/packages/backend/src/models/db.js
+++ b/packages/backend/src/models/db.js
@@ -117,9 +117,7 @@ module.exports.init = async () => {
             PRIMARY KEY (tag, type, subtype)
         );
 
-
-        DROP TABLE IF EXISTS estimate_file_table;
-        CREATE TABLE estimate_file_table (
+        CREATE TABLE IF NOT EXISTS estimate_file_table (
             dirName TEXT,
             dirPath TEXT,
             fileName TEXT,


### PR DESCRIPTION
## Summary
- avoid dropping the estimate_file_table during database initialization to preserve stored records
- create the table only if it does not already exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8716452e08325b651011359bd5668