### PR TITLE
fix(frontend): 修复设置页中英混合文案

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -116,6 +116,9 @@
     "clearExtractCache": "Clear Extract Cache",
     "clearing": "Clearing...",
     "cacheCleared": "Cache cleared",
-    "cacheClearedDetail": "Deleted {count} files, freed {size}"
+    "cacheClearedDetail": "Deleted {count} files, freed {size}",
+    "fetchFailed": "Failed to fetch settings",
+    "updateFailed": "Failed to update settings",
+    "clearCacheFailed": "Failed to clear cache"
   }
 }

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -116,6 +116,9 @@
     "clearExtractCache": "清理解压缓存",
     "clearing": "清理中...",
     "cacheCleared": "缓存已清理",
-    "cacheClearedDetail": "已删除 {count} 个文件，释放 {size}"
+    "cacheClearedDetail": "已删除 {count} 个文件，释放 {size}",
+    "fetchFailed": "获取设置失败",
+    "updateFailed": "更新设置失败",
+    "clearCacheFailed": "清理缓存失败"
   }
 }

--- a/frontend/src/routes/_layout/settings.tsx
+++ b/frontend/src/routes/_layout/settings.tsx
@@ -14,7 +14,7 @@ import useCustomToast from "@/hooks/useCustomToast"
 export const Route = createFileRoute("/_layout/settings")({
   component: SettingsPage,
   head: () => ({
-    meta: [{ title: "Settings" }],
+    meta: [{ title: "设置" }],
   }),
 })
 
@@ -166,7 +166,7 @@ function SettingsPage() {
     queryKey: ["settings"],
     queryFn: async () => {
       const response = await fetch(`${OpenAPI.BASE}/api/v1/settings`)
-      if (!response.ok) throw new Error("Failed to fetch settings")
+      if (!response.ok) throw new Error(t("settings.fetchFailed"))
       return response.json()
     },
   })
@@ -194,7 +194,7 @@ function SettingsPage() {
       })
       if (!response.ok) {
         const error = await response.json()
-        throw new Error(error.detail || "Failed to update settings")
+        throw new Error(error.detail || t("settings.updateFailed"))
       }
       return response.json()
     },
@@ -294,7 +294,7 @@ function SettingsPage() {
       })
       if (!response.ok) {
         const error = await response.json()
-        throw new Error(error.detail || "Failed to clear cache")
+        throw new Error(error.detail || t("settings.clearCacheFailed"))
       }
       return response.json() as Promise<ClearCacheResponse>
     },
@@ -306,7 +306,7 @@ function SettingsPage() {
       showSuccessToast(message)
     },
     onError: (error: Error) => {
-      showErrorToast(error.message || "Failed to clear cache")
+      showErrorToast(error.message || t("settings.clearCacheFailed"))
     },
   })
 


### PR DESCRIPTION
### Motivation

- 修复新增设置页 UI 中出现的中英混合文案问题，保证所有用户可通过语言配置看到一致的提示文案。 
- 同步页面标题与错误提示的 i18n，避免在中文环境下仍显示硬编码英文。 

### Description

- 将 `frontend/src/routes/_layout/settings.tsx` 中的硬编码英文错误提示改为使用 `t(...)` 读取 i18n 文案（包括获取设置、更新设置、清理缓存三处）。
- 将设置页路由 `head` 标题从英文改为中文 `设置`，避免默认显示英文标题。 
- 在 `frontend/src/i18n/locales/zh.json` 和 `frontend/src/i18n/locales/en.json` 中新增并同步了三个翻译键：`settings.fetchFailed`、`settings.updateFailed`、`settings.clearCacheFailed`。
- 变更文件：`frontend/src/routes/_layout/settings.tsx`、`frontend/src/i18n/locales/zh.json`、`frontend/src/i18n/locales/en.json`。

### Testing

- 运行 `cd frontend && npx biome check src/routes/_layout/settings.tsx src/i18n/locales/zh.json src/i18n/locales/en.json` 检查修改文件，命令执行通过（成功）。
- 已将修改提交到本地仓库（commit 信息包含 `fix(frontend): 统一设置页错误文案走 i18n`）。
- 尝试运行 `npm run dev` 启动前端以本地验证页面未能成功，因为当前环境缺少 `vite` 可执行文件（启动失败）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992021501a88325ac3f4453e62f0624)