### PR TITLE
feat: 启动时后台同步 files 表与文件系统并复用扫描快照

### DIFF
--- a/backend/app/api/routes/fs.py
+++ b/backend/app/api/routes/fs.py
@@ -33,7 +33,7 @@ from app.file_processing.name_parser import parse
 from app.file_processing.stepwise_extractor import stepwise_extract
 from app.index_db.confidence import compute_confidence
 from app.index_db.db import get_index_session
-from app.index_db.models import File
+from app.index_db.models import File, Folder
 from app.index_db.repository import IndexRepository, UpsertFileInput, UpsertFolderInput
 from app.services.thumb_service import ThumbService
 from app.utils import detect_file_type, get_mime_type
@@ -803,12 +803,65 @@ def _scan_root_with_scandir(root: Path) -> dict[str, tuple[int, int]]:
     return files
 
 
+
+
+def _should_update_existing_file(
+    db_size: int,
+    db_mtime: int,
+    db_scan_state: int,
+    real_size: int,
+    real_mtime: int,
+) -> bool:
+    """文件仍存在时，元数据变化或曾被标记删除都应回写。"""
+    return db_size != real_size or db_mtime != real_mtime or db_scan_state == 0
+
+
+def _build_folder_sync_mappings(
+    real_filepaths: set[str],
+    db_folder_paths: set[str],
+    now_ts: int,
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    """基于真实文件集合生成 folders 的批量插入/更新映射。"""
+    real_folder_paths = {str(Path(filepath).parent) for filepath in real_filepaths}
+
+    to_insert_folders: list[dict[str, object]] = []
+    for folderpath in real_folder_paths - db_folder_paths:
+        folder = Path(folderpath)
+        to_insert_folders.append(
+            {
+                "filepath": folderpath,
+                "dirname": folder.name or folderpath,
+                "mtime": None,
+                "scan_state": 1,
+                "watch_state": 0,
+                "first_seen_at": now_ts,
+                "last_seen_at": now_ts,
+                "last_scanned_at": now_ts,
+                "created_at": now_ts,
+                "updated_at": now_ts,
+            }
+        )
+
+    to_update_folders = [
+        {
+            "filepath": folderpath,
+            "scan_state": 1,
+            "last_seen_at": now_ts,
+            "last_scanned_at": now_ts,
+            "updated_at": now_ts,
+        }
+        for folderpath in (real_folder_paths & db_folder_paths)
+    ]
+
+    return to_insert_folders, to_update_folders
+
 def _sync_file_table_with_filesystem() -> None:
     """同步 files 表与真实文件系统。真实文件系统是唯一真相。"""
     started = time()
     with get_index_session() as session:
         repo = IndexRepository(session)
         db_rows = list(session.exec(select(File.filepath, File.filesize, File.mtime, File.scan_state)).all())
+        db_folder_paths = set(session.exec(select(Folder.filepath)).all())
 
         if not db_rows:
             logger.info("[file-sync] skip: no records in file table")
@@ -868,7 +921,13 @@ def _sync_file_table_with_filesystem() -> None:
         changed_paths = {
             filepath
             for filepath in common_paths
-            if db_map[filepath][0] != real_map[filepath][0] or db_map[filepath][1] != real_map[filepath][1]
+            if _should_update_existing_file(
+                db_size=db_map[filepath][0],
+                db_mtime=db_map[filepath][1],
+                db_scan_state=db_map[filepath][2],
+                real_size=real_map[filepath][0],
+                real_mtime=real_map[filepath][1],
+            )
         }
 
         to_update_changed: list[dict[str, object]] = []
@@ -902,13 +961,20 @@ def _sync_file_table_with_filesystem() -> None:
             if db_map[filepath][2] != 0
         ]
 
+        to_insert_folders, to_update_folders = _build_folder_sync_mappings(real_paths, db_folder_paths, now_ts)
+
+        if to_insert_folders:
+            session.bulk_insert_mappings(Folder, to_insert_folders)
+        if to_update_folders:
+            session.bulk_update_mappings(Folder, to_update_folders)
+
         if to_insert:
             session.bulk_insert_mappings(File, to_insert)
         if to_update_changed:
             session.bulk_update_mappings(File, to_update_changed)
         if to_mark_deleted:
             session.bulk_update_mappings(File, to_mark_deleted)
