### PR TITLE
feat: add electron GUI wrapper for backend service

### DIFF
--- a/packages/backend_gui/README.md
+++ b/packages/backend_gui/README.md
@@ -1,0 +1,109 @@
+# ShiguReader Backend GUI
+
+跨平台 Electron 应用，用于可视化地启动、停止和监控现有的 `packages/backend/src/app.js` 服务。提供配置表单、状态监控、日志查看和异常处理，让非技术同学也能轻松操作。应用采用 Electron (主进程) + React/Tailwind (渲染进程) 架构，并支持 `electron-builder` 打包 Windows、macOS 与 Linux 安装包。
+
+## 目录结构
+
+```
+packages/backend_gui/
+├── electron/             # 主进程源码（TypeScript）
+│   ├── config.ts         # 配置读写逻辑（含 .env 默认值）
+│   ├── logWriter.ts      # 日志写入与滚动
+│   ├── main.ts           # Electron 入口、IPC 处理
+│   └── serviceManager.ts # Node 服务生命周期管理
+├── preload.ts            # 预加载脚本，暴露安全 IPC API
+├── renderer/             # React + Tailwind 前端界面
+│   ├── index.html
+│   └── src/
+│       ├── main.tsx
+│       ├── pages/App.tsx # UI 主页面
+│       └── types.ts
+├── scripts/
+│   └── smoke-test.js     # 简易 E2E 冒烟脚本
+├── electron-builder.yml  # 打包配置
+├── package.json          # Electron 应用配置
+└── tsconfig*.json
+```
+
+## 运行步骤
+
+> 推荐使用 Node.js 18+，并确保仓库根目录已安装依赖（`npm install`）。
+
+1. 安装依赖
+
+   ```bash
+   cd packages/backend_gui
+   npm install
+   ```
+
+   安装过程中会自动在 `renderer/` 目录执行一次 `npm install`。
+
+2. 启动开发环境
+
+   ```bash
+   npm run dev
+   ```
+
+   - `renderer` 使用 Vite 在 `http://localhost:5173` 提供热重载。
+   - `electron/main.ts` 通过 `ts-node-dev` 运行，自动重启。
+   - UI 中可立即连接并控制 `packages/backend/src/app.js`。
+
+3. 生产构建
+
+   ```bash
+   npm run build        # 编译主进程 + 渲染进程
+   npm exec electron-builder -- --config electron-builder.yml
+   ```
+
+   生成安装包：
+
+   - Windows：`dist/ShiguReader Backend Console Setup.exe`（NSIS）
+   - macOS：`dist/ShiguReader-Backend-Console.dmg`
+   - Linux：`dist/ShiguReader-Backend-Console.AppImage`
+
+   > 默认图标文件位于 `electron/icons/`，目前提供占位逻辑，可根据品牌要求替换 `app.png` 与 `trayTemplate.png`。
+
+## 功能速览
+
+- **启动前配置**：支持端口、日志级别、崩溃自动重启开关，允许恢复默认。
+- **服务控制**：点击启动/停止；状态灯（绿/黄/灰）；显示 PID、端口、运行时长（hh:mm:ss）。
+- **日志面板**：实时读取 `stdout/stderr`，按级别着色，可过滤关键字、级别，支持清屏与复制全部。
+- **日志落盘**：写入 `userData/logs/YYYY-MM-DD.log`，单文件最大 10 MB，保留 10 个文件。
+- **异常处理**：捕获启动失败（端口占用、权限不足、Node 环境缺失等）并给出解决建议。
+- **端口冲突处理**：检测占用，推荐 +1/+10/+100 可用端口，支持“一键套用并重试”。
+- **健康检查**：后台定时访问 `/health`，UI 徽章同步健康/异常状态。
+- **崩溃自动重启**：可选开关，最多尝试三次并在日志中提醒。
+- **系统托盘**：托盘菜单支持打开主窗、启动/停止服务以及退出。
+
+## 与现有后端联动
+
+- 默认假设后端入口位于仓库 `packages/backend/src/app.js`，并且导出标准 Express 服务。
+- 若后端依赖 `.env`，将其放在 `packages/backend/.env`，GUI 会读取其中的 `PORT`、`LOG_LEVEL` 作为初始值。
+- 可在 UI 中修改端口、日志等级，最终以 GUI 配置为准（写入 Electron `userData/config.json`）。
+
+## 常见问题排查
+
+| 现象 | 可能原因 | 建议处理 |
+| ---- | -------- | -------- |
+| 启动失败并提示 `ENOENT` | 系统缺少 Node.js 或 `backend` 路径错误 | 安装 Node.js 18+，确认 `packages/backend/src/app.js` 存在 |
+| 端口占用 | 其他程序占用相同端口 | 通过提示按钮一键切换推荐端口后重试 |
+| 日志为空 | 后端未输出或被过滤 | 确认日志级别、关键字过滤是否正确 |
+| 健康状态持续异常 | `/health` 接口异常或网络被拦截 | 直接访问 `http://127.0.0.1:PORT/health` 检查返回 |
+| 自动重启超过 3 次仍失败 | 后端代码异常 | 关闭自动重启，查看日志定位问题 |
+
+## 冒烟测试脚本
+
+`scripts/smoke-test.js` 用于验证“启动 → 健康检查 → 停止”流程：
+
+```bash
+cd packages/backend_gui
+node scripts/smoke-test.js
+```
+
+脚本会在端口 `3100` 启动后端，访问 `/health`，最后发送 `SIGINT` 并在 5 秒内强制退出。
+
+## 下一步
+
+- 替换品牌化图标、应用名称。
+- 根据需要扩展更多配置项（例如数据目录、代理设置）。
+- 可引入自动更新（如 Squirrel / electron-updater）以提升发版体验。

--- a/packages/backend_gui/electron-builder.yml
+++ b/packages/backend_gui/electron-builder.yml
@@ -1,0 +1,31 @@
+appId: com.shigureader.backend
+productName: ShiguReader Backend Console
+copyright: Copyright © 2024 ShiguReader
+files:
+  - dist/main/**/*
+  - dist/renderer/**/*
+  - dist/backend/**/*
+  - package.json
+  - dist/main/preload.js
+directories:
+  buildResources: build
+extraMetadata:
+  main: dist/main/electron/main.js
+asar: true
+mac:
+  target:
+    - dmg
+  category: public.app-category.utilities
+win:
+  target:
+    - target: nsis
+      arch:
+        - x64
+nsis:
+  oneClick: false
+  allowToChangeInstallationDirectory: true
+linux:
+  target:
+    - AppImage
+  category: Utility
+publish: null

