### PR TITLE
Prevent LoadingImage from using video thumbnails

### DIFF
--- a/packages/backend/src/app.js
+++ b/packages/backend/src/app.js
@@ -411,6 +411,7 @@ app.all("/api/thumbnail/get", asyncWrapper(async (req, res) => {
     const filePath = body.filePath;
     const quickFlagFromBody = body.quick === true;
     const isQuickRequest = quickFlagFromBody;
+    const allowVideoPreviewForFolder = body.allowVideoPreviewForFolder !== false;
 
     if (!filePath || !(await isExist(filePath))) {
         res.send({ failed: true, reason: "NOT FOUND" });
@@ -423,12 +424,16 @@ app.all("/api/thumbnail/get", asyncWrapper(async (req, res) => {
 
     const quickResult = await thumbnailUtil.getQuickThumbnail(filePath);
     if (quickResult && quickResult.url) {
-        applyCacheHeader();
-        res.send({
-            url: quickResult.url,
-            useVideoPreviewForFolder: quickResult.useVideoPreviewForFolder,
-        });
-        return;
+        if (!allowVideoPreviewForFolder && quickResult.useVideoPreviewForFolder) {
+            // 继续执行后续逻辑，避免返回视频预览
+        } else {
+            applyCacheHeader();
+            res.send({
+                url: quickResult.url,
+                useVideoPreviewForFolder: quickResult.useVideoPreviewForFolder,
+            });
+            return;
+        }
     }
 
     if(isQuickRequest){

--- a/packages/frontend/src/api/thumbnail.js
+++ b/packages/frontend/src/api/thumbnail.js
@@ -3,8 +3,15 @@ import Sender from '@services/Sender';
 export const getTagThumbnail = (payload) =>
   Sender.postWithPromise('/api/thumbnail/get_for_tag', payload);
 
-export const getDetailedThumbnail = (filePath, options = {}) =>
-  Sender.postWithPromise('/api/thumbnail/get', { filePath, ...options });
+export const getDetailedThumbnail = (
+  filePath,
+  { allowVideoPreviewForFolder = true, ...options } = {}
+) =>
+  Sender.postWithPromise('/api/thumbnail/get', {
+    filePath,
+    allowVideoPreviewForFolder,
+    ...options,
+  });
 
 
 export const getQuickThumbnail = (filePath) =>

--- a/packages/frontend/src/components/LoadingImage/index.js
+++ b/packages/frontend/src/components/LoadingImage/index.js
@@ -62,7 +62,9 @@ export default function LoadingImage({
         body[mode] = tag;
         res = await getTagThumbnail(body);
       } else if ((mode === "folder" || mode === "zip") && filePath) {
-        res = await getDetailedThumbnail(filePath);
+        res = await getDetailedThumbnail(filePath, {
+          allowVideoPreviewForFolder: false,
+        });
       }
 
         if (!res || typeof res.isFailed === "function" && res.isFailed()) {


### PR DESCRIPTION
## Summary
- add an option to `getDetailedThumbnail` so callers can disallow video previews
- update the backend thumbnail endpoint to honor the new flag
- request folder/zip thumbnails in `LoadingImage` with video previews disabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dffc53f6f08325a6108e02a23e17fa