-        if to_insert or to_update_changed or to_mark_deleted:
+        if to_insert_folders or to_update_folders or to_insert or to_update_changed or to_mark_deleted:
             repo._commit()
 
         elapsed = time() - started

--- a/backend/app/api/routes/fs.py
+++ b/backend/app/api/routes/fs.py
@@ -9,7 +9,10 @@ import shutil
 import string
 import threading
 import zipfile
+from dataclasses import dataclass
+from collections.abc import Iterable
 from time import time
+from time import sleep
 from pathlib import Path
 from typing import Literal
 from urllib.parse import quote
@@ -18,6 +21,7 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
 from send2trash import send2trash
+from sqlmodel import select
 
 from app.constants import ARCHIVE_SUFFIXES, AUDIO_SUFFIXES, IMAGE_SUFFIXES, VIDEO_SUFFIXES
 from app.core.config import settings
@@ -29,6 +33,7 @@ from app.file_processing.name_parser import parse
 from app.file_processing.stepwise_extractor import stepwise_extract
 from app.index_db.confidence import compute_confidence
 from app.index_db.db import get_index_session
+from app.index_db.models import File
 from app.index_db.repository import IndexRepository, UpsertFileInput, UpsertFolderInput
 from app.services.thumb_service import ThumbService
 from app.utils import detect_file_type, get_mime_type
@@ -43,6 +48,26 @@ _watcher_lock = threading.Lock()
 _scan_status: dict[str, dict] = {}
 _scan_status_lock = threading.Lock()
 _SCAN_DB_BATCH_SIZE = 500
+_SYNC_LOW_PRIORITY_SLEEP_EVERY = 500
+_SYNC_LOW_PRIORITY_SLEEP_SEC = 0.001
+_SCAN_SNAPSHOT_TTL_SEC = 300
+
+
+@dataclass(slots=True)
+class ScanSnapshot:
+    root: str
+    recursive: bool
+    created_at: float
+    files: dict[str, tuple[int, int]]
+
+
+_scan_snapshot_lock = threading.Lock()
+_scan_snapshot_cache: dict[str, ScanSnapshot] = {}
+_scan_live_cache: dict[str, dict[str, tuple[int, int]]] = {}
+
+_TARGET_SUFFIXES = tuple(
+    sorted({*IMAGE_SUFFIXES, *VIDEO_SUFFIXES, *ARCHIVE_SUFFIXES, *AUDIO_SUFFIXES}, key=len, reverse=True)
+)
 
 # ---------------------------------------------------------------------------
 # 推荐分数内存缓存（避免每次 list 都查 DB）
@@ -423,6 +448,12 @@ def trigger_favorite_scan() -> None:
     threading.Thread(target=_run_scan, args=(resolved, True), daemon=True).start()
 
 
+def trigger_file_db_sync() -> None:
+    """启动时后台同步 file 表与真实文件系统（低优先级，不阻塞 API）。"""
+
+    threading.Thread(target=_sync_file_table_with_filesystem, daemon=True, name="file-db-sync").start()
+
+
 def _update_scan_status(path_key: str, **kwargs) -> None:
     with _scan_status_lock:
         current = _scan_status.get(path_key, {})
@@ -461,6 +492,10 @@ def _run_scan(path: Path, recursive: bool) -> None:
     scanned_files = 0
     parsed_files = 0
     scanned_filepaths: list[str] = []
+    live_snapshot: dict[str, tuple[int, int]] = {}
+
+    with _scan_snapshot_lock:
+        _scan_live_cache[path_key] = live_snapshot
 
     def _flush_scan_batch(repo: IndexRepository) -> None:
         nonlocal folders_to_upsert, files_to_upsert, parse_results
@@ -520,6 +555,7 @@ def _run_scan(path: Path, recursive: bool) -> None:
                             )
                         )
                         scanned_filepaths.append(str(file_path))
+                        live_snapshot[str(file_path)] = (int(stat.st_size), int(stat.st_mtime))
                         scanned_files += 1
 
                         parsed = parse(file_path.name)
@@ -601,6 +637,7 @@ def _run_scan(path: Path, recursive: bool) -> None:
                             )
                         )
                         scanned_filepaths.append(str(entry))
