### PR TITLE
Set Explorer default sort to modification time

### DIFF
--- a/packages/frontend/src/pages/ExplorerPage/index.js
+++ b/packages/frontend/src/pages/ExplorerPage/index.js
@@ -92,7 +92,7 @@ export default class ExplorerPage extends Component {
         this.metaInfo = [
             { key: "pageIndex", type: "int", defVal: 1 },
             { key: "isRecursive", type: "boolean", defVal: false },
-            { key: "sortOrder", type: "str", defVal: BY_TIME },
+            { key: "sortOrder", type: "str", defVal: BY_MTIME },
             { key: "isSortAsc", type: "boolean", defVal: false },
             { key: "showFolderThumbnail", type: "boolean", defVal: false },
             { key: "filterArr", type: "arr" },


### PR DESCRIPTION
## Summary
- set the Explorer page's default sort order to use modification time so folders open sorted by the latest changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3ac44721483258526427d878b8581