--- a/packages/backend_gui/electron/config.ts
+++ b/packages/backend_gui/electron/config.ts
@@ -1,0 +1,79 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { app } from 'electron';
+import dotenv from 'dotenv';
+
+export type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+export interface BackendConfig {
+  port: number;
+  logLevel: LogLevel;
+  autoRestart: boolean;
+}
+
+const DEFAULT_CONFIG: BackendConfig = {
+  port: 3000,
+  logLevel: 'info',
+  autoRestart: true
+};
+
+const CONFIG_FILE = 'config.json';
+
+export async function loadConfig(): Promise<BackendConfig> {
+  const dir = app.getPath('userData');
+  const filePath = path.join(dir, CONFIG_FILE);
+
+  if (!(await fs.pathExists(dir))) {
+    await fs.mkdirp(dir);
+  }
+
+  if (await fs.pathExists(filePath)) {
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(content);
+      return normalizeConfig(parsed);
+    } catch (err) {
+      console.warn('[config] Failed to read persisted config, falling back to defaults', err);
+    }
+  }
+
+  const envPath = path.join(process.cwd(), '..', 'backend', '.env');
+  let envDefaults: Partial<BackendConfig> = {};
+  if (await fs.pathExists(envPath)) {
+    const env = dotenv.parse(await fs.readFile(envPath));
+    envDefaults = {
+      port: env.PORT ? Number(env.PORT) : undefined,
+      logLevel: env.LOG_LEVEL as LogLevel | undefined
+    } as Partial<BackendConfig>;
+  }
+
+  return { ...DEFAULT_CONFIG, ...cleanUndefined(envDefaults) };
+}
+
+export async function saveConfig(cfg: BackendConfig): Promise<void> {
+  const dir = app.getPath('userData');
+  await fs.mkdirp(dir);
+  const data = JSON.stringify(normalizeConfig(cfg), null, 2);
+  await fs.writeFile(path.join(dir, CONFIG_FILE), data, 'utf-8');
+}
+
+export function restoreDefaults(): BackendConfig {
+  return { ...DEFAULT_CONFIG };
+}
+
+function cleanUndefined<T extends Record<string, any>>(input: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined)
+  );
+}
+
+function normalizeConfig(raw: any): BackendConfig {
+  const normalized: BackendConfig = {
+    port: Number(raw.port) || DEFAULT_CONFIG.port,
+    logLevel: ['info', 'warn', 'error', 'debug'].includes(raw.logLevel)
+      ? raw.logLevel
+      : DEFAULT_CONFIG.logLevel,
+    autoRestart: typeof raw.autoRestart === 'boolean' ? raw.autoRestart : DEFAULT_CONFIG.autoRestart
+  };
+  return normalized;
+}

--- a/packages/backend_gui/electron/logWriter.ts
+++ b/packages/backend_gui/electron/logWriter.ts
@@ -1,0 +1,95 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { app } from 'electron';
+
+export type LogEntryLevel = 'info' | 'warn' | 'error' | 'debug';
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogEntryLevel;
+  message: string;
+  source: 'stdout' | 'stderr' | 'system';
+}
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_FILES = 10;
+
+export class LogWriter {
+  private currentDate = '';
+  private stream: fs.WriteStream | null = null;
+
+  async append(entry: LogEntry) {
+    const date = entry.timestamp.slice(0, 10);
+    if (date !== this.currentDate) {
+      await this.rotate(date);
+    } else if (this.stream && (await this.getSize(this.stream.path as string)) > MAX_FILE_SIZE) {
+      await this.rotate(date, true);
+    }
+
+    if (!this.stream) {
+      await this.rotate(date);
+    }
+
+    this.stream!.write(`${entry.timestamp} [${entry.level.toUpperCase()}] (${entry.source}) ${entry.message}\n`);
+  }
+
+  async dispose() {
+    await this.closeStream();
+  }
+
+  private async rotate(date: string, increment = false) {
+    await this.closeStream();
+    this.currentDate = date;
+    const logDir = path.join(app.getPath('userData'), 'logs');
+    await fs.mkdirp(logDir);
+    const baseName = `${date}.log`;
+
+    let filePath = path.join(logDir, baseName);
+    if (increment) {
+      let idx = 1;
+      while (await fs.pathExists(filePath) && (await this.getSize(filePath)) > MAX_FILE_SIZE) {
+        idx += 1;
+        filePath = path.join(logDir, `${date}-${idx}.log`);
+      }
+    }
+
+    this.stream = fs.createWriteStream(filePath, { flags: 'a' });
+    await this.enforceRetention(logDir);
+  }
+
+  private async enforceRetention(dir: string) {
+    const files = (await fs.readdir(dir))
+      .filter((f) => f.endsWith('.log'))
+      .map((f) => ({
+        file: f,
+        fullPath: path.join(dir, f)
+      }));
+
+    files.sort((a, b) => (a.file > b.file ? -1 : 1));
+    while (files.length > MAX_FILES) {
+      const removed = files.pop();
+      if (removed) {
+        await fs.remove(removed.fullPath);
+      }
+    }
+  }
+
+  private async closeStream() {
+    if (this.stream) {
+      await new Promise((resolve) => {
+        this.stream!.once('finish', resolve);
+        this.stream!.end();
+      });
+      this.stream = null;
+    }
+  }
+
+  private async getSize(filePath: string) {
+    try {
+      const stat = await fs.stat(filePath);
+      return stat.size;
+    } catch {
+      return 0;
+    }
+  }
+}

--- a/packages/backend_gui/electron/main.ts
+++ b/packages/backend_gui/electron/main.ts
@@ -6,7 +6,7 @@ import { LogEntry } from './logWriter';
 import fs from 'fs';
 import net from 'net';
 
-const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
+const isDev = process.env.NODE_ENV === 'development' || !(app?.isPackaged);
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 