+                        live_snapshot[str(entry)] = (int(stat.st_size), int(stat.st_mtime))
                         scanned_files += 1
 
                         parsed = parse(entry.name)
@@ -671,6 +708,218 @@ def _run_scan(path: Path, recursive: bool) -> None:
             scanned_files=scanned_files,
             parsed_files=parsed_files,
             finished_at=int(time()),
+        )
+    finally:
+        with _scan_snapshot_lock:
+            current_live = _scan_live_cache.pop(path_key, live_snapshot)
+            _scan_snapshot_cache[path_key] = ScanSnapshot(
+                root=path_key,
+                recursive=recursive,
+                created_at=time(),
+                files=dict(current_live),
+            )
+
+
+def _is_target_extension(name: str) -> bool:
+    lowered = name.lower()
+    return any(lowered.endswith(suffix) for suffix in _TARGET_SUFFIXES)
+
+
+def _derive_minimal_root_dirs(filepaths: Iterable[str]) -> list[Path]:
+    """从 file 表路径推导最小覆盖目录集合（不向上扩展）。"""
+    dir_paths = sorted({str(Path(filepath).parent) for filepath in filepaths if filepath}, key=lambda x: (x.count(os.sep), x))
+    selected: list[Path] = []
+    for dir_path in dir_paths:
+        candidate = Path(dir_path)
+        if any(candidate == root or candidate.is_relative_to(root) for root in selected):
+            continue
+        selected.append(candidate)
+    return selected
+
+
+def _snapshot_covers_root(snapshot_root: str, root: Path) -> bool:
+    snapshot_path = Path(snapshot_root)
+    return root == snapshot_path or root.is_relative_to(snapshot_path)
+
+
+def _collect_cached_scan_for_root(root: Path) -> dict[str, tuple[int, int]] | None:
+    """复用已有扫描任务的 live/snapshot 结果，避免重复 IO。"""
+    now_ts = time()
+    with _scan_snapshot_lock:
+        for snapshot_root, live_map in _scan_live_cache.items():
+            if _snapshot_covers_root(snapshot_root, root):
+                prefix = str(root)
+                return {p: stat for p, stat in live_map.items() if p == prefix or p.startswith(prefix + os.sep)}
+
+        stale_keys = [k for k, s in _scan_snapshot_cache.items() if now_ts - s.created_at > _SCAN_SNAPSHOT_TTL_SEC]
+        for key in stale_keys:
+            _scan_snapshot_cache.pop(key, None)
+
+        for snapshot in _scan_snapshot_cache.values():
+            if _snapshot_covers_root(snapshot.root, root):
+                prefix = str(root)
+                return {p: stat for p, stat in snapshot.files.items() if p == prefix or p.startswith(prefix + os.sep)}
+    return None
+
+
+def _scan_root_with_scandir(root: Path) -> dict[str, tuple[int, int]]:
+    """使用 os.scandir 递归扫描目录，仅收集目标扩展文件。"""
+    files: dict[str, tuple[int, int]] = {}
+    pending: list[Path] = [root]
+    visited = 0
+
+    while pending:
+        current = pending.pop()
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    name = entry.name
+                    if entry.is_dir(follow_symlinks=False):
+                        if name.startswith(".") or should_ignore(name):
+                            continue
+                        pending.append(Path(entry.path))
+                        continue
+
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    if should_ignore(name) or not _is_target_extension(name):
+                        continue
+
+                    stat = entry.stat(follow_symlinks=False)
+                    files[entry.path] = (int(stat.st_size), int(stat.st_mtime))
+                    visited += 1
+                    if visited % _SYNC_LOW_PRIORITY_SLEEP_EVERY == 0:
+                        sleep(_SYNC_LOW_PRIORITY_SLEEP_SEC)
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            continue
+
+    with _scan_snapshot_lock:
+        _scan_snapshot_cache[str(root)] = ScanSnapshot(
+            root=str(root),
+            recursive=True,
+            created_at=time(),
+            files=dict(files),
+        )
+    return files
+
+
+def _sync_file_table_with_filesystem() -> None:
+    """同步 files 表与真实文件系统。真实文件系统是唯一真相。"""
+    started = time()
+    with get_index_session() as session:
+        repo = IndexRepository(session)
+        db_rows = list(session.exec(select(File.filepath, File.filesize, File.mtime, File.scan_state)).all())
+
+        if not db_rows:
+            logger.info("[file-sync] skip: no records in file table")
+            return
+
+        db_map: dict[str, tuple[int, int, int]] = {fp: (int(size), int(mtime), int(scan_state)) for fp, size, mtime, scan_state in db_rows}
+        root_dirs = _derive_minimal_root_dirs(db_map.keys())
+
+        real_map: dict[str, tuple[int, int]] = {}
+        for root_dir in root_dirs:
+            if not root_dir.exists() or not root_dir.is_dir():
+                continue
+
+            cached = _collect_cached_scan_for_root(root_dir)
+            if cached is not None:
+                real_map.update(cached)
+                continue
+
+            scanned = _scan_root_with_scandir(root_dir)
+            real_map.update(scanned)
+
+        db_paths = set(db_map.keys())
+        real_paths = set(real_map.keys())
+
+        new_paths = real_paths - db_paths
+        deleted_paths = db_paths - real_paths
+        common_paths = db_paths & real_paths
+
+        now_ts = int(time())
+        to_insert: list[dict[str, object]] = []
+        for filepath in new_paths:
+            path = Path(filepath)
+            size, mtime = real_map[filepath]
+            to_insert.append(
+                {
+                    "filepath": filepath,
+                    "folderpath": str(path.parent),
+                    "filename": path.name,
+                    "mtime": mtime,
+                    "filesize": size,
+                    "file_type": detect_file_type(path),
+                    "ext": path.suffix.lower() if path.suffix else None,
+                    "thumbnail_filepath": None,
+                    "fingerprint": f"{path.name}-{size}-{mtime}",
+                    "content_hash": None,
+                    "rec_score": 0.0,
+                    "scan_state": 1,
+                    "watch_state": 0,
+                    "first_seen_at": now_ts,
+                    "last_seen_at": now_ts,
+                    "last_scanned_at": now_ts,
+                    "created_at": now_ts,
+                    "updated_at": now_ts,
+                }
+            )
+
+        changed_paths = {
+            filepath
+            for filepath in common_paths
+            if db_map[filepath][0] != real_map[filepath][0] or db_map[filepath][1] != real_map[filepath][1]
+        }
+
+        to_update_changed: list[dict[str, object]] = []
+        for filepath in changed_paths:
+            path = Path(filepath)
+            size, mtime = real_map[filepath]
+            to_update_changed.append(
+                {
+                    "filepath": filepath,
+                    "folderpath": str(path.parent),
+                    "filename": path.name,
+                    "mtime": mtime,
+                    "filesize": size,
+                    "file_type": detect_file_type(path),
+                    "ext": path.suffix.lower() if path.suffix else None,
+                    "fingerprint": f"{path.name}-{size}-{mtime}",
+                    "scan_state": 1,
+                    "last_seen_at": now_ts,
+                    "last_scanned_at": now_ts,
+                    "updated_at": now_ts,
+                }
+            )
+
+        to_mark_deleted = [
+            {
+                "filepath": filepath,
+                "scan_state": 0,
+                "updated_at": now_ts,
+            }
+            for filepath in deleted_paths
+            if db_map[filepath][2] != 0
+        ]
+
+        if to_insert:
+            session.bulk_insert_mappings(File, to_insert)
+        if to_update_changed:
+            session.bulk_update_mappings(File, to_update_changed)
+        if to_mark_deleted:
+            session.bulk_update_mappings(File, to_mark_deleted)
+        if to_insert or to_update_changed or to_mark_deleted:
+            repo._commit()
+
+        elapsed = time() - started
+        logger.info(
+            "[file-sync] roots=%d scanned_files=%d new=%d deleted=%d changed=%d elapsed=%.3fs",
+            len(root_dirs),
+            len(real_map),
+            len(to_insert),
+            len(to_mark_deleted),
+            len(to_update_changed),
+            elapsed,
         )
 
 

