### PR TITLE
Replace react-visibility-sensor with local IntersectionObserver wrapper

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -29,7 +29,6 @@
         "react-range-slider-input": "^3.0.7",
         "react-router-dom": "^4.3.1",
         "react-toastify": "^9.1.2",
-        "react-visibility-sensor": "^5.1.1",
         "request": "^2.88.2",
         "request-promise": "^4.2.6",
         "screenfull": "^4.0.0",
@@ -8649,18 +8648,6 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
-      }
-    },
-    "node_modules/react-visibility-sensor": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
-      "integrity": "sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/read-pkg": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,7 +36,6 @@
     "react-range-slider-input": "^3.0.7",
     "react-router-dom": "^4.3.1",
     "react-toastify": "^9.1.2",
-    "react-visibility-sensor": "^5.1.1",
     "request": "^2.88.2",
     "request-promise": "^4.2.6",
     "screenfull": "^4.0.0",

--- a/packages/frontend/src/components/LoadingImage/index.js
+++ b/packages/frontend/src/components/LoadingImage/index.js
@@ -2,8 +2,8 @@ import React, { useEffect, useRef, useState, useCallback } from "react";
 import { getFolderThumbnail, getTagThumbnail, getZipThumbnail } from "@api/thumbnail";
 import classNames from "classnames";
 import './LoadingImage.scss';
+import VisibilitySensor from "@components/common/VisibilitySensor";
 const clientUtil = require("@utils/clientUtil");
-const VisibilitySensor = require("react-visibility-sensor").default;
 
 /**
  * LoadingImage (Function Component)

--- a/packages/frontend/src/components/common/VisibilitySensor/index.jsx
+++ b/packages/frontend/src/components/common/VisibilitySensor/index.jsx
@@ -1,0 +1,101 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import PropTypes from "prop-types";
+
+/**
+ * 使用 IntersectionObserver 封装的可见性探测组件，替代旧的 react-visibility-sensor。
+ */
+export default function VisibilitySensor({ children, onChange, partialVisibility = false, offset = {} }) {
+  const [node, setNode] = useState(null);
+  const onChangeRef = useRef(onChange);
+  const lastVisibleRef = useRef(undefined);
+
+  const topOffset = typeof offset.top === "number" ? offset.top : 0;
+  const rightOffset = typeof offset.right === "number" ? offset.right : 0;
+  const bottomOffset = typeof offset.bottom === "number" ? offset.bottom : 0;
+  const leftOffset = typeof offset.left === "number" ? offset.left : 0;
+
+  const rootMargin = useMemo(() => {
+    return `${topOffset}px ${rightOffset}px ${bottomOffset}px ${leftOffset}px`;
+  }, [topOffset, rightOffset, bottomOffset, leftOffset]);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    if (!node) {
+      return undefined;
+    }
+
+    if (typeof IntersectionObserver === "undefined") {
+      if (lastVisibleRef.current !== true) {
+        lastVisibleRef.current = true;
+        if (onChangeRef.current) {
+          onChangeRef.current(true);
+        }
+      }
+      return undefined;
+    }
+
+    const thresholds = partialVisibility ? [0, 0.0001, 1] : [1];
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const isVisible = partialVisibility ? entry.isIntersecting : entry.intersectionRatio >= 1;
+          if (lastVisibleRef.current !== isVisible) {
+            lastVisibleRef.current = isVisible;
+            if (onChangeRef.current) {
+              onChangeRef.current(isVisible);
+            }
+          }
+        });
+      },
+      {
+        root: null,
+        rootMargin,
+        threshold: thresholds,
+      }
+    );
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [node, partialVisibility, rootMargin]);
+
+  const child = React.Children.only(children);
+  const childRef = child.ref;
+
+  const attachRef = useCallback(
+    (currentNode) => {
+      setNode(currentNode);
+      if (!childRef) {
+        return;
+      }
+      if (typeof childRef === "function") {
+        childRef(currentNode);
+      } else if (typeof childRef === "object") {
+        childRef.current = currentNode;
+      }
+    },
+    [childRef]
+  );
+
+  return React.cloneElement(child, {
+    ref: attachRef,
+  });
+}
+
+VisibilitySensor.propTypes = {
+  children: PropTypes.element.isRequired,
+  onChange: PropTypes.func,
+  partialVisibility: PropTypes.bool,
+  offset: PropTypes.shape({
+    top: PropTypes.number,
+    right: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+  }),
+};

--- a/packages/frontend/src/pages/BookOverviewPage/index.js
+++ b/packages/frontend/src/pages/BookOverviewPage/index.js
@@ -9,9 +9,8 @@ import '../shared/OneBook.scss';
 import ErrorPage from '@pages/ErrorPage';
 import CenterSpinner from '@components/common/CenterSpinner';
 import FileNameDiv from '@components/common/FileNameDiv';
+import VisibilitySensor from '@components/common/VisibilitySensor';
 // import ReactDOM from 'react-dom';
-
-const VisibilitySensor = require('react-visibility-sensor').default;
 const util = require("@common/util");
 const queryString = require('query-string');
 

--- a/packages/frontend/src/pages/BookWaterfallPage/index.js
+++ b/packages/frontend/src/pages/BookWaterfallPage/index.js
@@ -11,6 +11,7 @@ import '../shared/OneBook.scss';
 import ErrorPage from '@pages/ErrorPage';
 import CenterSpinner from '@components/common/CenterSpinner';
 import FileNameDiv from '@components/common/FileNameDiv';
+import VisibilitySensor from '@components/common/VisibilitySensor';
 
 const util = require("@common/util");
 const queryString = require('query-string');
@@ -18,7 +19,6 @@ import screenfull from 'screenfull';
 
 const clientUtil = require("@utils/clientUtil");
 const { getDir, getBaseName, isMobile, getFileUrl, sortFileNames } = clientUtil;
-const VisibilitySensor = require('react-visibility-sensor').default;
 
 class SmartImage extends Component {
   constructor(props) {


### PR DESCRIPTION
## Summary
- add a locally maintained VisibilitySensor built on IntersectionObserver to replace the outdated react-visibility-sensor package
- update image-heavy components to consume the shared visibility helper
- remove the external react-visibility-sensor dependency from the frontend package metadata

## Testing
- npm test -- --help *(fails: mocha is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d91ac9b9748325833e8cfcab19664a