### PR TITLE
Stop mutating estimate file table on file ops

### DIFF
--- a/packages/backend/src/models/estimate-file-db.js
+++ b/packages/backend/src/models/estimate-file-db.js
@@ -29,29 +29,6 @@ module.exports.addEstimateFiles = async function(rows){
     await sqldb.batchInsert('estimate_file_table', payload);
 };
 
-module.exports.removeEstimateFiles = async function(filePath, fileNames){
-    if(!fileNames || fileNames.length === 0){
-        return;
-    }
-    const placeholders = fileNames.map(() => '?').join(',');
-    const sql = `DELETE FROM estimate_file_table WHERE filePath=? AND fileName IN (${placeholders})`;
-    await sqldb.runSync(sql, [filePath, ...fileNames]);
-};
-
-module.exports.touchEstimateFiles = async function(filePath, fileNames){
-    if(!fileNames || fileNames.length === 0){
-        return;
-    }
-    const placeholders = fileNames.map(() => '?').join(',');
-    const sql = `UPDATE estimate_file_table SET scan_time=? WHERE filePath=? AND fileName IN (${placeholders})`;
-    await sqldb.runSync(sql, [util.getCurrentTime(), filePath, ...fileNames]);
-};
-
-module.exports.getEstimateFilesInDir = async function(filePath){
-    const sql = `SELECT * FROM estimate_file_table WHERE filePath=?`;
-    return await sqldb.allSync(sql, [filePath]);
-};
-
 module.exports.findEstimateByText = async function(text){
     const sql = `SELECT fileName FROM estimate_file_table WHERE fileName LIKE ?`;
     return await sqldb.allSync(sql, [`%${text}%`]);

--- a/packages/backend/src/routes/file-move-delete.js
+++ b/packages/backend/src/routes/file-move-delete.js
@@ -7,7 +7,6 @@ const router = express.Router();
 const logger = require("../config/logger");
 const thumbnailDb = require("../models/thumbnail-db");
 const zipInfoDb = require("../models/zip-info-db");
-const estimateFileTable = require("../services/estimate-file-table");
 const historyDb = require("../models/history-db");
 
 const pathUtil = require("../utils/path-util");
@@ -63,7 +62,6 @@ router.post('/api/file/rename', serverUtil.asyncWrapper(async (req, res) => {
         if (err) { throw err; }
 
         logger.info(`[rename] ${src} to ${dest}`);
-        estimateFileTable.onMove(src, dest).catch(e=>logger.error(e));
         res.send({ failed: false, dest });
     } catch (err) {
         logger.error(err);
@@ -125,7 +123,6 @@ router.post('/api/file/move', serverUtil.asyncWrapper(async (req, res) => {
             tempZinInfo.filePath = destFP;
             zipInfoDb.updateZipDb_v2(tempZinInfo);
         }
-        estimateFileTable.onMove(src, destFP).catch(e=>logger.error(e));
         res.send({ failed: false, dest: destFP });
     } catch (err) {
         logger.error(err);
@@ -164,7 +161,6 @@ router.post('/api/file/delete', serverUtil.asyncWrapper(async (req, res) => {
         await deleteThing(src);
         res.send({ failed: false });
         logger.info(`[DELETE] ${src}`);
-        estimateFileTable.onDelete(src).catch(e=>logger.error(e));
 
         deleteCallBack(src);
     } catch (e) {
@@ -193,7 +189,6 @@ router.post('/api/folder/delete', serverUtil.asyncWrapper(async (req, res) => {
         await deleteThing(src);
         res.send({ failed: false });
         logger.info(`[DELETE_FOLDER] ${src}`);
-        estimateFileTable.onDelete(src).catch(e=>logger.error(e));
     } catch (e) {
         logger.error(e);
         res.send({ reason: file_occupy_warning, failed: true });

--- a/packages/backend/src/services/estimate-file-table.js
+++ b/packages/backend/src/services/estimate-file-table.js
@@ -4,74 +4,23 @@ const logger = require('../config/logger');
 
 async function updateByScan(filePathes){
     try{
-        if(filePathes.length === 0){
+        if(!filePathes || filePathes.length === 0){
             return;
         }
 
-        const grouped = new Map();
-        filePathes.forEach(fp=>{
-            const dirPath = path.dirname(fp);
-            if(!grouped.has(dirPath)){
-                grouped.set(dirPath, new Set());
-            }
-            grouped.get(dirPath).add(path.basename(fp));
-        });
+        const rows = Array.from(new Set(filePathes))
+            .filter(Boolean)
+            .map(fp => ({
+                filePath: fp,
+                fileName: path.basename(fp)
+            }));
 
-        filePathes.forEach(fp=>{
-            if(!grouped.has(fp)){
-                grouped.set(fp, new Set());
-            }
-        });
-
-        for(const [dirPath, nameSet] of grouped.entries()){
-            const uniqueNames = Array.from(nameSet);
-            const rows = await estimateFileDb.getEstimateFilesInDir(dirPath);
-            const oldSet = new Set(rows.map(r=>r.fileName));
-
-            const toInsert = uniqueNames
-                .filter(fn=>!oldSet.has(fn))
-                .map(fn=>({ filePath: dirPath, fileName: fn }));
-            const toRemove = Array.from(oldSet).filter(fn=>!nameSet.has(fn));
-
-            if(toInsert.length){
-                await estimateFileDb.addEstimateFiles(toInsert);
-            }
-            if(toRemove.length){
-                await estimateFileDb.removeEstimateFiles(dirPath, toRemove);
-            }
-            if(uniqueNames.length){
-                await estimateFileDb.touchEstimateFiles(dirPath, uniqueNames);
-            }
-        }
-    }catch(e){
-        logger.error(e);
-    }
-}
-
-async function onMove(src, dest){
-    try{
-        await estimateFileDb.removeEstimateFiles(path.dirname(src), [path.basename(src)]);
-        await estimateFileDb.addEstimateFiles([
-            {
-                filePath: path.dirname(dest),
-                fileName: path.basename(dest)
-            }
-        ]);
-    }catch(e){
-        logger.error(e);
-    }
-}
-
-async function onDelete(src){
-    try{
-        await estimateFileDb.removeEstimateFiles(path.dirname(src), [path.basename(src)]);
+        await estimateFileDb.addEstimateFiles(rows);
     }catch(e){
         logger.error(e);
     }
 }
 
 module.exports = {
-    updateByScan,
-    onMove,
-    onDelete
+    updateByScan
 };


### PR DESCRIPTION
## Summary
- ensure estimate file scan records store the full path string when inserting
- drop the move/delete helpers so file operations stop touching the estimate table and adjust routes accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d89de827848325bbf97a6d6e2868c7