--- a/backend/app/index_db/models.py
+++ b/backend/app/index_db/models.py
@@ -2,6 +2,15 @@ from __future__ import annotations
 
 from sqlmodel import Field, SQLModel
 
+# scan_state / watch_state 状态位约定：
+# - 0: inactive（当前不在该状态）
+# - 1: active（当前在该状态）
+#
+# scan_state: 是否在最近一次文件系统扫描中“确认存在/可见”
+# watch_state: 是否处于目录监听（watcher）覆盖范围
+STATE_INACTIVE = 0
+STATE_ACTIVE = 1
+
 
 def _ts_now() -> int:
     """统一的秒级时间戳默认值工厂。"""
@@ -13,49 +22,49 @@ def _ts_now() -> int:
 class Folder(SQLModel, table=True):
     __tablename__ = "folders"
 
-    filepath: str = Field(primary_key=True)
-    dirname: str
-    mtime: int | None = None
+    filepath: str = Field(primary_key=True)  # 目录绝对路径（主键）
+    dirname: str  # 目录名（basename）
+    mtime: int | None = None  # 目录最后修改时间（秒级 Unix 时间戳）
 
-    scan_state: int = Field(default=0)
-    watch_state: int = Field(default=0)
+    scan_state: int = Field(default=STATE_INACTIVE)  # 0=未确认存在，1=扫描确认存在
+    watch_state: int = Field(default=STATE_INACTIVE)  # 0=未监听，1=已在 watcher 监听范围
 
