### PR TITLE
Bundle Windows ffmpeg integration for video thumbnails

### DIFF
--- a/packages/backend/resource/ffmpeg/README.md
+++ b/packages/backend/resource/ffmpeg/README.md
@@ -1,0 +1,5 @@
+# Bundled ffmpeg binary
+
+为了方便 Windows 用户使用内置的 gif 预览生成功能，我们在 `resource/ffmpeg` 目录预留了 `ffmpeg.exe` 可执行文件的位置。
+
+请从官方渠道下载对应版本的 ffmpeg 静态编译包，将其中的 `ffmpeg.exe` 复制到本目录下即可。程序会在启动时自动检测并调用该文件；若未找到则会提示缺少 ffmpeg，并跳过 GIF 缩略图生成。

--- a/packages/backend/resource/ffmpeg/index.js
+++ b/packages/backend/resource/ffmpeg/index.js
@@ -1,0 +1,5 @@
+const path = require('path');
+
+module.exports = {
+    ffmpeg: path.join(__dirname, 'ffmpeg.exe'),
+};

--- a/packages/backend/src/app.js
+++ b/packages/backend/src/app.js
@@ -15,6 +15,7 @@ const serverUtil = require('./utils/server-util');
 const { getHash, asyncWrapper } = serverUtil;
 const filewatch = require('./services/file-watchers/file-watch');
 const thumbnailUtil = require('./services/thumbnail-query');
+const videoThumbnailService = require('./services/video-thumbnail');
 const { getStatAndUpdateDB } = require('./services/server-common');
 const initializeEnvironment = require('./bootstrap/environment');
 const loadConfig = require('./bootstrap/loadConfig');
@@ -62,6 +63,8 @@ logger.init();
 const sevenZipHelp = require('./services/seven-zip');
 sevenZipHelp.init();
 const { listZipContentAndUpdateDb, extractAll, extractByRange } = sevenZipHelp;
