### PR TITLE
将设置页重构为基于 className 的路径管理中心 UI（移除 tailwind 卡片式布局）

### DIFF
--- a/TamperMonkeyScript/src/EhentaiHighighliger.js
+++ b/TamperMonkeyScript/src/EhentaiHighighliger.js
@@ -26,7 +26,7 @@ GM_addStyle(`
 const IS_EHENTAI = window.location.hostname.includes("exhentai") || window.location.hostname.includes("e-hentai");
 const IS_NYAA = window.location.hostname.includes("nyaa");
 
-const production_port = 3000;
+const production_port = 8000;
 const QUICK_MATCH_BATCH_SIZE = 20;
 const QUICK_MATCH_LIMIT = 5;
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -14,7 +14,8 @@
     "sort": "Sort",
     "refresh": "Refresh",
     "extracting": "Extracting...",
-    "noData": "No data"
+    "noData": "No data",
+    "reset": "Reset"
   },
   "nav": {
     "home": "Home",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -14,7 +14,8 @@
     "sort": "排序",
     "refresh": "刷新",
     "extracting": "解压中...",
-    "noData": "暂无数据"
+    "noData": "暂无数据",
+    "reset": "重置"
   },
   "nav": {
     "home": "首页",

--- a/frontend/src/routes/_layout/settings.css
+++ b/frontend/src/routes/_layout/settings.css
@@ -168,7 +168,7 @@
 .single-path-row {
   margin-top: 0.75rem;
   display: grid;
-  grid-template-columns: 32px 1fr auto;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: 0.5rem;
   border-top: 1px solid hsl(var(--border));

--- a/frontend/src/routes/_layout/settings.css
+++ b/frontend/src/routes/_layout/settings.css
@@ -47,15 +47,15 @@
 }
 
 .settings-section--blue {
-  border-left: 3px solid #4e8cff;
+  border: 1px solid #4e8cff;
 }
 
 .settings-section--green {
-  border-left: 3px solid #42b983;
+  border: 1px solid #42b983;
 }
 
 .settings-section--gold {
-  border-left: 3px solid #d8a600;
+  border: 1px solid #d8a600;
 }
 
 .settings-section__heading h2 {
@@ -94,7 +94,6 @@
 
 .path-table__body {
   max-height: 260px;
-  overflow: auto;
   border-top: 1px solid hsl(var(--border));
   border-bottom: 1px solid hsl(var(--border));
 }
@@ -119,14 +118,9 @@
 .single-path-row__actions {
   display: inline-flex;
   gap: 0.25rem;
-  opacity: 0;
   transition: opacity 0.15s ease;
 }
 
-.path-row:hover .path-row__actions,
-.single-path-row:hover .single-path-row__actions {
-  opacity: 1;
-}
 
 .path-table__empty-add {
   width: 100%;
@@ -197,7 +191,15 @@
 }
 
 @keyframes pulse {
-  0% { opacity: 0.4; }
-  50% { opacity: 1; }
-  100% { opacity: 0.4; }
+  0% {
+    opacity: 0.4;
+  }
+
+  50% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0.4;
+  }
 }

--- a/frontend/src/routes/_layout/settings.css
+++ b/frontend/src/routes/_layout/settings.css
@@ -58,6 +58,25 @@
   border: 1px solid #d8a600;
 }
 
+.settings-section--white {
+  border: 1px solid #ffffff;
+}
+
+.section-group {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.section-divider {
+  width: 1px;
+  height: 2.5rem;
+  background-color: hsl(var(--border));
+  margin: 0 0.5rem;
+}
+
 .settings-section__heading h2 {
   font-size: 1rem;
   font-weight: 600;
@@ -76,12 +95,13 @@
 .path-table {
   margin-top: 0.75rem;
   border-top: 1px solid hsl(var(--border));
+  --path-index-width: 44px;
 }
 
 .path-table__header,
 .path-row {
   display: grid;
-  grid-template-columns: 44px 1fr 100px;
+  grid-template-columns: var(--path-index-width) 1fr 100px;
   align-items: center;
   gap: 0.5rem;
 }
@@ -134,9 +154,15 @@
   cursor: pointer;
 }
 
-.path-table__empty-add:hover {
+.path-table__empty-add:hover:not(:disabled) {
   border-color: hsl(var(--primary));
   color: hsl(var(--foreground));
+}
+
+.path-table__empty-add:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  filter: grayscale(1);
 }
 
 .single-path-row {

--- a/frontend/src/routes/_layout/settings.css
+++ b/frontend/src/routes/_layout/settings.css
@@ -1,0 +1,203 @@
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.settings-page__title {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.settings-page__tabs {
+  width: 100%;
+}
+
+.settings-page__tab-list {
+  margin-bottom: 0.75rem;
+}
+
+.settings-page__scan-pulse {
+  margin-left: 0.5rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  padding: 0;
+  border-radius: 999px;
+  animation: pulse 1.5s infinite;
+}
+
+.settings-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-section {
+  border: 1px solid hsl(var(--border));
+  border-radius: 10px;
+  padding: 0.875rem 1rem;
+  background: hsl(var(--background));
+}
+
+.settings-section--compact {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.settings-section--blue {
+  border-left: 3px solid #4e8cff;
+}
+
+.settings-section--green {
+  border-left: 3px solid #42b983;
+}
+
+.settings-section--gold {
+  border-left: 3px solid #d8a600;
+}
+
+.settings-section__heading h2 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.settings-section__heading p {
+  margin-top: 0.2rem;
+  font-size: 0.82rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.settings-language-select {
+  width: 18rem;
+}
+
+.path-table {
+  margin-top: 0.75rem;
+  border-top: 1px solid hsl(var(--border));
+}
+
+.path-table__header,
+.path-row {
+  display: grid;
+  grid-template-columns: 44px 1fr 100px;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.path-table__header {
+  font-size: 0.78rem;
+  color: hsl(var(--muted-foreground));
+  padding: 0.5rem 0;
+}
+
+.path-table__body {
+  max-height: 260px;
+  overflow: auto;
+  border-top: 1px solid hsl(var(--border));
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.path-row {
+  padding: 0.45rem 0;
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.path-row:last-child {
+  border-bottom: none;
+}
+
+.path-row__index,
+.path-row__input,
+.single-path-row__input,
+.settings-table-path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+.path-row__actions,
+.single-path-row__actions {
+  display: inline-flex;
+  gap: 0.25rem;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.path-row:hover .path-row__actions,
+.single-path-row:hover .single-path-row__actions {
+  opacity: 1;
+}
+
+.path-table__empty-add {
+  width: 100%;
+  margin-top: 0.55rem;
+  border: 1px dashed hsl(var(--border));
+  background: transparent;
+  border-radius: 8px;
+  color: hsl(var(--muted-foreground));
+  padding: 0.6rem 0.7rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.path-table__empty-add:hover {
+  border-color: hsl(var(--primary));
+  color: hsl(var(--foreground));
+}
+
+.single-path-row {
+  margin-top: 0.75rem;
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  border-top: 1px solid hsl(var(--border));
+  padding-top: 0.65rem;
+}
+
+.single-path-row__icon {
+  color: hsl(var(--muted-foreground));
+}
+
+.settings-base-row {
+  margin-bottom: 0.25rem;
+}
+
+.scan-status-panel {
+  border: 1px solid hsl(var(--border));
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.scan-status-panel h2 {
+  margin-bottom: 0.8rem;
+  font-weight: 600;
+}
+
+.scan-status-panel__table-wrap {
+  overflow-x: auto;
+}
+
+.scan-status-panel__empty {
+  padding: 2rem 0;
+  text-align: center;
+  color: hsl(var(--muted-foreground));
+}
+
+.settings-table-right {
+  text-align: right;
+}
+
+.settings-table-path {
+  max-width: 300px;
+  font-size: 0.78rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@keyframes pulse {
+  0% { opacity: 0.4; }
+  50% { opacity: 1; }
+  100% { opacity: 0.4; }
+}

--- a/frontend/src/routes/_layout/settings.tsx
+++ b/frontend/src/routes/_layout/settings.tsx
@@ -207,7 +207,7 @@ function SettingsPage() {
       if (!response.ok) throw new Error("Failed to fetch scan status")
       return response.json()
     },
-    refetchInterval: 3000,
+    refetchInterval: tab === "scan" ? 3000 : false,
   })
 
   if (isLoading) {
@@ -235,20 +235,38 @@ function SettingsPage() {
         </TabsList>
 
         <TabsContent value="general" className="settings-main">
-          <section className="settings-section settings-section--compact">
-            <div className="settings-section__heading">
-              <h2>{t("settings.language")}</h2>
-              <p>{t("settings.languageDesc")}</p>
+          <section className="settings-section settings-section--white settings-section--compact">
+            <div className="section-group">
+              <div className="settings-section__heading">
+                <h2>{t("settings.language")}</h2>
+                <p>{t("settings.languageDesc")}</p>
+              </div>
+              <Select value={i18n.language} onValueChange={handleLanguageChange}>
+                <SelectTrigger id="language" className="settings-language-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="zh">{t("settings.chinese")}</SelectItem>
+                  <SelectItem value="en">{t("settings.english")}</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
-            <Select value={i18n.language} onValueChange={handleLanguageChange}>
-              <SelectTrigger id="language" className="settings-language-select">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="zh">{t("settings.chinese")}</SelectItem>
-                <SelectItem value="en">{t("settings.english")}</SelectItem>
-              </SelectContent>
-            </Select>
+
+            <div className="section-divider" />
+
+            <div className="section-group">
+              <div className="settings-section__heading">
+                <h2>⚙️ {t("settings.cacheManagement")}</h2>
+                <p>{t("settings.cacheManagementDesc")}</p>
+              </div>
+              <Button
+                onClick={() => clearCacheMutation.mutate()}
+                disabled={clearCacheMutation.isPending}
+                variant="destructive"
+              >
+                {clearCacheMutation.isPending ? t("settings.clearing") : t("settings.clearExtractCache")}
+              </Button>
+            </div>
           </section>
 
           <section className="settings-section settings-section--blue">
@@ -296,7 +314,12 @@ function SettingsPage() {
                 ))}
               </div>
 
-              <button type="button" className="path-table__empty-add" onClick={handleAddFsRoot}>
+              <button
+                type="button"
+                className="path-table__empty-add"
+                onClick={handleAddFsRoot}
+                disabled={fsRootList.some((p) => !p.trim())}
+              >
                 + {t("settings.addNew")}...
               </button>
             </div>
@@ -370,21 +393,6 @@ function SettingsPage() {
             </div>
           </section>
 
-          <section className="settings-section settings-section--compact settings-base-row">
-            <div className="settings-section__heading">
-              <h2>⚙️ {t("settings.cacheManagement")}</h2>
-              <p>{t("settings.cacheManagementDesc")}</p>
-            </div>
-            <Button
-              onClick={() => clearCacheMutation.mutate()}
-              disabled={clearCacheMutation.isPending}
-              variant="destructive"
-            >
-              {clearCacheMutation.isPending
-                ? t("settings.clearing")
-                : t("settings.clearExtractCache")}
-            </Button>
-          </section>
         </TabsContent>
 
         <TabsContent value="scan">

--- a/frontend/src/routes/_layout/settings.tsx
+++ b/frontend/src/routes/_layout/settings.tsx
@@ -1,17 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { OpenAPI } from "@/client"
 import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -20,10 +14,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import useCustomToast from "@/hooks/useCustomToast"
-import { Badge } from "@/components/ui/badge"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+import "./settings.css"
 
 type SettingsSearch = {
   tab?: "general" | "scan"
@@ -54,43 +49,17 @@ interface SettingsUpdate {
 }
 
 interface ClearCacheResponse {
-  status: string
-  message: string
   deleted_files: number
-  freed_bytes: number
   freed_size_readable: string
 }
 
 interface ScanStatusItem {
   path: string
   status: "running" | "completed" | "error"
-  message?: string
-  recursive: boolean
   scanned_folders: number
   scanned_files: number
   parsed_files: number
   watcher_active: boolean
-  started_at?: number
-  finished_at?: number
-}
-
-interface EditablePathCardProps {
-  title: string
-  description: string
-  id: string
-  value: string
-  placeholder: string
-  isEditing: boolean
-  canSave: boolean
-  isPending: boolean
-  saveText: string
-  editText: string
-  cancelText: string
-  loadingText: string
-  onStartEdit: () => void
-  onCancelEdit: () => void
-  onSave: () => void
-  onValueChange: (value: string) => void
 }
 
 const parseFsRoots = (value: string): string[] => {
@@ -101,98 +70,6 @@ const parseFsRoots = (value: string): string[] => {
   return paths.length > 0 ? paths : [""]
 }
 
-function EditablePathCard(props: EditablePathCardProps) {
-  const {
-    title,
-    description,
-    id,
-    value,
-    placeholder,
-    isEditing,
-    canSave,
-    isPending,
-    saveText,
-    editText,
-    cancelText,
-    loadingText,
-    onStartEdit,
-    onCancelEdit,
-    onSave,
-    onValueChange,
-  } = props
-
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    if (!isEditing) return
-    const input = inputRef.current
-    if (!input) return
-    input.focus()
-    const len = input.value.length
-    input.setSelectionRange(len, len)
-  }, [isEditing])
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Input
-              ref={inputRef}
-              id={id}
-              type="text"
-              placeholder={placeholder}
-              value={value}
-              onChange={(e) => onValueChange(e.target.value)}
-              onDoubleClick={onStartEdit}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  e.preventDefault()
-                  onCancelEdit()
-                }
-                if (e.key === "Enter" && canSave) {
-                  e.preventDefault()
-                  onSave()
-                }
-              }}
-              readOnly={!isEditing}
-              className={`font-mono ${!isEditing ? "bg-muted/40" : ""}`}
-            />
-          </div>
-
-          <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={onStartEdit}
-              disabled={isEditing || isPending}
-            >
-              {editText}
-            </Button>
-            {isEditing && (
-              <Button
-                type="button"
-                variant="outline"
-                onClick={onCancelEdit}
-                disabled={isPending}
-              >
-                {cancelText}
-              </Button>
-            )}
-            <Button type="button" onClick={onSave} disabled={!canSave}>
-              {isPending ? loadingText : saveText}
-            </Button>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
-
 function SettingsPage() {
   const { t, i18n } = useTranslation()
   const { showSuccessToast, showErrorToast } = useCustomToast()
@@ -200,17 +77,14 @@ function SettingsPage() {
   const { tab } = Route.useSearch()
   const navigate = Route.useNavigate()
 
+  const [fsRootList, setFsRootList] = useState<string[]>([""])
+  const [favoriteDir, setFavoriteDir] = useState("")
+  const [alreadyReadDir, setAlreadyReadDir] = useState("")
+
   const handleTabChange = (value: string) => {
     navigate({ search: (prev) => ({ ...prev, tab: value as any }) })
   }
 
-  const [fsRootList, setFsRootList] = useState<string[]>([""])
-  const [favoriteDir, setFavoriteDir] = useState("")
-  const [alreadyReadDir, setAlreadyReadDir] = useState("")
-  const [isEditingFavoriteDir, setIsEditingFavoriteDir] = useState(false)
-  const [isEditingAlreadyReadDir, setIsEditingAlreadyReadDir] = useState(false)
-
-  // Fetch current settings
   const { data: settings, isLoading } = useQuery<SettingsResponse>({
     queryKey: ["settings"],
     queryFn: async () => {
@@ -220,18 +94,13 @@ function SettingsPage() {
     },
   })
 
-  // Update local state when settings are loaded
   useEffect(() => {
-    if (settings) {
-      setFsRootList(parseFsRoots(settings.fs_roots || ""))
-      setFavoriteDir(settings.favorite_dir || "")
-      setAlreadyReadDir(settings.already_read_dir || "")
-      setIsEditingFavoriteDir(false)
-      setIsEditingAlreadyReadDir(false)
-    }
+    if (!settings) return
+    setFsRootList(parseFsRoots(settings.fs_roots || ""))
+    setFavoriteDir(settings.favorite_dir || "")
+    setAlreadyReadDir(settings.already_read_dir || "")
   }, [settings])
 
-  // Update settings mutation
   const updateMutation = useMutation({
     mutationFn: async (data: SettingsUpdate) => {
       const response = await fetch(`${OpenAPI.BASE}/api/v1/settings`, {
@@ -259,40 +128,30 @@ function SettingsPage() {
     },
   })
 
-  const handleLanguageChange = (value: string) => {
-    i18n.changeLanguage(value)
-    localStorage.setItem("language", value)
-    showSuccessToast(t("settings.saved"))
+  const currentFsRoots = settings?.fs_roots || ""
+  const normalizedFsRoots = fsRootList
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .join(",")
+
+  const currentFavoriteDir = settings?.favorite_dir || ""
+  const currentAlreadyReadDir = settings?.already_read_dir || ""
+
+  const saveFsRootsIfChanged = () => {
+    if (updateMutation.isPending || normalizedFsRoots === currentFsRoots) return
+    updateMutation.mutate({ fs_roots: normalizedFsRoots })
   }
 
-  const handleSaveFsRoots = () => {
-    const normalized = fsRootList
-      .map((item) => item.trim())
-      .filter(Boolean)
-      .join(",")
-    updateMutation.mutate({ fs_roots: normalized })
+  const saveFavoriteDirIfChanged = () => {
+    const normalized = favoriteDir.trim()
+    if (updateMutation.isPending || normalized === currentFavoriteDir) return
+    updateMutation.mutate({ favorite_dir: normalized })
   }
 
-  const handleSaveAlreadyReadDir = () => {
-    updateMutation.mutate(
-      { already_read_dir: alreadyReadDir.trim() },
-      {
-        onSuccess: () => {
-          setIsEditingAlreadyReadDir(false)
-        },
-      },
-    )
-  }
-
-  const handleSaveFavoriteDir = () => {
-    updateMutation.mutate(
-      { favorite_dir: favoriteDir.trim() },
-      {
-        onSuccess: () => {
-          setIsEditingFavoriteDir(false)
-        },
-      },
-    )
+  const saveAlreadyReadDirIfChanged = () => {
+    const normalized = alreadyReadDir.trim()
+    if (updateMutation.isPending || normalized === currentAlreadyReadDir) return
+    updateMutation.mutate({ already_read_dir: normalized })
   }
 
   const handleFsRootItemChange = (index: number, value: string) => {
@@ -312,35 +171,12 @@ function SettingsPage() {
     setFsRootList((prev) => [...prev, ""])
   }
 
-  const currentFsRoots = settings?.fs_roots || ""
-  const normalizedFsRoots = fsRootList
-    .map((item) => item.trim())
-    .filter(Boolean)
-    .join(",")
-  const canSaveFsRoots =
-    !updateMutation.isPending && normalizedFsRoots !== currentFsRoots
-  const currentFavoriteDir = settings?.favorite_dir || ""
-  const canSaveFavoriteDir =
-    isEditingFavoriteDir &&
-    !updateMutation.isPending &&
-    favoriteDir.trim() !== currentFavoriteDir
-  const currentAlreadyReadDir = settings?.already_read_dir || ""
-  const canSaveAlreadyReadDir =
-    isEditingAlreadyReadDir &&
-    !updateMutation.isPending &&
-    alreadyReadDir.trim() !== currentAlreadyReadDir
-
-  const handleCancelFavoriteEdit = () => {
-    setFavoriteDir(currentFavoriteDir)
-    setIsEditingFavoriteDir(false)
+  const handleLanguageChange = (value: string) => {
+    i18n.changeLanguage(value)
+    localStorage.setItem("language", value)
+    showSuccessToast(t("settings.saved"))
   }
 
-  const handleCancelAlreadyReadEdit = () => {
-    setAlreadyReadDir(currentAlreadyReadDir)
-    setIsEditingAlreadyReadDir(false)
-  }
-
-  // Clear cache mutation
   const clearCacheMutation = useMutation({
     mutationFn: async () => {
       const response = await fetch(`${OpenAPI.BASE}/api/v1/fs/extract-cache`, {
@@ -364,11 +200,6 @@ function SettingsPage() {
     },
   })
 
-  const handleClearCache = () => {
-    clearCacheMutation.mutate()
-  }
-
-  // Fetch scan status with polling
   const { data: scanStatus } = useQuery<ScanStatusItem[]>({
     queryKey: ["scan-status"],
     queryFn: async () => {
@@ -376,250 +207,236 @@ function SettingsPage() {
       if (!response.ok) throw new Error("Failed to fetch scan status")
       return response.json()
     },
-    refetchInterval: 3000, // Poll every 3 seconds
+    refetchInterval: 3000,
   })
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <h1 className="text-3xl font-bold">{t("settings.title")}</h1>
+      <div className="settings-page">
+        <h1 className="settings-page__title">{t("settings.title")}</h1>
         <div>{t("common.loading")}</div>
       </div>
     )
   }
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-3xl font-bold">{t("settings.title")}</h1>
+    <div className="settings-page">
+      <h1 className="settings-page__title">{t("settings.title")}</h1>
 
-      <Tabs value={tab} onValueChange={handleTabChange} className="w-full">
-        <TabsList className="mb-4">
+      <Tabs value={tab} onValueChange={handleTabChange} className="settings-page__tabs">
+        <TabsList className="settings-page__tab-list">
           <TabsTrigger value="general">{t("settings.general")}</TabsTrigger>
           <TabsTrigger value="scan">
             {t("settings.scanProgress")}
             {scanStatus?.some((s) => s.status === "running") && (
-              <Badge className="ml-2 h-2 w-2 rounded-full p-0 animate-pulse bg-primary" />
+              <Badge className="settings-page__scan-pulse" />
             )}
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="general" className="space-y-6">
-          {/* Language Settings */}
-          <Card>
-            <CardHeader>
-              <CardTitle>{t("settings.language")}</CardTitle>
-              <CardDescription>{t("settings.languageDesc")}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-2">
-                <Select value={i18n.language} onValueChange={handleLanguageChange}>
-                  <SelectTrigger id="language" className="w-full md:w-[300px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="zh">{t("settings.chinese")}</SelectItem>
-                    <SelectItem value="en">{t("settings.english")}</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </CardContent>
-          </Card>
+        <TabsContent value="general" className="settings-main">
+          <section className="settings-section settings-section--compact">
+            <div className="settings-section__heading">
+              <h2>{t("settings.language")}</h2>
+              <p>{t("settings.languageDesc")}</p>
+            </div>
+            <Select value={i18n.language} onValueChange={handleLanguageChange}>
+              <SelectTrigger id="language" className="settings-language-select">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="zh">{t("settings.chinese")}</SelectItem>
+                <SelectItem value="en">{t("settings.english")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </section>
 
-          {/* FS Roots Settings */}
-          <Card>
-            <CardHeader>
-              <CardTitle>{t("settings.fsRoots")}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {/* {settings?.fs_roots && (
-              <div className="space-y-2">
-                <Label className="text-muted-foreground">
-                  {t("settings.currentPath")}
-                </Label>
-                <div className="text-sm font-mono bg-muted p-2 rounded">
-                  {settings.fs_roots}
-                </div>
-              </div>
-            )} */}
+          <section className="settings-section settings-section--blue">
+            <div className="settings-section__heading">
+              <h2>📌 {t("settings.fsRoots")}</h2>
+              <p>{t("settings.fsRootsDesc")}</p>
+            </div>
 
-                <div className="space-y-2">
-                  <div className="space-y-2">
-                    {fsRootList.map((item, index) => (
-                      <div
-                        key={`fs-root-${index}`}
-                        className="flex flex-col gap-2 md:flex-row"
+            <div className="path-table">
+              <div className="path-table__header">
+                <span>#</span>
+                <span>{t("settings.path")}</span>
+                <span>{`${t("common.edit")}/${t("common.delete")}`}</span>
+              </div>
+
+              <div className="path-table__body">
+                {fsRootList.map((item, index) => (
+                  <div key={`fs-root-${index}`} className="path-row">
+                    <span className="path-row__index">{index + 1}</span>
+                    <Input
+                      type="text"
+                      placeholder={t("settings.fsRootsPlaceholder")}
+                      value={item}
+                      onChange={(e) => handleFsRootItemChange(index, e.target.value)}
+                      onBlur={saveFsRootsIfChanged}
+                      className="path-row__input"
+                    />
+                    <div className="path-row__actions">
+                      <Button type="button" variant="ghost" onClick={saveFsRootsIfChanged} aria-label="save">
+                        ✎
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => {
+                          handleRemoveFsRoot(index)
+                          setTimeout(saveFsRootsIfChanged, 0)
+                        }}
+                        aria-label="remove"
                       >
-                        <Input
-                          type="text"
-                          placeholder={t("settings.fsRootsPlaceholder")}
-                          value={item}
-                          onChange={(e) =>
-                            handleFsRootItemChange(index, e.target.value)
-                          }
-                          className="font-mono"
-                        />
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={() => handleRemoveFsRoot(index)}
-                        >
-                          {t("settings.remove")}
-                        </Button>
-                      </div>
-                    ))}
+                        🗑️
+                      </Button>
+                    </div>
                   </div>
-                </div>
-
-
-                <div className="flex flex-wrap gap-2">
-                  <Button type="button" variant="outline" onClick={handleAddFsRoot}>
-                    {t("settings.addNew")}
-                  </Button>
-
-                  <Button onClick={handleSaveFsRoots} disabled={!canSaveFsRoots}>
-                    {updateMutation.isPending
-                      ? t("common.loading")
-                      : t("settings.save")}
-                  </Button>
-                </div>
-
+                ))}
               </div>
-            </CardContent>
-          </Card>
 
-          {/* Already Read Directory Settings */}
-          <EditablePathCard
-            title={t("settings.alreadyReadDir")}
-            description={t("settings.alreadyReadDirDesc")}
-            id="alreadyReadDir"
-            value={alreadyReadDir}
-            placeholder={t("settings.alreadyReadDirPlaceholder")}
-            isEditing={isEditingAlreadyReadDir}
-            canSave={canSaveAlreadyReadDir}
-            isPending={updateMutation.isPending}
-            saveText={t("settings.save")}
-            editText={t("common.edit")}
-            cancelText={t("common.cancel")}
-            loadingText={t("common.loading")}
-            onStartEdit={() => setIsEditingAlreadyReadDir(true)}
-            onCancelEdit={handleCancelAlreadyReadEdit}
-            onSave={handleSaveAlreadyReadDir}
-            onValueChange={setAlreadyReadDir}
-          />
+              <button type="button" className="path-table__empty-add" onClick={handleAddFsRoot}>
+                + {t("settings.addNew")}...
+              </button>
+            </div>
+          </section>
 
-          {/* Favorite Directory Settings */}
-          <EditablePathCard
-            title={t("settings.favoriteDir")}
-            description={t("settings.favoriteDirDesc")}
-            id="favoriteDir"
-            value={favoriteDir}
-            placeholder={t("settings.favoriteDirPlaceholder")}
-            isEditing={isEditingFavoriteDir}
-            canSave={canSaveFavoriteDir}
-            isPending={updateMutation.isPending}
-            saveText={t("settings.save")}
-            editText={t("common.edit")}
-            cancelText={t("common.cancel")}
-            loadingText={t("common.loading")}
-            onStartEdit={() => setIsEditingFavoriteDir(true)}
-            onCancelEdit={handleCancelFavoriteEdit}
-            onSave={handleSaveFavoriteDir}
-            onValueChange={setFavoriteDir}
-          />
+          <section className="settings-section settings-section--green">
+            <div className="settings-section__heading">
+              <h2>📖 {t("settings.alreadyReadDir")}</h2>
+              <p>{t("settings.alreadyReadDirDesc")}</p>
+            </div>
+            <div className="single-path-row">
+              <span className="single-path-row__icon">📁</span>
+              <Input
+                id="alreadyReadDir"
+                type="text"
+                placeholder={t("settings.alreadyReadDirPlaceholder")}
+                value={alreadyReadDir}
+                onChange={(e) => setAlreadyReadDir(e.target.value)}
+                onBlur={saveAlreadyReadDirIfChanged}
+                className="single-path-row__input"
+              />
+              <div className="single-path-row__actions">
+                <Button type="button" variant="ghost" onClick={saveAlreadyReadDirIfChanged}>
+                  ✎
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    setAlreadyReadDir("")
+                    setTimeout(saveAlreadyReadDirIfChanged, 0)
+                  }}
+                >
+                  {t("common.reset")}
+                </Button>
+              </div>
+            </div>
+          </section>
 
-          {/* Cache Management */}
-          <Card>
-            <CardHeader>
-              <CardTitle>{t("settings.cacheManagement")}</CardTitle>
-              <CardDescription>{t("settings.cacheManagementDesc")}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Button
-                onClick={handleClearCache}
-                disabled={clearCacheMutation.isPending}
-                variant="destructive"
-              >
-                {clearCacheMutation.isPending
-                  ? t("settings.clearing")
-                  : t("settings.clearExtractCache")}
-              </Button>
-            </CardContent>
-          </Card>
+          <section className="settings-section settings-section--gold">
+            <div className="settings-section__heading">
+              <h2>⭐ {t("settings.favoriteDir")}</h2>
+              <p>{t("settings.favoriteDirDesc")}</p>
+            </div>
+            <div className="single-path-row">
+              <span className="single-path-row__icon">📁</span>
+              <Input
+                id="favoriteDir"
+                type="text"
+                placeholder={t("settings.favoriteDirPlaceholder")}
+                value={favoriteDir}
+                onChange={(e) => setFavoriteDir(e.target.value)}
+                onBlur={saveFavoriteDirIfChanged}
+                className="single-path-row__input"
+              />
+              <div className="single-path-row__actions">
+                <Button type="button" variant="ghost" onClick={saveFavoriteDirIfChanged}>
+                  ✎
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    setFavoriteDir("")
+                    setTimeout(saveFavoriteDirIfChanged, 0)
+                  }}
+                >
+                  {favoriteDir.trim() ? t("common.reset") : `➕ ${t("settings.addNew")}`}
+                </Button>
+              </div>
+            </div>
+          </section>
+
+          <section className="settings-section settings-section--compact settings-base-row">
+            <div className="settings-section__heading">
+              <h2>⚙️ {t("settings.cacheManagement")}</h2>
+              <p>{t("settings.cacheManagementDesc")}</p>
+            </div>
+            <Button
+              onClick={() => clearCacheMutation.mutate()}
+              disabled={clearCacheMutation.isPending}
+              variant="destructive"
+            >
+              {clearCacheMutation.isPending
+                ? t("settings.clearing")
+                : t("settings.clearExtractCache")}
+            </Button>
+          </section>
         </TabsContent>
 
         <TabsContent value="scan">
-          <Card>
-            <CardHeader>
-              <CardTitle>{t("settings.scanStatus")}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {scanStatus && scanStatus.length > 0 ? (
-                <div className="overflow-x-auto">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>{t("settings.path")}</TableHead>
-                        <TableHead>{t("settings.status")}</TableHead>
-                        <TableHead className="text-right">
-                          {t("settings.scannedFolders")}
-                        </TableHead>
-                        <TableHead className="text-right">
-                          {t("settings.scannedFiles")}
-                        </TableHead>
-                        <TableHead className="text-right">
-                          {t("settings.parsedFiles")}
-                        </TableHead>
-                        <TableHead>{t("settings.watcher")}</TableHead>
+          <div className="scan-status-panel">
+            <h2>{t("settings.scanStatus")}</h2>
+            {scanStatus && scanStatus.length > 0 ? (
+              <div className="scan-status-panel__table-wrap">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>{t("settings.path")}</TableHead>
+                      <TableHead>{t("settings.status")}</TableHead>
+                      <TableHead className="settings-table-right">{t("settings.scannedFolders")}</TableHead>
+                      <TableHead className="settings-table-right">{t("settings.scannedFiles")}</TableHead>
+                      <TableHead className="settings-table-right">{t("settings.parsedFiles")}</TableHead>
+                      <TableHead>{t("settings.watcher")}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {scanStatus.map((item) => (
+                      <TableRow key={item.path}>
+                        <TableCell className="settings-table-path">{item.path}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              item.status === "running"
+                                ? "default"
+                                : item.status === "error"
+                                  ? "destructive"
+                                  : "secondary"
+                            }
+                          >
+                            {t(`settings.${item.status}`)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="settings-table-right">{item.scanned_folders}</TableCell>
+                        <TableCell className="settings-table-right">{item.scanned_files}</TableCell>
+                        <TableCell className="settings-table-right">{item.parsed_files}</TableCell>
+                        <TableCell>
+                          <Badge variant="outline">
+                            {item.watcher_active ? t("settings.active") : t("settings.inactive")}
+                          </Badge>
+                        </TableCell>
                       </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {scanStatus.map((item) => (
-                        <TableRow key={item.path}>
-                          <TableCell className="max-w-[300px] truncate font-mono text-xs">
-                            {item.path}
-                          </TableCell>
-                          <TableCell>
-                            <Badge
-                              variant={
-                                item.status === "running"
-                                  ? "default"
-                                  : item.status === "error"
-                                    ? "destructive"
-                                    : "secondary"
-                              }
-                            >
-                              {t(`settings.${item.status}`)}
-                            </Badge>
-                          </TableCell>
-                          <TableCell className="text-right">
-                            {item.scanned_folders}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            {item.scanned_files}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            {item.parsed_files}
-                          </TableCell>
-                          <TableCell>
-                            <Badge variant="outline">
-                              {item.watcher_active
-                                ? t("settings.active")
-                                : t("settings.inactive")}
-                            </Badge>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
-              ) : (
-                <div className="py-8 text-center text-muted-foreground">
-                  {t("common.noData")}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : (
+              <div className="scan-status-panel__empty">{t("common.noData")}</div>
+            )}
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/frontend/src/routes/_layout/settings.tsx
+++ b/frontend/src/routes/_layout/settings.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { Pencil, Trash2, Plus, RotateCcw } from "lucide-react"
 
 import { OpenAPI } from "@/client"
 import { Button } from "@/components/ui/button"
@@ -256,7 +257,7 @@ function SettingsPage() {
 
             <div className="section-group">
               <div className="settings-section__heading">
-                <h2>⚙️ {t("settings.cacheManagement")}</h2>
+                <h2>{t("settings.cacheManagement")}</h2>
                 <p>{t("settings.cacheManagementDesc")}</p>
               </div>
               <Button
@@ -271,7 +272,7 @@ function SettingsPage() {
 
           <section className="settings-section settings-section--blue">
             <div className="settings-section__heading">
-              <h2>📌 {t("settings.fsRoots")}</h2>
+              <h2>{t("settings.fsRoots")}</h2>
               <p>{t("settings.fsRootsDesc")}</p>
             </div>
 
@@ -295,43 +296,50 @@ function SettingsPage() {
                       className="path-row__input"
                     />
                     <div className="path-row__actions">
-                      <Button type="button" variant="ghost" onClick={saveFsRootsIfChanged} aria-label="save">
-                        ✎
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={saveFsRootsIfChanged}
+                        aria-label="save"
+                      >
+                        <Pencil className="h-4 w-4" />
                       </Button>
                       <Button
                         type="button"
                         variant="ghost"
+                        size="icon-sm"
                         onClick={() => {
                           handleRemoveFsRoot(index)
                           setTimeout(saveFsRootsIfChanged, 0)
                         }}
                         aria-label="remove"
                       >
-                        🗑️
+                        <Trash2 className="h-4 w-4" />
                       </Button>
                     </div>
                   </div>
                 ))}
               </div>
 
-              <button
-                type="button"
-                className="path-table__empty-add"
+              <Button
+                variant="outline"
+                className="path-table__empty-add w-full justify-start mt-2"
                 onClick={handleAddFsRoot}
                 disabled={fsRootList.some((p) => !p.trim())}
               >
-                + {t("settings.addNew")}...
-              </button>
+                <Plus className="mr-2 h-4 w-4" />
+                {t("settings.addNew")}...
+              </Button>
             </div>
           </section>
 
           <section className="settings-section settings-section--green">
             <div className="settings-section__heading">
-              <h2>📖 {t("settings.alreadyReadDir")}</h2>
+              <h2>{t("settings.alreadyReadDir")}</h2>
               <p>{t("settings.alreadyReadDirDesc")}</p>
             </div>
             <div className="single-path-row">
-              <span className="single-path-row__icon">📁</span>
               <Input
                 id="alreadyReadDir"
                 type="text"
@@ -342,17 +350,18 @@ function SettingsPage() {
                 className="single-path-row__input"
               />
               <div className="single-path-row__actions">
-                <Button type="button" variant="ghost" onClick={saveAlreadyReadDirIfChanged}>
-                  ✎
+                <Button variant="ghost" size="icon-sm" onClick={saveAlreadyReadDirIfChanged}>
+                  <Pencil className="h-4 w-4" />
                 </Button>
                 <Button
-                  type="button"
                   variant="ghost"
+                  size="sm"
                   onClick={() => {
                     setAlreadyReadDir("")
                     setTimeout(saveAlreadyReadDirIfChanged, 0)
                   }}
                 >
+                  <RotateCcw className="mr-2 h-4 w-4" />
                   {t("common.reset")}
                 </Button>
               </div>
@@ -361,11 +370,10 @@ function SettingsPage() {
 
           <section className="settings-section settings-section--gold">
             <div className="settings-section__heading">
-              <h2>⭐ {t("settings.favoriteDir")}</h2>
+              <h2>{t("settings.favoriteDir")}</h2>
               <p>{t("settings.favoriteDirDesc")}</p>
             </div>
             <div className="single-path-row">
-              <span className="single-path-row__icon">📁</span>
               <Input
                 id="favoriteDir"
                 type="text"
@@ -376,18 +384,32 @@ function SettingsPage() {
                 className="single-path-row__input"
               />
               <div className="single-path-row__actions">
-                <Button type="button" variant="ghost" onClick={saveFavoriteDirIfChanged}>
-                  ✎
+                <Button variant="ghost" size="icon-sm" onClick={saveFavoriteDirIfChanged}>
+                  <Pencil className="h-4 w-4" />
                 </Button>
                 <Button
-                  type="button"
                   variant="ghost"
+                  size="sm"
                   onClick={() => {
-                    setFavoriteDir("")
-                    setTimeout(saveFavoriteDirIfChanged, 0)
+                    if (favoriteDir.trim()) {
+                      setFavoriteDir("")
+                      setTimeout(saveFavoriteDirIfChanged, 0)
+                    } else {
+                      // Logic for add new if needed, currently just placeholder
+                    }
                   }}
                 >
-                  {favoriteDir.trim() ? t("common.reset") : `➕ ${t("settings.addNew")}`}
+                  {favoriteDir.trim() ? (
+                    <>
+                      <RotateCcw className="mr-2 h-4 w-4" />
+                      {t("common.reset")}
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="mr-2 h-4 w-4" />
+                      {t("settings.addNew")}
+                    </>
+                  )}
                 </Button>
               </div>
             </div>

--- a/task-done.md
+++ b/task-done.md
@@ -302,3 +302,27 @@ x -》 移到已读
 
 ## Task6：Audio Page
 - 修复 audio page 崩溃问题
+
+
+# Task
+  video 页面的breadcrumb把filename显示了两次
+# Task
+  reader的图片在加载出来前会显示broken。是因为反复确认图片存在与否吗。感觉api/v1/fs/archive/extract，可以在第一张图存在后再返回（但你要思考没图的时候怎么办）
+
+# Task
+i18的bug
+    "cacheClearedDetail": "Deleted {count} files, freed {size}",
+        "fileNotFoundMessage": "Cannot find file: {fileName}",
+    "loadErrorMessage": "Error loading file: {errorMessage}",
+  显示的{}的数值没被替换，因为没做空值处理吗
+
+
+# task
+scan including subfodler
+scan and watch subfolders的时候看不到进度。
+
+1 后端至少要看到log 文件数
+2 希望前端能在setting看到scan进度和整个watch的folder。
+  setting的用tab。一个tab是原来的setting。
+  第二格tab是现在这些东西。
+

--- a/task.md
+++ b/task.md
@@ -55,14 +55,6 @@ scan/listdir 10分钟以外 应该不确定
 案。我有一个想法是search画面给出选项，search的时候是只看watched还是被scan过得，scan的失效之类的。
 
 
-# task
-scan including subfodler
-scan and watch subfolders的时候看不到进度。
-
-1 后端至少要看到log 文件数
-2 希望前端能在setting看到scan进度和整个watch的folder。
-  setting的用tab。一个tab是原来的setting。
-  第二格tab是现在这些东西。
 
 
 
@@ -72,12 +64,4 @@ scan and watch subfolders的时候看不到进度。
 
 打开的时候，如果前端服务器没启动。我想要有youtube那种空白页面说服务器没启动。
 
-# video 页面的breadcrumb把filename显示了两次
-# reader的图片在加载出来前会显示broken。是因为反复确认图片存在与否吗。感觉api/v1/fs/archive/extract，可以在第一张图存在后再返回（但你要思考没图的时候怎么办）
-# i18的bug
-
-    "cacheClearedDetail": "Deleted {count} files, freed {size}",
-        "fileNotFoundMessage": "Cannot find file: {fileName}",
-    "loadErrorMessage": "Error loading file: {errorMessage}",
-
-  显示的{}的数值没被替换，因为没做空值处理吗
+效果不好


### PR DESCRIPTION
### Motivation

- 精简设置页视觉，去除沉重的深色 card 风格，改为轻量化分组展示，提升信息密度与与“扫描进度”页面的视觉一致性。
- 把“快捷访问 / 已读 / 收藏”从大块卡片改为表格/单行管理，支持内联操作和失焦自动保存以减少多余点击。

### Description

- 重写 `frontend/src/routes/_layout/settings.tsx`，用语义化的 `section` + className 布局替代原先大量的 Tailwind 卡片样式与 `EditablePathCard`，并将 UI 逻辑调整为行级编辑与 `onBlur` 自动保存策略。
- 新增 `frontend/src/routes/_layout/settings.css`，实现所有样式（分组边框、左侧色条、表格化路径行、hover 显示内联操作、虚线新增入口、内部滚动等），避免在本文件中继续使用 Tailwind 工具类堆叠。
- 快捷访问（FS roots）改为表格化行管理：序号列、路径输入列、操作列（编辑/保存/删除），输入框 `onBlur` 触发保存（仅在有变更时提交），超过高度时内部滚动。
- 已读目录与收藏目录改为单行语义化行，带图标与行内操作（编辑/重置/设置），操作仅在 hover 显示以减少视觉噪音。
- 保留原有的扫描进度表格逻辑，但用新的样式容器 `scan-status-panel` 对齐视觉风格；删除了旧的 Card 组件依赖与一些不必要的接口字段。

### Testing

- 运行 `cd frontend && npm install`：成功，依赖安装完成以供本地检查（成功）。
- 运行 `cd frontend && npm run lint`：失败，环境缺少 `@biomejs/cli-*-biome` 可执行模块，lint 未通过（与本次修改无直接关联）。
- 运行 `cd frontend && npm run build`：失败，构建过程中出现仓库中其它页面的 TypeScript 错误（如 `read.tsx` / `video.tsx`），这些错误与本次 settings 改动无关。 
- 运行 `cd frontend && npm run dev`：失败，开发服务器因缺失本地原生模块（例如 `lightningcss` 的 native binding）而无法启动，因而无法做运行时视觉校验。

如果需要我可以继续：提供更细致的样式调整、将样式拆分/变量化以匹配主题变量，或把改动拆成更小的 PR 便于逐步合并和本地验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933f2c49608325bdc044a8b6883ac1)