-    first_seen_at: int | None = None
-    last_seen_at: int | None = None
-    last_scanned_at: int | None = None
+    first_seen_at: int | None = None  # 首次被扫描发现时间
+    last_seen_at: int | None = None  # 最近一次“仍存在”确认时间
+    last_scanned_at: int | None = None  # 最近一次被主动扫描时间
 
-    created_at: int = Field(default_factory=_ts_now)
-    updated_at: int = Field(default_factory=_ts_now)
+    created_at: int = Field(default_factory=_ts_now)  # 记录创建时间
+    updated_at: int = Field(default_factory=_ts_now)  # 记录更新时间
 
 
 class File(SQLModel, table=True):
     __tablename__ = "files"
 
-    filepath: str = Field(primary_key=True)
-    folderpath: str | None = Field(default=None, foreign_key="folders.filepath")
+    filepath: str = Field(primary_key=True)  # 文件绝对路径（主键）
+    folderpath: str | None = Field(default=None, foreign_key="folders.filepath")  # 所属目录路径
 
-    filename: str
-    mtime: int
-    filesize: int
+    filename: str  # 文件名（basename）
+    mtime: int  # 文件最后修改时间（秒级 Unix 时间戳）
+    filesize: int  # 文件大小（字节）
 
-    file_type: str = Field(default="unknown")
-    ext: str | None = None
-    thumbnail_filepath: str | None = None
+    file_type: str = Field(default="unknown")  # 业务类型：image/video/archive/audio/unknown
+    ext: str | None = None  # 扩展名（小写，含点）
+    thumbnail_filepath: str | None = None  # 缩略图缓存路径（本地）
 
-    fingerprint: str
-    content_hash: str | None = None
+    fingerprint: str  # 轻量指纹（通常由 name-size-mtime 组成）
+    content_hash: str | None = None  # 内容哈希（可选；大多数流程不依赖）
 
-    rec_score: float = Field(default=0.0)
+    rec_score: float = Field(default=0.0)  # 推荐分数（用于排序）
 
-    scan_state: int = Field(default=0)
-    watch_state: int = Field(default=0)
+    scan_state: int = Field(default=STATE_INACTIVE)  # 0=未确认存在，1=扫描确认存在
+    watch_state: int = Field(default=STATE_INACTIVE)  # 0=未监听，1=已在 watcher 监听范围
 
-    first_seen_at: int | None = None
-    last_seen_at: int | None = None
-    last_scanned_at: int | None = None
+    first_seen_at: int | None = None  # 首次被扫描发现时间
+    last_seen_at: int | None = None  # 最近一次“仍存在”确认时间
+    last_scanned_at: int | None = None  # 最近一次被主动扫描时间
 
-    created_at: int = Field(default_factory=_ts_now)
-    updated_at: int = Field(default_factory=_ts_now)
+    created_at: int = Field(default_factory=_ts_now)  # 记录创建时间
+    updated_at: int = Field(default_factory=_ts_now)  # 记录更新时间
 
 
 class ArchiveMeta(SQLModel, table=True):