+
+videoThumbnailService.init();
 
 const resolveExtractedEntry = (baseOutputPath, entryPath) => {
     if (!entryPath) {
@@ -699,6 +702,8 @@ app.get('/api/thumbnail/get_quick', asyncWrapper(async (req, res) => {
                 useVideoPreviewForFolder = true;
             }
         }
+    } else if (isVideo(filePath)) {
+        url = await videoThumbnailService.getVideoThumbnail(filePath);
     }
     res.setHeader('Cache-Control', 'public, max-age=60');
     res.setHeader('Connection', 'Keep-Alive');

--- a/packages/backend/src/services/video-thumbnail.js
+++ b/packages/backend/src/services/video-thumbnail.js
@@ -1,0 +1,169 @@
+const path = require('path');
+const stringHash = require('string-hash');
+const execa = require('../utils/own-execa');
+const util = require('../../../common/src/util');
+const pathUtil = require('../utils/path-util');
+const appState = require('../state/appState');
+const thumbnailDb = require('../models/thumbnail-db');
+const logger = require('../config/logger');
+
+const generatingTasks = new Map();
+const GIF_DURATION_SECONDS = 3;
+const GIF_WIDTH = 320;
+const GIF_FPS = 12;
+
+let ffmpegBinary = 'ffmpeg';
+let ffmpegReadyPromise = null;
+global._has_ffmpeg_ = null;
+
+function resolveBundledFfmpeg() {
+    try {
+        const rootPath = (pathUtil.getRootPath && pathUtil.getRootPath()) || path.join(__dirname, '..', '..');
+        const ffmpegModulePath = path.join(rootPath, 'resource', 'ffmpeg');
+        const bundled = require(ffmpegModulePath);
+        return bundled && bundled.ffmpeg ? bundled.ffmpeg : bundled;
+    } catch (error) {
+        logger.error('[video-thumbnail] no bundled ffmpeg found', error && error.message ? error.message : error);
+        return null;
+    }
+}
+
+function setFfmpegBinary(candidate) {
+    if (!candidate) {
+        global._has_ffmpeg_ = false;
+        ffmpegReadyPromise = null;
+        return;
+    }
+
+    ffmpegBinary = candidate;
+    global._has_ffmpeg_ = null;
+    ffmpegReadyPromise = execa(ffmpegBinary, ['-version'])
+        .then(() => {
+            global._has_ffmpeg_ = true;
+        })
+        .catch(error => {
+            global._has_ffmpeg_ = false;
+            logger.error('[video-thumbnail] ffmpeg not available', error && error.stderr ? error.stderr : error);
+        });
+    return ffmpegReadyPromise;
+}
+
+function init() {
+    if (global.isWindows) {
+        const bundledPath = resolveBundledFfmpeg();
+        if (bundledPath) {
+            setFfmpegBinary(bundledPath);
+        } else {
+            logger.error('[video-thumbnail] Windows environment detected but no ffmpeg.exe bundled');
+            global._has_ffmpeg_ = false;
+        }
+    } else {
+        setFfmpegBinary('ffmpeg');
+    }
+}
+
+function buildOutputPath(filePath) {
+    const folderPath = appState.getThumbnailFolderPath();
+    const parsed = path.parse(filePath);
+    const hash = stringHash(filePath).toString(36);
+    const fileName = `${parsed.name}-${hash}.gif`;
+    return path.join(folderPath, fileName);
+}
+
+async function ensureExistingThumbnail(filePath) {
+    const thumbRows = thumbnailDb.getThumbnailArr(filePath);
+    if (thumbRows[0]) {
+        const existingPath = thumbRows[0].thumbnailFilePath;
+        if (await pathUtil.isExist(existingPath)) {
+            return existingPath;
+        }
+    }
+    return null;
+}
+
+async function generateGif(filePath) {
+    if (!await pathUtil.isExist(filePath)) {
+        return null;
+    }
+
+    const folderPath = appState.getThumbnailFolderPath();
+    if (!folderPath) {
+        return null;
+    }
+
+    if (global._has_ffmpeg_ === null && !ffmpegReadyPromise) {
+        init();
+    }
+
+    if (ffmpegReadyPromise) {
+        await ffmpegReadyPromise.catch(() => null);
+    }
+
+    if (!global._has_ffmpeg_) {
+        return null;
+    }
+
+    const outputPath = buildOutputPath(filePath);
+    try {
+        await execa(ffmpegBinary, [
+            '-hide_banner',
+            '-loglevel', 'error',
+            '-y',
+            '-ss', '1',
+            '-i', filePath,
+            '-t', String(GIF_DURATION_SECONDS),
+            '-vf', `fps=${GIF_FPS},scale=${GIF_WIDTH}:-1:flags=lanczos`,
+            '-loop', '0',
+            outputPath,
+        ]);
+    } catch (error) {
+        logger.warn('[video-thumbnail] Failed to generate gif', filePath, error.stderr || error);
+        return null;
+    }
+
+    const exists = await pathUtil.isExist(outputPath);
+    if (!exists) {
+        return null;
+    }
+
+    thumbnailDb.addNewThumbnail(filePath, outputPath);
+    return outputPath;
+}
+
+async function getVideoThumbnail(filePath) {
+    if (!filePath || !util.isVideo(filePath)) {
+        return null;
+    }
+
+    if (global._has_ffmpeg_ === null && !ffmpegReadyPromise) {
+        init();
+    }
+
+    if (ffmpegReadyPromise) {
+        await ffmpegReadyPromise.catch(() => null);
+    }
+
+    if (!global._has_ffmpeg_) {
+        return null;
+    }
+
+    const existing = await ensureExistingThumbnail(filePath);
+    if (existing) {
+        return existing;
+    }
+
+    if (generatingTasks.has(filePath)) {
+        return generatingTasks.get(filePath);
+    }
+
+    const task = generateGif(filePath).finally(() => {
+        generatingTasks.delete(filePath);
+    });
+    generatingTasks.set(filePath, task);
+    return task;
+}
+
+module.exports = {
+    init,
+    getVideoThumbnail,
+};

--- a/packages/frontend/src/components/common/ThumbnailPopup/index.js
+++ b/packages/frontend/src/components/common/ThumbnailPopup/index.js
@@ -18,6 +18,8 @@ class ThumbnailPopup extends Component {
         this.isHovering = false;
         this.state = {};
         this.useVideoPreviewForFolder = false;
+        this.hasFetchedThumbnail = !!prop.url;
+        this.fetching = false;
 
         // a throttled function that can only call the func parameter maximally once per every wait milliseconds. 
         this.throttleGet = _.throttle(()=> {
@@ -27,11 +29,13 @@ class ThumbnailPopup extends Component {
 
     componentDidUpdate(prevProps) {
         if (this.props.url && prevProps.url !== this.props.url && !this.state.url) {
-          this.setState({
-            url: this.props.url
-          });
+            this.url = this.props.url;
+            this.hasFetchedThumbnail = true;
+            this.setState({
+                url: this.props.url
+            });
         }
-      }
+    }
 
     askRerender(){
         this.setState({
@@ -41,21 +45,26 @@ class ThumbnailPopup extends Component {
 
     async fetchData ()  {
         const { filePath} = this.props;
-        if(isVideo(filePath)){
+        if (!filePath || this.hasFetchedThumbnail || this.fetching) {
             return;
         }
 
-        if(!this.url){
+        this.fetching = true;
+        try {
             const res = await getQuickThumbnail(filePath);
-            if (res.isFailed() || !res.json.url) {
-                // todo
-                // nothing 
-            } else {
+            this.useVideoPreviewForFolder = !!(res.json && res.json.useVideoPreviewForFolder);
+            if (!res.isFailed() && res.json && res.json.url) {
                 this.url = clientUtil.getFileUrl(res.json.url);
-                this.useVideoPreviewForFolder = res.json.useVideoPreviewForFolder;
+            } else {
+                this.url = null;
             }
-            this.askRerender();
-        } 
+            this.hasFetchedThumbnail = true;
+        } catch (e) {
+            this.fetching = false;
+            return;
+        }
+        this.fetching = false;
+        this.askRerender();
     }
 
     onMouseMove(){
@@ -71,7 +80,8 @@ class ThumbnailPopup extends Component {
 
     render() {
         const { children, filePath, FileName } = this.props;
-        const { isHovering, url } = this;
+        const isHovering = this.isHovering;
+        const previewUrl = this.url;
         const cn = classNames("thumbnail-popup-wrap", {
             "open": isHovering
         })
@@ -80,25 +90,31 @@ class ThumbnailPopup extends Component {
         let titleStr = clientUtil.getBaseName(filePath);
         titleStr = util.truncateString(titleStr, 35);
         if(this.isHovering){
-            if(isVideo(filePath)|| (this.useVideoPreviewForFolder && this.url)){
-                let src;
-                if(isVideo(filePath)){
-                    src = clientUtil.getFileUrl(filePath);
-                }else{
-                    src = this.url;
-                }
+            if(isVideo(filePath)){
+                const fallbackSrc = clientUtil.getFileUrl(filePath);
+                extraDom = (<div className='thumbnail-popup-content'>
+                    <div className='thumbnail-popup-title'>{titleStr}</div>
+                    {previewUrl ? (
+                        <img className='thumbnail-popup-img' src={previewUrl}></img>
+                    ) : (
+                        <video className={'thumbnail-video-preview'} src={fallbackSrc} autoPlay={true} muted loop>
+                            Your browser does not support the video tag.
+                        </video>
+                    )}
+                </div>)
 
+            } else if(this.useVideoPreviewForFolder && previewUrl){
                 extraDom = (<div className='thumbnail-popup-content'>
                 <div className='thumbnail-popup-title'>{titleStr}</div>
-                    <video className={"thumbnail-video-preview"} src={src} autoPlay={true} muted>
+                    <video className={"thumbnail-video-preview"} src={previewUrl} autoPlay={true} muted>
                         Your browser does not support the video tag.
                     </video>
                 </div>)
 
-            } else if(url){
+            } else if(previewUrl){
                 extraDom = (<div className='thumbnail-popup-content'>
                 <div className='thumbnail-popup-title'>{titleStr}</div>
-                <img className='thumbnail-popup-img' src={url}></img>
+                <img className='thumbnail-popup-img' src={previewUrl}></img>
                 </div>)
             }else{
                 extraDom = (<div className='thumbnail-popup-content'>


### PR DESCRIPTION
## Summary
- backend: initialize the video thumbnail service with a bundled Windows ffmpeg binary when available and fall back gracefully when missing
- backend: wait for ffmpeg availability before spawning conversions and reuse the resolved binary for GIF generation
- docs: document the resource folder where Windows users should place ffmpeg.exe

## Testing
- npm test (backend) *(fails: path-util assertions expect Windows-style paths when running on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68da63a33cf883258517611154e16fce