### PR TITLE
Enhance one-click pkg script with asset packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/packages/SGR_pkg/*
+/packages/ShiguReaderExeRelease/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,6 +85,13 @@
       "name": "Sync frontend assets to backend",
       "program": "${workspaceFolder}/packages/backend/etc/sync_frontend_assets_to_backend.py",
       "console": "integratedTerminal"
+    },
+    {
+      "type": "python",
+      "request": "launch",
+      "name": "one click pkg",
+      "program": "${workspaceFolder}/packages/backend/etc/pkg/one_click_pkg.py",
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/packages/backend/etc/pkg/one_click_pkg.py
+++ b/packages/backend/etc/pkg/one_click_pkg.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Utility script to build ShiguReader backend executable with pkg.
+
+Steps:
+1. Synchronize the frontend build output to the backend `dist` directory.
+2. Run `pkg` with the documented arguments to produce the executable.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+CURRENT_DIR = Path(__file__).resolve().parent
+BACKEND_DIR = CURRENT_DIR.parent.parent
+PACKAGES_DIR = BACKEND_DIR.parent
+REPO_ROOT = PACKAGES_DIR.parent
+RELEASE_DIR = PACKAGES_DIR / "ShiguReaderExeRelease"
+SYNC_SCRIPT = BACKEND_DIR / "etc" / "sync_frontend_assets_to_backend.py"
+
+
+def run_sync() -> None:
+    """Run the frontend asset synchronization script."""
+    if not SYNC_SCRIPT.is_file():
+        raise FileNotFoundError(f"找不到同步脚本: {SYNC_SCRIPT}")
+
+    print("[1/2] 同步前端资源到后端……")
+    subprocess.run(
+        [sys.executable, str(SYNC_SCRIPT)],
+        cwd=BACKEND_DIR,
+        check=True,
+    )
+
+
+def run_pkg() -> None:
+    """Execute pkg to build the backend executable."""
+    pkg_cmd = shutil.which("pkg")
+    if pkg_cmd is None:
+        raise FileNotFoundError(
+            "未找到 `pkg` 命令，请先按 README 说明安装 (npm install -g pkg)。"
+        )
+
+    print("[2/2] 运行 pkg 打包后端……")
+    subprocess.run(
+        [pkg_cmd, ".", "--compress", "GZip"],
+        cwd=BACKEND_DIR,
+        check=True,
+    )
+
+
+def copy_release_assets() -> None:
+    """复制 dist 与 resource 到打包目录。"""
+
+    dist_dir = BACKEND_DIR / "dist"
+    resource_dir = BACKEND_DIR / "resource"
+
+    RELEASE_DIR.mkdir(parents=True, exist_ok=True)
+
+    for folder in (dist_dir, resource_dir):
+        if not folder.exists():
+            raise FileNotFoundError(f"缺少必须的目录: {folder}")
+
+        target = RELEASE_DIR / folder.name
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(folder, target)
+        print(f"已复制 {folder} -> {target}")
+
+
+def clear_release_workspace() -> None:
+    """清空打包目录中的 workspace。"""
+
+    workspace_dir = RELEASE_DIR / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    for child in list(workspace_dir.iterdir()):
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+    print(f"已清空 {workspace_dir}")
+
+
+def zip_release() -> Path:
+    """将打包目录压缩成带日期后缀的 zip。"""
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    zip_path = REPO_ROOT / f"ShiguReader_{today}.zip"
+
+    if zip_path.exists():
+        zip_path.unlink()
+
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in RELEASE_DIR.rglob("*"):
+            if path.is_dir():
+                continue
+            archive.write(path, path.relative_to(RELEASE_DIR))
+
+    print(f"已生成压缩包: {zip_path}")
+    return zip_path
+
+
+def main() -> None:
+    run_sync()
+    run_pkg()
+    copy_release_assets()
+    clear_release_workspace()
+    zip_release()
+    print("✅ 打包流程完成。")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/backend/etc/pkg/pkg_zip_tool.py
+++ b/packages/backend/etc/pkg/pkg_zip_tool.py
@@ -12,7 +12,7 @@ import shutil
 script_dir = os.path.dirname(os.path.realpath(__file__))
 root_folder = os.path.normpath(os.path.join(script_dir, '..\\..\\..'))
 print("root_folder", root_folder)
-pkg_folder =  os.path.join(root_folder, "SGR_pkg")   
+pkg_folder =  os.path.join(root_folder, "ShiguReaderExeRelease")
 
 # The relative paths of the directories to be excluded from the compression
 dirs_to_exclude = ["thumbnails", "workspace", "cache", ".git"]

--- a/packages/backend/etc/pkg/prepare_exe_pkg.py
+++ b/packages/backend/etc/pkg/prepare_exe_pkg.py
@@ -5,7 +5,7 @@ script_dir = os.path.dirname(os.path.realpath(__file__))
 root_folder = os.path.normpath(os.path.join(script_dir, '..\\..\\..'))
 print("root_folder", root_folder)
 
-pkg_folder = os.path.join(root_folder, "SGR_pkg")
+pkg_folder = os.path.join(root_folder, "ShiguReaderExeRelease")
 os.makedirs(pkg_folder, exist_ok=True)  # 确保目标文件夹存在
 
 # 要复制的文件夹

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,7 +22,7 @@
     "targets": [
       "node22-win-x64"
     ],
-    "outputPath": "../SGR_pkg/"
+    "outputPath": "../ShiguReaderExeRelease/"
   },
   "author": "aji47",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- fix the path handling in the one-click pkg helper so it runs from the backend directory
- extend the helper to copy dist/resource into ShiguReaderExeRelease, clear workspace, and emit a dated zip archive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8f4f7a5d48325a9190c2fe8e8e24b