@@ -87,8 +96,8 @@ class VideoMeta(SQLModel, table=True):
     audio_channels: int | None = None
     sample_rate: int | None = None
 
-    has_subtitle: int = 0
-    scanned_at: int | None = None
+    has_subtitle: int = 0  # 0=无字幕，1=有字幕
+    scanned_at: int | None = None  # 视频元信息扫描时间
 
 
 class Progress(SQLModel, table=True):
@@ -100,16 +109,16 @@ class Progress(SQLModel, table=True):
     filesize: int | None = None
     mtime: int | None = None
     thumbnail_url: str | None = None
-    last_opened_at: int = Field(default_factory=_ts_now)
-    total_time_sec: float = 0
+    last_opened_at: int = Field(default_factory=_ts_now)  # 最近打开时间
+    total_time_sec: float = 0  # 累计阅读/播放时长（秒）
 
-    page_current: int | None = None
-    page_total: int | None = None
+    page_current: int | None = None  # 当前页（图像/文档）
+    page_total: int | None = None  # 总页数
 
-    position_sec: float | None = None
-    duration_sec: float | None = None
+    position_sec: float | None = None  # 当前播放位置（秒）
+    duration_sec: float | None = None  # 媒体总时长（秒）
 
-    updated_at: int = Field(default_factory=_ts_now)
+    updated_at: int = Field(default_factory=_ts_now)  # 进度更新时间
 
 
 class Tag(SQLModel, table=True):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import sys
 
 from app.api.main import api_router
-from app.api.routes.fs import clear_extract_cache, trigger_favorite_scan
+from app.api.routes.fs import clear_extract_cache, trigger_favorite_scan, trigger_file_db_sync
 from app.core.config import settings
 from app.index_db import ensure_index_db_initialized
 import logging
@@ -42,6 +42,7 @@ def startup_index_db() -> None:
     ensure_index_db_initialized()
     clear_extract_cache()
     trigger_favorite_scan()
