### PR TITLE
Handle filename thumbnail fallback

### DIFF
--- a/packages/backend/src/app.js
+++ b/packages/backend/src/app.js
@@ -133,6 +133,26 @@ const modifyResponseForChart = require('./middleware/chartResponseMiddleware');
 // 将中间件应用到指定的 API 路由
 app.use(['/api/folder/list_dir', '/api/search/search_file', '/api/info/get_all'], modifyResponseForChart);
 
+const delayedThumbnailQueue = new Map();
+const DELAYED_THUMBNAIL_WAIT = 2000;
+
+function enqueueDelayedThumbnailExtract(filePath) {
+    if (delayedThumbnailQueue.has(filePath)) {
+        return;
+    }
+
+    const timer = setTimeout(async () => {
+        delayedThumbnailQueue.delete(filePath);
+        try {
+            await extractThumbnailFromZip(filePath, null, "delay-generate");
+        } catch (e) {
+            logger.warn("[thumbnail-delay]", e);
+        }
+    }, DELAYED_THUMBNAIL_WAIT);
+
+    delayedThumbnailQueue.set(filePath, timer);
+}
+
 //  to consume json request body
 //  https://stackoverflow.com/questions/10005939/how-do-i-consume-the-json-post-data-in-an-express-application
 // https://stackoverflow.com/questions/50304779/payloadtoolargeerror-request-entity-too-large?noredirect=1&lq=1
@@ -423,6 +443,12 @@ app.all("/api/thumbnail/get", asyncWrapper(async (req, res) => {
     }
 
     const quickResult = await thumbnailUtil.getQuickThumbnail(filePath);
+    const quickZipFromFilename = quickResult && quickResult.zipThumbnailSource === "fileName";
+
+    if (isQuickRequest && isCompress(filePath) && (!quickResult || !quickResult.url || quickZipFromFilename)) {
+        enqueueDelayedThumbnailExtract(filePath);
+    }
+
     if (quickResult && quickResult.url) {
         if (!allowVideoPreviewForFolder && quickResult.useVideoPreviewForFolder) {
             // 继续执行后续逻辑，避免返回视频预览

--- a/packages/backend/src/services/thumbnail-query.js
+++ b/packages/backend/src/services/thumbnail-query.js
@@ -101,10 +101,12 @@ async function getThumbnailForFolders(filePathes) {
  */
 async function getQuickThumbnailForZip(filePath){
     let url;
+    let source = null;
     const thumbnails = await getThumbnailsForZipFiles([filePath]);
     const oneThumbnail = thumbnails[filePath];
     if(oneThumbnail){
         url = oneThumbnail;
+        source = "filePath";
     }else{
         // 先找到发过去再说
         // TODO 但会导致不生成thumbnail了
@@ -113,10 +115,11 @@ async function getQuickThumbnailForZip(filePath){
             const thumbRows = await thumbnailDb.getThumbnailByFileName(fileName);
             if(thumbRows.length > 0){
                 url = thumbRows[0].thumbnailFilePath;
+                source = "fileName";
             }
         }
     }
-    return url;
+    return { url, source };
 }
 
 async function findVideoForFolder(filePath){
@@ -143,10 +146,11 @@ async function getQuickThumbnail(filePath) {
 
     if (util.isCompress(filePath)) {
         result.attempted.zip = true;
-        const url = await getQuickThumbnailForZip(filePath);
+        const { url, source: zipSource } = await getQuickThumbnailForZip(filePath);
         if (url) {
             result.url = url;
-            result.source = "zip-thumbnail";
+            result.source = zipSource === "fileName" ? "zip-thumbnail-by-filename" : "zip-thumbnail";
+            result.zipThumbnailSource = zipSource;
         }
         return result;
     }


### PR DESCRIPTION
## Summary
- track whether quick zip thumbnails come from filepath matches or filename fallbacks
- enqueue delayed extraction when quick requests rely on filename fallbacks or miss

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692881f430588325a35646a2a18ea213)