### PR TITLE
Adjust TamperMonkey link spacing

### DIFF
--- a/packages/TamperMonkeyScript/EhentaiHighighliger.user.js
+++ b/packages/TamperMonkeyScript/EhentaiHighighliger.user.js
@@ -1244,9 +1244,11 @@ function appendSimilarLink(fileTitleDom, text) {
     }
 
     const link = document.createElement("a");
-    link.textContent = "Find similar";
+    link.textContent = "Find in ShiguReader";
     link.title = trimmed;
     link.style.display = "block";
+    link.style.marginTop = "8px";
+    link.style.marginBottom = "8px";
     link.target = "_blank";
     link.className = "shigureader_link";
     const encodedText = encodeURIComponent(trimmed);

--- a/packages/TamperMonkeyScript/src/EhentaiHighighliger.js
+++ b/packages/TamperMonkeyScript/src/EhentaiHighighliger.js
@@ -232,9 +232,11 @@ function appendSimilarLink(fileTitleDom, text) {
     }
 
     const link = document.createElement("a");
-    link.textContent = "Find similar";
+    link.textContent = "Find in ShiguReader";
     link.title = trimmed;
     link.style.display = "block";
+    link.style.marginTop = "8px";
+    link.style.marginBottom = "8px";
     link.target = "_blank";
     link.className = "shigureader_link";
     const encodedText = encodeURIComponent(trimmed);


### PR DESCRIPTION
## Summary
- add bottom margin to the ShiguReader helper link in the TamperMonkey source
- mirror the updated spacing in the built user script

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da538723ec8325a7e2e336c818fae8