+    trigger_file_db_sync()
 
 # Set all CORS enabled origins
 cors_options = {

--- a/backend/tests/api/routes/test_fs.py
+++ b/backend/tests/api/routes/test_fs.py
@@ -43,6 +43,8 @@ def client_with_root(test_fs_root: Path, monkeypatch: pytest.MonkeyPatch) -> Tes
 def reset_scan_state() -> None:
     fs_route._scan_status.clear()
     fs_route._active_watchers.clear()
+    fs_route._scan_live_cache.clear()
+    fs_route._scan_snapshot_cache.clear()
 
 
 def test_get_roots(client_with_root: TestClient, test_fs_root: Path) -> None:
@@ -881,3 +883,47 @@ def test_backfill_directory_non_recursive(
     # 不应扫描到 sub/nested.zip
     assert payload["scanned_files"] < 10
     assert payload["backfilled_meta"] >= 2
+
+
+def test_derive_minimal_root_dirs_removes_nested_dirs() -> None:
+    roots = fs_route._derive_minimal_root_dirs([
+        "/data/library/a/1.jpg",
+        "/data/library/a/sub/2.jpg",
+        "/data/library/b/3.jpg",
+    ])
+
+    assert roots == [Path('/data/library/a'), Path('/data/library/b')]
+
+
+def test_scan_root_with_scandir_skips_hidden_and_ignored(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "node_modules").mkdir()
+    (root / "node_modules" / "a.jpg").write_bytes(b"x")
+    (root / ".hidden").mkdir()
+    (root / ".hidden" / "b.jpg").write_bytes(b"x")
+    (root / "ok").mkdir()
+    (root / "ok" / "keep.jpg").write_bytes(b"x")
+    (root / "ok" / "skip.txt").write_text("x")
+
+    result = fs_route._scan_root_with_scandir(root)
+
+    assert str(root / "ok" / "keep.jpg") in result
+    assert str(root / "node_modules" / "a.jpg") not in result
+    assert str(root / ".hidden" / "b.jpg") not in result
+    assert str(root / "ok" / "skip.txt") not in result
+
+
+def test_collect_cached_scan_for_root_prefers_live_cache(tmp_path: Path) -> None:
+    root = tmp_path / "live"
+    root.mkdir()
+    file_a = root / "a.jpg"
+    file_a.write_bytes(b"x")
+
+    fs_route._scan_live_cache[str(root)] = {str(file_a): (1, 2)}
+    try:
+        result = fs_route._collect_cached_scan_for_root(root)
+        assert result == {str(file_a): (1, 2)}
+    finally:
+        fs_route._scan_live_cache.clear()
+        fs_route._scan_snapshot_cache.clear()

--- a/backend/tests/api/routes/test_fs.py
+++ b/backend/tests/api/routes/test_fs.py
@@ -927,3 +927,29 @@ def test_collect_cached_scan_for_root_prefers_live_cache(tmp_path: Path) -> None
     finally:
         fs_route._scan_live_cache.clear()
         fs_route._scan_snapshot_cache.clear()
+
+
+def test_should_update_existing_file_restores_deleted_state() -> None:
+    assert fs_route._should_update_existing_file(
+        db_size=100,
+        db_mtime=200,
+        db_scan_state=0,
+        real_size=100,
+        real_mtime=200,
+    ) is True
+
+
+def test_build_folder_sync_mappings_creates_missing_parent_rows() -> None:
+    now_ts = 123
+    to_insert, to_update = fs_route._build_folder_sync_mappings(
+        real_filepaths={"/data/new_dir/a.jpg", "/data/existing_dir/b.jpg"},
+        db_folder_paths={"/data/existing_dir"},
+        now_ts=now_ts,
+    )
+
+    inserted_paths = {item["filepath"] for item in to_insert}
+    assert "/data/new_dir" in inserted_paths
+    assert "/data/existing_dir" not in inserted_paths
+
+    updated_paths = {item["filepath"] for item in to_update}
+    assert "/data/existing_dir" in updated_paths


### PR DESCRIPTION
### Motivation

- 保证索引数据库的 `files` 表与真实文件系统一致，且以文件系统为唯一真相。 
- 启动时自动触发、后台低优先级运行，不阻塞 API 启动或已有实时扫描任务。 
- 尽量复用已有扫描结果以降低重复 IO 并实现 O(n) 同步复杂度。

### Description

- 在 `backend/app/api/routes/fs.py` 中新增同步子系统：增加 `ScanSnapshot` 缓存（live + snapshot + TTL），并在 `_run_scan` 期间收集 live snapshot，扫描结束时固化为 snapshot，供复用。 
- 新增最小根目录推导函数 `_derive_minimal_root_dirs()`，从 `files.filepath` 推导最小覆盖目录集合且不向上扩展。 
- 新增基于 `os.scandir` 的低优先级递归扫描函数 `_scan_root_with_scandir()`，会跳过隐藏/忽略目录整棵子树并只收集目标扩展名（image/video/archive/audio），并通过微小 `sleep` 让出 CPU。 
- 新增核心同步入口 `_sync_file_table_with_filesystem()`，实现一次性读取 DB、一次扫描（或复用 snapshot）、用集合差分得到 `new/deleted/common`，用 `size/mtime` 判定变更，使用 `bulk_insert_mappings` / `bulk_update_mappings` 批量写入并单次提交；删除采用 `scan_state=0` 标记。 
- 在应用 `startup` 中注册 `trigger_file_db_sync()`，以后台线程异步触发同步（文件：`backend/app/main.py`）。 

### Testing

- 新增 3 个单元测试位于 `backend/tests/api/routes/test_fs.py`：覆盖 `_derive_minimal_root_dirs`、`_scan_root_with_scandir` 的忽略规则与 `_collect_cached_scan_for_root` 的 live cache 优先行为，并在测试 fixture 中清理 live/snapshot cache。 
- 在当前容器中运行 `python -m compileall backend/app/main.py backend/app/api/routes/fs.py backend/tests/api/routes/test_fs.py` 编译通过。 
- 试图运行 `cd backend && pytest tests/api/routes/test_fs.py -q` 时因运行环境缺少依赖报错：`ModuleNotFoundError: No module named 'fastapi'`，因此完整 pytest 未能在此环境中执行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993620828bc83259b56b2aa13a36a76)