--- a/packages/backend_gui/electron/main.ts
+++ b/packages/backend_gui/electron/main.ts
@@ -1,0 +1,316 @@
+import path from 'path';
+import { app, BrowserWindow, ipcMain, dialog, Tray, Menu, nativeImage } from 'electron';
+import { loadConfig, saveConfig, restoreDefaults, BackendConfig } from './config';
+import { ServiceManager, ServiceStatus } from './serviceManager';
+import { LogEntry } from './logWriter';
+import fs from 'fs';
+import net from 'net';
+
+const isDev = process.env.NODE_ENV === 'development';
+let mainWindow: BrowserWindow | null = null;
+let tray: Tray | null = null;
+
+const backendRoot = resolveBackendRoot();
+const serviceManager = new ServiceManager(backendRoot);
+let currentConfig: BackendConfig;
+let healthState: 'unknown' | 'healthy' | 'unhealthy' = 'unknown';
+let healthTimer: NodeJS.Timeout | null = null;
+
+function resolveBackendRoot() {
+  if (isDev) {
+    return path.resolve(__dirname, '..', '..', 'backend');
+  }
+  return path.join(process.resourcesPath, 'backend');
+}
+
+async function createWindow() {
+  currentConfig = await loadConfig();
+
+  mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    title: 'ShiguReader Backend 控制台',
+    webPreferences: {
+      contextIsolation: true,
+      preload: path.join(__dirname, '..', 'preload.js'),
+      nodeIntegration: false
+    }
+  });
+
+  if (isDev) {
+    await mainWindow.loadURL('http://localhost:5173');
+    mainWindow.webContents.openDevTools({ mode: 'detach' });
+  } else {
+    const indexPath = path.join(__dirname, '..', 'renderer', 'index.html');
+    await mainWindow.loadFile(indexPath);
+  }
+
+  buildTray();
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+
+  setupListeners();
+  broadcastStatus(serviceManager.getStatus());
+}
+
+function setupListeners() {
+  ipcMain.handle('config:get', async () => currentConfig);
+
+  ipcMain.handle('config:set', async (_event, cfg: BackendConfig) => {
+    currentConfig = cfg;
+    await saveConfig(cfg);
+    return currentConfig;
+  });
+
+  ipcMain.handle('config:restore', async () => {
+    currentConfig = restoreDefaults();
+    await saveConfig(currentConfig);
+    return currentConfig;
+  });
+
+  ipcMain.handle('service:start', async (event, args?: { autoPort?: boolean }) => {
+    const status = serviceManager.getStatus();
+    if (status.state === 'running' || status.state === 'starting') {
+      return status;
+    }
+
+    const portCheck = await ensurePortAvailable(currentConfig.port);
+    if (!portCheck.available) {
+      event.sender.send('service:port-conflict', portCheck);
+      throw new Error(`端口 ${currentConfig.port} 已被占用。`);
+    }
+
+    await serviceManager.start({ config: currentConfig });
+    startHealthChecks();
+    return serviceManager.getStatus();
+  });
+
+  ipcMain.handle('service:stop', async () => {
+    await serviceManager.stop();
+    stopHealthChecks();
+    return serviceManager.getStatus();
+  });
+
+  ipcMain.handle('service:status', async () => serviceManager.getStatus());
+
+  ipcMain.handle('service:auto-port', async () => {
+    const suggestions = await suggestPorts(currentConfig.port);
+    return suggestions;
+  });
+
+  ipcMain.on('logs:subscribe', (event) => {
+    const webContents = event.sender;
+    const logListener = (entry: LogEntry) => {
+      if (!webContents.isDestroyed()) {
+        webContents.send('logs:push', entry);
+      }
+    };
+    const statusListener = (status: ServiceStatus) => {
+      if (!webContents.isDestroyed()) {
+        webContents.send('service:status-updated', status);
+      }
+    };
+    const errorListener = (error: any) => {
+      if (!webContents.isDestroyed()) {
+        webContents.send('service:error', error);
+      }
+    };
+
+    serviceManager.on('log', logListener);
+    serviceManager.on('status', statusListener);
+    serviceManager.on('error', errorListener);
+
+    webContents.once('destroyed', () => {
+      serviceManager.off('log', logListener);
+      serviceManager.off('status', statusListener);
+      serviceManager.off('error', errorListener);
+    });
+  });
+
+  serviceManager.on('status', (status) => {
+    broadcastStatus(status);
+  });
+
+  serviceManager.on('error', (error) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('service:error', error);
+    }
+  });
+
+  serviceManager.on('log', (entry) => {
+    if (entry.message.includes('EADDRINUSE')) {
+      mainWindow?.webContents.send('service:port-conflict', {
+        port: currentConfig.port,
+        available: false
+      });
+    }
+  });
+}
+
+function startHealthChecks() {
+  if (healthTimer) return;
+  healthTimer = setInterval(async () => {
+    const status = serviceManager.getStatus();
+    if (status.state !== 'running' || !status.port) {
+      setHealthState('unknown');
+      return;
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${status.port}/health`, {
+        method: 'GET',
+        cache: 'no-store'
+      });
+      if (response.ok) {
+        setHealthState('healthy');
+      } else {
+        setHealthState('unhealthy');
+      }
+    } catch (err) {
+      setHealthState('unhealthy');
+    }
+  }, 5000);
+}
+
+function stopHealthChecks() {
+  if (healthTimer) {
+    clearInterval(healthTimer);
+    healthTimer = null;
+  }
+  setHealthState('unknown');
+}
+
+function setHealthState(state: typeof healthState) {
+  healthState = state;
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('service:health', state);
+  }
+  updateTray(state);
+}
+
+function broadcastStatus(status: ServiceStatus) {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('service:status-updated', status);
+  }
+  updateTray(healthState, status);
+}
+
+function buildTray() {
+  if (tray) return;
+    const trayIconPath = path.join(__dirname, 'icons', 'trayTemplate.png');
+  const icon = fs.existsSync(trayIconPath) ? nativeImage.createFromPath(trayIconPath) : nativeImage.createEmpty();
+  tray = new Tray(icon);
+  tray.setToolTip('ShiguReader Backend');
+  tray.on('double-click', () => {
+    if (!mainWindow) {
+      void createWindow();
+      return;
+    }
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore();
+    }
+    mainWindow.focus();
+  });
+  updateTray('unknown');
+}
+
+function updateTray(state: typeof healthState, status?: ServiceStatus) {
+  if (!tray) return;
+  const statusLabel = status?.state === 'running' ? '运行中' : status?.state === 'starting' ? '启动中' : '已停止';
+  tray.setToolTip(`ShiguReader Backend\n状态: ${statusLabel}\n健康: ${state}`);
+  tray.setContextMenu(
+    Menu.buildFromTemplate([
+      {
+        label: '打开控制台',
+        click: () => {
+          if (mainWindow) {
+            if (mainWindow.isMinimized()) mainWindow.restore();
+            mainWindow.focus();
+          } else {
+            void createWindow();
+          }
+        }
+      },
+      { type: 'separator' },
+      {
+        label: status?.state === 'running' ? '停止服务' : '启动服务',
+        click: () => {
+          if (status?.state === 'running') {
+            void serviceManager.stop();
+          } else {
+            void serviceManager.start({ config: currentConfig });
+          }
+        }
+      },
+      { type: 'separator' },
+      {
+        label: '退出',
+        click: () => {
+          stopHealthChecks();
+          app.quit();
+        }
+      }
+    ])
+  );
+}
+
+async function ensurePortAvailable(port: number) {
+  const available = await checkPort(port);
+  if (available) {
+    return { available: true, port };
+  }
+  return { available: false, port, suggestions: await suggestPorts(port) };
+}
+
+async function checkPort(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const tester = net
+      .createServer()
+      .once('error', () => resolve(false))
+      .once('listening', () => tester.close(() => resolve(true)))
+      .listen(port, '0.0.0.0');
+  });
+}
+
+async function suggestPorts(port: number) {
+  const candidates = [port + 1, port + 10, port + 100];
+  const available: number[] = [];
+  for (const candidate of candidates) {
+    if (await checkPort(candidate)) {
+      available.push(candidate);
+    }
+  }
+  return available;
+}
+
+app.whenReady().then(async () => {
+  await createWindow();
+  if (process.platform === 'darwin') {
+    const iconPath = path.join(__dirname, 'icons', 'app.png');
+    if (fs.existsSync(iconPath)) {
+      app.dock.setIcon(iconPath);
+    }
+  }
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      void createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    stopHealthChecks();
+    app.quit();
+  }
+});
+
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught error', error);
+  dialog.showErrorBox('应用异常', error.message);
+});
+
+process.on('unhandledRejection', (reason: any) => {
+  console.error('Unhandled rejection', reason);
+});

--- a/packages/backend_gui/electron/main.ts
+++ b/packages/backend_gui/electron/main.ts
@@ -6,7 +6,7 @@ import { LogEntry } from './logWriter';
 import fs from 'fs';
 import net from 'net';
 
-const isDev = process.env.NODE_ENV === 'development';
+const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 
@@ -17,10 +17,18 @@ let healthState: 'unknown' | 'healthy' | 'unhealthy' = 'unknown';
 let healthTimer: NodeJS.Timeout | null = null;
 
 function resolveBackendRoot() {
+  if (process.env.BACKEND_ROOT) {
+    return process.env.BACKEND_ROOT;
+  }
   if (isDev) {
     return path.resolve(__dirname, '..', '..', 'backend');
   }
-  return path.join(process.resourcesPath, 'backend');
+  const resourcesPath = process.resourcesPath;
+  if (!resourcesPath) {
+    // 在某些开发或调试场景下，Electron 可能尚未初始化 resourcesPath。
+    return path.resolve(__dirname, '..', '..', 'backend');
+  }
+  return path.join(resourcesPath, 'backend');
 }
 
 async function createWindow() {

--- a/packages/backend_gui/electron/serviceManager.ts
+++ b/packages/backend_gui/electron/serviceManager.ts
@@ -1,0 +1,214 @@
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import path from 'path';
+import EventEmitter from 'eventemitter3';
+import treeKill from 'tree-kill';
+import { BackendConfig } from './config';
+import { LogEntry, LogWriter } from './logWriter';
+
+export type ServiceState = 'stopped' | 'starting' | 'running' | 'stopping';
+
+export interface ServiceStatus {
+  state: ServiceState;
+  pid: number | null;
+  port: number;
+  startedAt: number | null;
+  restartCount: number;
+  exitCode?: number | null;
+  exitSignal?: NodeJS.Signals | null;
+}
+
+export interface ServiceError {
+  title: string;
+  message: string;
+  suggestion?: string;
+}
+
+export interface LogSubscribers {
+  send(log: LogEntry): void;
+}
+
+interface StartOptions {
+  config: BackendConfig;
+}
+
+export declare interface ServiceManager {
+  on(event: 'status', listener: (status: ServiceStatus) => void): this;
+  on(event: 'log', listener: (entry: LogEntry) => void): this;
+  on(event: 'error', listener: (error: ServiceError) => void): this;
+}
+
+export class ServiceManager extends EventEmitter {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private status: ServiceStatus = {
+    state: 'stopped',
+    pid: null,
+    port: 3000,
+    startedAt: null,
+    restartCount: 0
+  };
+  private restartAttempts = 0;
+  private readonly logWriter = new LogWriter();
+  private restartTimer: NodeJS.Timeout | null = null;
+
+  constructor(private readonly backendRoot: string) {
+    super();
+  }
+
+  getStatus() {
+    return this.status;
+  }
+
+  async start(opts: StartOptions) {
+    if (this.child || this.status.state === 'starting') {
+      return;
+    }
+    const { config } = opts;
+
+    this.updateStatus({ state: 'starting', port: config.port, restartCount: this.restartAttempts });
+
+    const backendEntry = path.join(this.backendRoot, 'src', 'app.js');
+    const child = spawn(process.execPath, [backendEntry], {
+      cwd: this.backendRoot,
+      env: {
+        ...process.env,
+        PORT: String(config.port),
+        LOG_LEVEL: config.logLevel,
+        AUTO_RESTART: String(config.autoRestart)
+      }
+    });
+    this.child = child;
+
+    const onLog = (buffer: Buffer, source: 'stdout' | 'stderr') => {
+      const lines = buffer.toString().split(/\r?\n/).filter(Boolean);
+      for (const line of lines) {
+        const entry: LogEntry = parseLogLine(line, source);
+        this.emit('log', entry);
+        void this.logWriter.append(entry);
+      }
+    };
+
+    child.stdout.on('data', (buf) => onLog(buf, 'stdout'));
+    child.stderr.on('data', (buf) => onLog(buf, 'stderr'));
+
+    child.on('spawn', () => {
+      this.updateStatus({
+        state: 'running',
+        pid: child.pid ?? null,
+        startedAt: Date.now(),
+        port: config.port,
+        exitCode: null,
+        exitSignal: null
+      });
+    });
+
+    child.on('error', (error) => {
+      const message = error.message;
+      let suggestion = '请确认已经正确安装 Node.js 并且具有访问 backend 的权限。';
+      if (message.includes('ENOENT')) {
+        suggestion = '请检查 Node.js 是否安装，或路径是否正确。';
+      }
+      this.emit('error', { title: '启动失败', message, suggestion });
+      this.updateStatus({ state: 'stopped', pid: null, startedAt: null });
+      this.child = null;
+    });
+
+    child.on('exit', (code, signal) => {
+      const wasRunning = this.status.state === 'running';
+      this.child = null;
+      this.updateStatus({
+        state: 'stopped',
+        pid: null,
+        startedAt: null,
+        exitCode: code,
+        exitSignal: signal ?? null
+      });
+
+      const autoRestart = opts.config.autoRestart;
+      if (wasRunning && autoRestart && this.restartAttempts < 3) {
+        this.restartAttempts += 1;
+        const entry: LogEntry = {
+          level: 'warn',
+          message: `服务异常退出 (code: ${code ?? 'null'}, signal: ${signal ?? 'null'})，将在 3 秒后尝试第 ${this.restartAttempts} 次重启。`,
+          source: 'system',
+          timestamp: new Date().toISOString()
+        };
+        this.emit('log', entry);
+        void this.logWriter.append(entry);
+        this.restartTimer = setTimeout(() => {
+          this.start(opts).catch((err) => {
+            this.emit('error', {
+              title: '自动重启失败',
+              message: err.message,
+              suggestion: '请手动重新启动服务。'
+            });
+          });
+        }, 3000);
+      } else if (wasRunning && !autoRestart) {
+        const entry: LogEntry = {
+          level: 'info',
+          message: '服务已停止。',
+          source: 'system',
+          timestamp: new Date().toISOString()
+        };
+        this.emit('log', entry);
+        void this.logWriter.append(entry);
+      }
+    });
+  }
+
+  async stop() {
+    if (!this.child) {
+      return;
+    }
+    this.restartAttempts = 0;
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+    const child = this.child;
+    this.updateStatus({ state: 'stopping' });
+
+    const killTimeout = setTimeout(() => {
+      if (child.pid) {
+        treeKill(child.pid, 'SIGKILL');
+      }
+    }, 5000);
+
+    await new Promise<void>((resolve) => {
+      child.once('exit', () => {
+        clearTimeout(killTimeout);
+        resolve();
+      });
+      child.kill('SIGINT');
+    });
+  }
+
+  override removeAllListeners(): this {
+    this.logWriter.dispose().catch(() => undefined);
+    return super.removeAllListeners();
+  }
+
+  private updateStatus(partial: Partial<ServiceStatus>) {
+    this.status = { ...this.status, ...partial };
+    this.emit('status', this.status);
+  }
+}
+
+function parseLogLine(line: string, source: 'stdout' | 'stderr'): LogEntry {
+  const level = detectLevel(line, source);
+  return {
+    level,
+    message: line,
+    source,
+    timestamp: new Date().toISOString()
+  };
+}
+
+function detectLevel(message: string, source: 'stdout' | 'stderr'): LogEntry['level'] {
+  if (source === 'stderr') return 'error';
+  const lowered = message.toLowerCase();
+  if (lowered.includes('error')) return 'error';
+  if (lowered.includes('warn')) return 'warn';
+  if (lowered.includes('debug')) return 'debug';
+  return 'info';
+}

--- a/packages/backend_gui/package.json
+++ b/packages/backend_gui/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "backend-gui",
+  "version": "0.1.0",
+  "description": "Electron GUI wrapper for ShiguReader backend",
+  "main": "dist/main/electron/main.js",
+  "author": "ShiguReader Contributors",
+  "license": "MIT",
+  "scripts": {
+    "dev": "run-p dev:renderer dev:main",
+    "dev:renderer": "cd renderer && vite",
+    "dev:main": "ts-node-dev --respawn --transpile-only --project tsconfig.main.json electron/main.ts",
+    "build": "run-s clean build:renderer build:main copy:backend",
+    "build:renderer": "cd renderer && vite build",
+    "build:main": "tsc -p tsconfig.main.json",
+    "lint": "eslint --ext .ts,.tsx electron renderer/src",
+    "typecheck": "tsc --noEmit -p tsconfig.main.json && tsc --noEmit -p renderer/tsconfig.json",
+    "postinstall": "cd renderer && npm install",
+    "copy:backend": "node scripts/copy-backend.cjs",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@electron/remote": "^2.1.2",
+    "eventemitter3": "^5.0.1",
+    "fs-extra": "^11.2.0",
+    "dotenv": "^16.3.1",
+    "tree-kill": "^1.2.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.19",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@typescript-eslint/eslint-plugin": "^6.14.0",
+    "@typescript-eslint/parser": "^6.14.0",
+    "autoprefixer": "^10.4.16",
+    "concurrently": "^8.2.2",
+    "electron": "^28.2.3",
+    "electron-builder": "^24.6.4",
+    "eslint": "^8.55.0",
+    "eslint-plugin-react": "^7.33.2",
+    "npm-run-all": "^4.1.5",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.6",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.7",
+    "rimraf": "^5.0.5"
+  }
+}

--- a/packages/backend_gui/preload.ts
+++ b/packages/backend_gui/preload.ts
@@ -1,0 +1,89 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import type { BackendConfig } from './electron/config';
+import type { ServiceStatus } from './electron/serviceManager';
+import type { LogEntry } from './electron/logWriter';
+
+type HealthState = 'unknown' | 'healthy' | 'unhealthy';
+
+declare global {
+  interface Window {
+    backend: {
+      getConfig(): Promise<BackendConfig>;
+      setConfig(config: BackendConfig): Promise<BackendConfig>;
+      restoreDefaults(): Promise<BackendConfig>;
+      startService(): Promise<ServiceStatus>;
+      stopService(): Promise<ServiceStatus>;
+      getStatus(): Promise<ServiceStatus>;
+      getPortSuggestions(): Promise<number[]>;
+      onLog(callback: (entry: LogEntry) => void): () => void;
+      onStatus(callback: (status: ServiceStatus) => void): () => void;
+      onError(callback: (error: any) => void): () => void;
+      onHealth(callback: (state: HealthState) => void): () => void;
+      onPortConflict(callback: (payload: { port: number; suggestions?: number[] }) => void): () => void;
+    };
+  }
+}
+
+const listeners: Array<() => void> = [];
+
+contextBridge.exposeInMainWorld('backend', {
+  async getConfig() {
+    return ipcRenderer.invoke('config:get');
+  },
+  async setConfig(config: BackendConfig) {
+    return ipcRenderer.invoke('config:set', config);
+  },
+  async restoreDefaults() {
+    return ipcRenderer.invoke('config:restore');
+  },
+  async startService() {
+    return ipcRenderer.invoke('service:start');
+  },
+  async stopService() {
+    return ipcRenderer.invoke('service:stop');
+  },
+  async getStatus() {
+    return ipcRenderer.invoke('service:status');
+  },
+  async getPortSuggestions() {
+    return ipcRenderer.invoke('service:auto-port');
+  },
+  onLog(callback: (entry: LogEntry) => void) {
+    ipcRenderer.send('logs:subscribe');
+    ipcRenderer.on('logs:push', (_event, entry: LogEntry) => callback(entry));
+    const remove = () => ipcRenderer.removeAllListeners('logs:push');
+    listeners.push(remove);
+    return remove;
+  },
+  onStatus(callback: (status: ServiceStatus) => void) {
+    ipcRenderer.on('service:status-updated', (_event, status: ServiceStatus) => callback(status));
+    const remove = () => ipcRenderer.removeAllListeners('service:status-updated');
+    listeners.push(remove);
+    return remove;
+  },
+  onError(callback: (error: any) => void) {
+    ipcRenderer.on('service:error', (_event, error: any) => callback(error));
+    const remove = () => ipcRenderer.removeAllListeners('service:error');
+    listeners.push(remove);
+    return remove;
+  },
+  onHealth(callback: (state: HealthState) => void) {
+    ipcRenderer.on('service:health', (_event, state: HealthState) => callback(state));
+    const remove = () => ipcRenderer.removeAllListeners('service:health');
+    listeners.push(remove);
+    return remove;
+  },
+  onPortConflict(callback: (payload: { port: number; suggestions?: number[] }) => void) {
+    ipcRenderer.on('service:port-conflict', (_event, payload) => callback(payload));
+    const remove = () => ipcRenderer.removeAllListeners('service:port-conflict');
+    listeners.push(remove);
+    return remove;
+  }
+});
+
+globalThis.addEventListener('unload', () => {
+  for (const remove of listeners) {
+    remove();
+  }
+  listeners.length = 0;
+});

--- a/packages/backend_gui/renderer/index.html
+++ b/packages/backend_gui/renderer/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ShiguReader Backend Console</title>
+  </head>
+  <body class="bg-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/backend_gui/renderer/package.json
+++ b/packages/backend_gui/renderer/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "backend-gui-renderer",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.18",
+    "@heroicons/react": "^2.0.18",
+    "classnames": "^2.5.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "tailwindcss": "^3.3.6",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.7"
+  }
+}

--- a/packages/backend_gui/renderer/postcss.config.cjs
+++ b/packages/backend_gui/renderer/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/packages/backend_gui/renderer/src/global.d.ts
+++ b/packages/backend_gui/renderer/src/global.d.ts
@@ -1,0 +1,22 @@
+import type { BackendConfig, HealthState, LogEntry, ServiceStatus } from './types';
+
+declare global {
+  interface Window {
+    backend: {
+      getConfig(): Promise<BackendConfig>;
+      setConfig(config: BackendConfig): Promise<BackendConfig>;
+      restoreDefaults(): Promise<BackendConfig>;
+      startService(): Promise<ServiceStatus>;
+      stopService(): Promise<ServiceStatus>;
+      getStatus(): Promise<ServiceStatus>;
+      getPortSuggestions(): Promise<number[]>;
+      onLog(callback: (entry: LogEntry) => void): () => void;
+      onStatus(callback: (status: ServiceStatus) => void): () => void;
+      onError(callback: (error: any) => void): () => void;
+      onHealth(callback: (state: HealthState) => void): () => void;
+      onPortConflict(callback: (payload: { port: number; suggestions?: number[] }) => void): () => void;
+    };
+  }
+}
+
+export {};

--- a/packages/backend_gui/renderer/src/index.css
+++ b/packages/backend_gui/renderer/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply font-sans text-slate-900;
+}

--- a/packages/backend_gui/renderer/src/main.tsx
+++ b/packages/backend_gui/renderer/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './pages/App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/packages/backend_gui/renderer/src/pages/App.tsx
+++ b/packages/backend_gui/renderer/src/pages/App.tsx
@@ -1,0 +1,397 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { BackendConfig, HealthState, LogEntry, LogLevel, ServiceStatus } from '../types';
+import { PlayIcon, StopIcon, ExclamationTriangleIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import classNames from 'classnames';
+
+const levelLabels: Record<LogLevel, string> = {
+  info: '信息',
+  warn: '警告',
+  error: '错误',
+  debug: '调试'
+};
+
+const levelColors: Record<LogLevel, string> = {
+  info: 'text-slate-200',
+  warn: 'text-amber-300',
+  error: 'text-rose-300',
+  debug: 'text-slate-400'
+};
+
+const healthLabels: Record<HealthState, { label: string; className: string }> = {
+  healthy: { label: '健康', className: 'bg-emerald-100 text-emerald-700 border border-emerald-200' },
+  unhealthy: { label: '异常', className: 'bg-rose-100 text-rose-700 border border-rose-200' },
+  unknown: { label: '未知', className: 'bg-slate-100 text-slate-500 border border-slate-200' }
+};
+
+const DEFAULT_CONFIG: BackendConfig = {
+  port: 3000,
+  logLevel: 'info',
+  autoRestart: true
+};
+
+type PortConflictPayload = { port: number; suggestions?: number[] };
+
+const App: React.FC = () => {
+  const [config, setConfig] = useState<BackendConfig>(DEFAULT_CONFIG);
+  const [status, setStatus] = useState<ServiceStatus | null>(null);
+  const [health, setHealth] = useState<HealthState>('unknown');
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [selectedLevels, setSelectedLevels] = useState<LogLevel[]>(['info', 'warn', 'error', 'debug']);
+  const [keyword, setKeyword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [portConflict, setPortConflict] = useState<PortConflictPayload | null>(null);
+
+  useEffect(() => {
+    window.backend.getConfig().then(setConfig);
+    window.backend.getStatus().then(setStatus);
+
+    const unsubLog = window.backend.onLog((entry) => {
+      setLogs((prev) => [...prev.slice(-999), entry]);
+    });
+    const unsubStatus = window.backend.onStatus((newStatus) => {
+      setStatus(newStatus);
+      if (newStatus.state === 'stopped') {
+        setLoading(false);
+      }
+    });
+    const unsubError = window.backend.onError((payload) => {
+      setError(`${payload.title}: ${payload.message}\n${payload.suggestion ?? ''}`);
+      setLoading(false);
+    });
+    const unsubHealth = window.backend.onHealth((state) => setHealth(state));
+    const unsubPortConflict = window.backend.onPortConflict((payload) => {
+      setPortConflict(payload);
+      setLoading(false);
+    });
+
+    return () => {
+      unsubLog();
+      unsubStatus();
+      unsubError();
+      unsubHealth();
+      unsubPortConflict();
+    };
+  }, []);
+
+  const handleStart = async () => {
+    setError(null);
+    setPortConflict(null);
+    setLoading(true);
+    try {
+      const newStatus = await window.backend.startService();
+      setStatus(newStatus);
+    } catch (err: any) {
+      setError(err.message ?? '服务启动失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleStop = async () => {
+    setLoading(true);
+    try {
+      const newStatus = await window.backend.stopService();
+      setStatus(newStatus);
+    } catch (err: any) {
+      setError(err.message ?? '停止失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfigChange = (partial: Partial<BackendConfig>) => {
+    setConfig((prev) => ({ ...prev, ...partial }));
+  };
+
+  const handleSave = async () => {
+    await window.backend.setConfig(config);
+    setError(null);
+  };
+
+  const handleRestore = async () => {
+    const restored = await window.backend.restoreDefaults();
+    setConfig(restored);
+  };
+
+  const handleApplySuggestion = async (port: number) => {
+    const newConfig = { ...config, port };
+    setConfig(newConfig);
+    await window.backend.setConfig(newConfig);
+    setPortConflict(null);
+  };
+
+  const filteredLogs = useMemo(() => {
+    const normalizedKeyword = keyword.trim().toLowerCase();
+    return logs.filter((entry) => {
+      if (!selectedLevels.includes(entry.level)) return false;
+      if (!normalizedKeyword) return true;
+      return entry.message.toLowerCase().includes(normalizedKeyword);
+    });
+  }, [logs, keyword, selectedLevels]);
+
+  const handleCopyLogs = async () => {
+    try {
+      await navigator.clipboard.writeText(
+        filteredLogs
+          .map((log) => `${log.timestamp} [${log.level.toUpperCase()}] ${log.message}`)
+          .join('\n')
+      );
+    } catch (err) {
+      setError('复制失败，请确认系统权限。');
+    }
+  };
+
+  const runningDuration = useMemo(() => {
+    if (!status?.startedAt || status.state !== 'running') return '00:00:00';
+    const diff = Date.now() - status.startedAt;
+    const hours = Math.floor(diff / 3600000);
+    const minutes = Math.floor((diff % 3600000) / 60000);
+    const seconds = Math.floor((diff % 60000) / 1000);
+    return [hours, minutes, seconds]
+      .map((value) => value.toString().padStart(2, '0'))
+      .join(':');
+  }, [status?.startedAt, status?.state]);
+
+  const isRunning = status?.state === 'running';
+  const isStarting = status?.state === 'starting';
+
+  return (
+    <div className="min-h-screen flex flex-col gap-4 p-6 text-slate-800">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-primary-dark">ShiguReader 服务控制台</h1>
+          <p className="text-sm text-slate-500">可视化管理后台服务，适合非技术用户快速操作。</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <StatusDot state={status?.state ?? 'stopped'} />
+          <HealthBadge state={health} />
+        </div>
+      </header>
+
+      <main className="grid grid-cols-1 xl:grid-cols-3 gap-4 flex-1">
+        <section className="col-span-1 bg-white shadow rounded-lg p-4 flex flex-col gap-4">
+          <h2 className="text-lg font-medium">启动配置</h2>
+          <label className="flex flex-col gap-2">
+            <span className="text-sm text-slate-500">服务端口</span>
+            <input
+              type="number"
+              className="rounded border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+              value={config.port}
+              min={1}
+              max={65535}
+              onChange={(event) => handleConfigChange({ port: Number(event.target.value) })}
+            />
+          </label>
+          <label className="flex flex-col gap-2">
+            <span className="text-sm text-slate-500">日志级别</span>
+            <select
+              className="rounded border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+              value={config.logLevel}
+              onChange={(event) => handleConfigChange({ logLevel: event.target.value as LogLevel })}
+            >
+              {(['info', 'warn', 'error', 'debug'] as LogLevel[]).map((level) => (
+                <option key={level} value={level}>
+                  {levelLabels[level]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="inline-flex items-center gap-2 text-sm text-slate-600">
+            <input
+              type="checkbox"
+              checked={config.autoRestart}
+              onChange={(event) => handleConfigChange({ autoRestart: event.target.checked })}
+            />
+            崩溃自动重启（最多 3 次）
+          </label>
+          <div className="flex gap-2 mt-auto">
+            <button
+              className="px-4 py-2 rounded border border-slate-200 text-slate-600 hover:bg-slate-100"
+              onClick={handleRestore}
+            >
+              恢复默认
+            </button>
+            <button
+              className="px-4 py-2 rounded bg-primary text-white hover:bg-primary-dark"
+              onClick={handleSave}
+            >
+              保存配置
+            </button>
+          </div>
+        </section>
+
+        <section className="col-span-1 xl:col-span-2 bg-white shadow rounded-lg p-4 flex flex-col gap-4">
+          <h2 className="text-lg font-medium">服务控制</h2>
+          {error && (
+            <div className="rounded border border-rose-200 bg-rose-50 p-3 text-rose-700 text-sm flex items-start gap-2">
+              <ExclamationTriangleIcon className="h-5 w-5 mt-0.5" />
+              <div>
+                <strong className="block">{error.split('\n')[0]}</strong>
+                <p>{error.split('\n').slice(1).join('\n')}</p>
+              </div>
+            </div>
+          )}
+          {portConflict && (
+            <div className="rounded border border-amber-200 bg-amber-50 p-3 text-amber-700 text-sm">
+              <p>端口 {portConflict.port} 已被占用。请选择以下可用端口并重试：</p>
+              <div className="flex gap-2 mt-2 flex-wrap">
+                {(portConflict.suggestions ?? []).map((port) => (
+                  <button
+                    key={port}
+                    className="px-3 py-1 rounded bg-amber-100 hover:bg-amber-200"
+                    onClick={() => handleApplySuggestion(port)}
+                  >
+                    {port}
+                  </button>
+                ))}
+                <button
+                  className="px-3 py-1 rounded border border-amber-300 hover:bg-amber-100"
+                  onClick={async () => {
+                    const suggestions = await window.backend.getPortSuggestions();
+                    setPortConflict({ port: config.port, suggestions });
+                  }}
+                >
+                  重新推荐
+                </button>
+              </div>
+            </div>
+          )}
+          <div className="grid grid-cols-2 gap-4">
+            <InfoCard label="当前状态" value={translateState(status?.state ?? 'stopped')} />
+            <InfoCard label="运行时间" value={runningDuration} />
+            <InfoCard label="监听端口" value={String(status?.port ?? config.port)} />
+            <InfoCard label="进程 PID" value={status?.pid ? String(status.pid) : '—'} />
+          </div>
+          <div className="flex gap-2">
+            <button
+              className={classNames(
+                'flex items-center gap-2 px-4 py-2 rounded text-white transition',
+                (isRunning || isStarting || loading) ? 'bg-slate-400 cursor-not-allowed' : 'bg-emerald-500 hover:bg-emerald-600'
+              )}
+              disabled={isRunning || isStarting || loading}
+              onClick={handleStart}
+            >
+              <PlayIcon className="w-5 h-5" />
+              启动服务
+            </button>
+            <button
+              className={classNames(
+                'flex items-center gap-2 px-4 py-2 rounded text-white transition',
+                !isRunning ? 'bg-slate-400 cursor-not-allowed' : 'bg-rose-500 hover:bg-rose-600'
+              )}
+              disabled={!isRunning}
+              onClick={handleStop}
+            >
+              <StopIcon className="w-5 h-5" />
+              停止服务
+            </button>
+          </div>
+        </section>
+      </main>
+
+      <section className="bg-white shadow rounded-lg p-4 flex flex-col gap-4 h-[40vh]">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-medium flex items-center gap-2">
+            <InformationCircleIcon className="w-5 h-5" />
+            实时日志
+          </h2>
+          <div className="flex items-center gap-2">
+            <input
+              type="search"
+              placeholder="按关键字过滤"
+              className="rounded border border-slate-200 px-3 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+              value={keyword}
+              onChange={(event) => setKeyword(event.target.value)}
+            />
+            <div className="flex gap-1">
+              {(Object.keys(levelLabels) as LogLevel[]).map((level) => (
+                <button
+                  key={level}
+                  className={classNames(
+                    'px-2 py-1 rounded border text-xs',
+                    selectedLevels.includes(level)
+                      ? 'bg-primary text-white border-primary'
+                      : 'border-slate-200 text-slate-500'
+                  )}
+                  onClick={() =>
+                    setSelectedLevels((prev) =>
+                      prev.includes(level) ? prev.filter((l) => l !== level) : [...prev, level]
+                    )
+                  }
+                >
+                  {levelLabels[level]}
+                </button>
+              ))}
+            </div>
+            <button
+              className="px-3 py-1 rounded border border-slate-200 text-sm hover:bg-slate-100"
+              onClick={() => setLogs([])}
+            >
+              清屏
+            </button>
+            <button
+              className="px-3 py-1 rounded border border-slate-200 text-sm hover:bg-slate-100"
+              onClick={handleCopyLogs}
+            >
+              复制全部
+            </button>
+          </div>
+        </div>
+        <div className="flex-1 overflow-y-auto bg-slate-950 rounded text-sm p-3 text-slate-50">
+          {filteredLogs.length === 0 && (
+            <p className="text-slate-400">暂无日志输出。</p>
+          )}
+          {filteredLogs.map((entry, index) => (
+            <div key={`${entry.timestamp}-${index}`} className={classNames('whitespace-pre-wrap', levelColors[entry.level])}>
+              <span className="text-xs text-slate-500 mr-2">{formatTimestamp(entry.timestamp)}</span>
+              <span className="mr-2">[{entry.level.toUpperCase()}]</span>
+              <span>{entry.message}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default App;
+
+const StatusDot: React.FC<{ state: ServiceStatus['state'] }> = ({ state }) => {
+  const mapping: Record<ServiceStatus['state'], string> = {
+    running: 'bg-emerald-500',
+    starting: 'bg-amber-500 animate-pulse',
+    stopping: 'bg-amber-400 animate-pulse',
+    stopped: 'bg-slate-400'
+  };
+  return <span className={classNames('w-3 h-3 rounded-full inline-block', mapping[state])} title={translateState(state)} />;
+};
+
+const HealthBadge: React.FC<{ state: HealthState }> = ({ state }) => {
+  const meta = healthLabels[state];
+  return <span className={classNames('px-3 py-1 rounded-full text-xs font-medium', meta.className)}>{meta.label}</span>;
+};
+
+const InfoCard: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="bg-slate-50 rounded-lg border border-slate-200 p-4 flex flex-col gap-1">
+    <span className="text-xs text-slate-500 uppercase tracking-wide">{label}</span>
+    <span className="text-lg font-semibold text-slate-800">{value}</span>
+  </div>
+);
+
+function translateState(state: ServiceStatus['state']): string {
+  switch (state) {
+    case 'running':
+      return '运行中';
+    case 'starting':
+      return '启动中';
+    case 'stopping':
+      return '停止中';
+    default:
+      return '已停止';
+  }
+}
+
+function formatTimestamp(timestamp: string) {
+  return new Date(timestamp).toLocaleTimeString();
+}

--- a/packages/backend_gui/renderer/src/types.ts
+++ b/packages/backend_gui/renderer/src/types.ts
@@ -1,0 +1,28 @@
+export type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+export interface BackendConfig {
+  port: number;
+  logLevel: LogLevel;
+  autoRestart: boolean;
+}
+
+export type ServiceState = 'stopped' | 'starting' | 'running' | 'stopping';
+
+export interface ServiceStatus {
+  state: ServiceState;
+  pid: number | null;
+  port: number;
+  startedAt: number | null;
+  restartCount: number;
+  exitCode?: number | null;
+  exitSignal?: NodeJS.Signals | null;
+}
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  source: 'stdout' | 'stderr' | 'system';
+}
+
+export type HealthState = 'unknown' | 'healthy' | 'unhealthy';

--- a/packages/backend_gui/renderer/tailwind.config.cjs
+++ b/packages/backend_gui/renderer/tailwind.config.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#4C51BF',
+          dark: '#3A3F9F'
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/packages/backend_gui/renderer/tsconfig.json
+++ b/packages/backend_gui/renderer/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "../tsconfig.main.json" }]
+}

--- a/packages/backend_gui/renderer/vite.config.ts
+++ b/packages/backend_gui/renderer/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  },
+  build: {
+    outDir: '../dist/renderer',
+    emptyOutDir: true
+  },
+  server: {
+    port: 5173,
+    strictPort: true
+  }
+});

--- a/packages/backend_gui/scripts/copy-backend.cjs
+++ b/packages/backend_gui/scripts/copy-backend.cjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs-extra');
+
+async function main() {
+  const projectRoot = path.resolve(__dirname, '..');
+  const backendSource = path.resolve(projectRoot, '..', 'backend');
+  const targetDir = path.resolve(projectRoot, 'dist', 'backend');
+  await fs.remove(targetDir);
+  await fs.mkdirp(targetDir);
+  await fs.copy(backendSource, targetDir, {
+    filter: (src) => !src.includes('node_modules')
+  });
+  console.log('[copy-backend] Copied backend to dist/backend');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/backend_gui/scripts/smoke-test.js
+++ b/packages/backend_gui/scripts/smoke-test.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const path = require('path');
+
+async function run() {
+  const backendRoot = path.resolve(__dirname, '..', '..', 'backend');
+  const entry = path.join(backendRoot, 'src', 'app.js');
+  console.log('[smoke] 启动服务...');
+  const child = spawn(process.execPath, [entry], {
+    cwd: backendRoot,
+    env: { ...process.env, PORT: '3100', LOG_LEVEL: 'info' }
+  });
+
+  let ready = false;
+  child.stdout.on('data', (data) => {
+    const text = data.toString();
+    process.stdout.write(text);
+    if (text.includes('listening') || text.includes('Server started')) {
+      ready = true;
+    }
+  });
+
+  child.stderr.on('data', (data) => process.stderr.write(data.toString()));
+
+  await waitUntil(() => ready, 15000, 500);
+  console.log('[smoke] 健康检查...');
+  const resp = await fetch('http://127.0.0.1:3100/health');
+  if (!resp.ok) {
+    throw new Error(`[smoke] 健康检查失败: ${resp.status}`);
+  }
+  console.log('[smoke] 健康检查通过，准备停止服务');
+  await stopChild(child);
+  console.log('[smoke] 服务已停止');
+}
+
+async function waitUntil(predicate, timeout, interval) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  throw new Error('等待超时，服务未就绪');
+}
+
+async function stopChild(child) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (child.pid) process.kill(child.pid, 'SIGKILL');
+      reject(new Error('服务关闭超时'));
+    }, 5000);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve(undefined);
+    });
+    child.kill('SIGINT');
+  });
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/backend_gui/tsconfig.main.json
+++ b/packages/backend_gui/tsconfig.main.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "outDir": "dist/main",
+    "rootDir": "./",
+    "strict": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["electron/**/*.ts", "preload.ts"],
+  "exclude": ["node_modules", "renderer"]
+}


### PR DESCRIPTION
## Summary
- add a new `packages/backend_gui` Electron + React application that wraps the existing backend service
- implement configuration persistence, process lifecycle management, log streaming/rotation, health checks, and tray controls in the main process
- build a Tailwind-based UI for configuration, service control, and log filtering plus provide packaging scripts, README, and a smoke test helper

## Testing
- not run (environment only)


------
https://chatgpt.com/codex/tasks/task_e_68d9f4b1dd0c83259cc2513bbef30bd9