### PR TITLE
build: use frontend favicon as EXE icon (generate .ico fallback)

### DIFF
--- a/build_tools/build_exe.py
+++ b/build_tools/build_exe.py
@@ -9,6 +9,8 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent
 FRONTEND_DIR = PROJECT_ROOT / "frontend"
 DIST_DIR = PROJECT_ROOT / "dist"
+FAVICON_PNG = FRONTEND_DIR / "public" / "assets" / "images" / "favicon.png"
+FAVICON_ICO = PROJECT_ROOT / "build_tools" / "favicon.ico"
 
 
 def run_command(cmd, cwd=None):
@@ -66,6 +68,9 @@ def create_pyinstaller_spec():
     print("Creating PyInstaller spec...")
     print("=" * 60)
     
+    icon_path = resolve_exe_icon()
+    icon_value = repr(str(icon_path)) if icon_path else "None"
+
     spec_content = """# -*- mode: python ; coding: utf-8 -*-
 
 block_cipher = None
@@ -127,14 +132,35 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon=None,
+    icon=__ICON_VALUE__,
 )
 """
+    spec_content = spec_content.replace('__ICON_VALUE__', icon_value)
     
     spec_file = PROJECT_ROOT / "shigureader.spec"
     spec_file.write_text(spec_content)
     print(f"✓ Created spec file: {spec_file}")
     return spec_file
+
+
+def resolve_exe_icon():
+    """Resolve icon path for PyInstaller EXE packaging."""
+    if not FAVICON_PNG.exists():
+        print(f"! Icon source not found: {FAVICON_PNG}")
+        return None
+
+    # Prefer .ico for Windows executable icon.
+    try:
+        from PIL import Image
+
+        with Image.open(FAVICON_PNG) as img:
+            img.save(FAVICON_ICO, format="ICO", sizes=[(256, 256), (128, 128), (64, 64), (32, 32), (16, 16)])
+        print(f"✓ Using exe icon: {FAVICON_ICO}")
+        return FAVICON_ICO
+    except Exception as exc:
+        print(f"! Failed to convert png to ico ({exc}), fallback to png icon")
+        print(f"✓ Using exe icon: {FAVICON_PNG}")
+        return FAVICON_PNG
 
 
 def build_exe():


### PR DESCRIPTION
### Motivation
- 让打包生成的 `ShiguReader.exe` 使用前端项目的 favicon，统一应用图标并避免手动维护单独的 .ico 文件。

### Description
- 在 `build_tools/build_exe.py` 中新增 `FAVICON_PNG` 和 `FAVICON_ICO` 常量以定位前端 favicon 和目标 ico 路径。 
- 新增 `resolve_exe_icon()` 函数，优先使用 Pillow (`PIL`) 将 `frontend/public/assets/images/favicon.png` 转为 `build_tools/favicon.ico`，若转换失败则回退使用原始 PNG 路径。 
- 在 `create_pyinstaller_spec()` 中调用该解析函数并将返回的图标路径注入生成的 PyInstaller spec，使 `icon=` 字段指向解析后的图标路径。 
- 成功转换时会在仓库生成 `build_tools/favicon.ico`，无需在外部准备 .ico 文件即可获得 Windows 可执行文件图标。

### Testing
- 已运行 `python -m py_compile build_tools/build_exe.py`，编译检查通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993d71ee4f083259411eb39777ffd55)