### PR TITLE
Add one-click pkg packaging script

### DIFF
--- a/packages/backend/.vscode/launch.json
+++ b/packages/backend/.vscode/launch.json
@@ -52,6 +52,13 @@
       "name": "sub server [no scan and different port, share the same db with main server]",
       "program": "${workspaceFolder}\\src\\app.js",
       "args": ["--skip-scan", "--skip-cache-clean", "--port", "34213"]
+    },
+    {
+      "type": "python",
+      "request": "launch",
+      "name": "one click pkg",
+      "program": "${workspaceFolder}/etc/pkg/one_click_pkg.py",
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/packages/backend/etc/pkg/one_click_pkg.py
+++ b/packages/backend/etc/pkg/one_click_pkg.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Utility script to build ShiguReader backend executable with pkg.
+
+Steps:
+1. Synchronize the frontend build output to the backend `dist` directory.
+2. Run `pkg` with the documented arguments to produce the executable.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+CURRENT_DIR = Path(__file__).resolve().parent
+BACKEND_DIR = CURRENT_DIR.parent
+SYNC_SCRIPT = BACKEND_DIR / "etc" / "sync_frontend_assets_to_backend.py"
+
+
+def run_sync() -> None:
+    """Run the frontend asset synchronization script."""
+    if not SYNC_SCRIPT.is_file():
+        raise FileNotFoundError(f"找不到同步脚本: {SYNC_SCRIPT}")
+
+    print("[1/2] 同步前端资源到后端……")
+    subprocess.run(
+        [sys.executable, str(SYNC_SCRIPT)],
+        cwd=BACKEND_DIR,
+        check=True,
+    )
+
+
+def run_pkg() -> None:
+    """Execute pkg to build the backend executable."""
+    pkg_cmd = shutil.which("pkg")
+    if pkg_cmd is None:
+        raise FileNotFoundError(
+            "未找到 `pkg` 命令，请先按 README 说明安装 (npm install -g pkg)。"
+        )
+
+    print("[2/2] 运行 pkg 打包后端……")
+    subprocess.run(
+        [pkg_cmd, ".", "--compress", "GZip"],
+        cwd=BACKEND_DIR,
+        check=True,
+    )
+
+
+def main() -> None:
+    run_sync()
+    run_pkg()
+    print("✅ 打包流程完成。")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python helper that syncs frontend assets and runs `pkg` to produce the backend executable
- register the helper script as a VS Code launch configuration for easy access

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8f4f7a5d48325a9190c2fe8e8e24b