### PR TITLE
feat(home): 添加最近活动与库总览支持

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,13 @@
       "preLaunchTask": "Install Backend Dependencies"
     },
     {
+      "name": "Backend: Update DB Schema",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "uv run python -c \"from app.index_db import ensure_index_db_initialized; ensure_index_db_initialized()\"",
+      "cwd": "${workspaceFolder}/backend"
+    },
+    {
       "name": "Backend: SQLite 一键解锁并启动",
       "type": "debugpy",
       "request": "launch",

--- a/backend/app/api/routes/fs.py
+++ b/backend/app/api/routes/fs.py
@@ -34,7 +34,7 @@ from app.file_processing.stepwise_extractor import stepwise_extract
 from app.index_db.confidence import compute_confidence
 from app.index_db.db import get_index_session
 from app.index_db.models import File, Folder
-from app.index_db.repository import IndexRepository, UpsertFileInput, UpsertFolderInput
+from app.index_db.repository import ActivityLogInput, IndexRepository, UpsertFileInput, UpsertFolderInput
 from app.services.thumb_service import ThumbService
 from app.utils import detect_file_type, get_mime_type
 
@@ -84,6 +84,22 @@ _rec_cache: dict[str, object] = {
 def _build_thumb_url(path: Path | str) -> str:
     encoded_path = quote(str(path), safe="")
     return f"{settings.API_V1_STR}/fs/thumb?path={encoded_path}"
+
+
+
+def _log_activity(activity_type: str, message: str, target_path: str | None = None) -> None:
+    try:
+        with get_index_session() as session:
+            repo = IndexRepository(session)
+            repo.log_activity(
+                ActivityLogInput(
+                    activity_type=activity_type,
+                    message=message,
+                    target_path=target_path,
+                )
+            )
+    except Exception as e:
+        logger.warning("log activity failed: %s", e)
 
 
 def _parse_roots() -> list[Path]:
@@ -246,6 +262,26 @@ class RenameRequest(BaseModel):
 class UnzipRequest(BaseModel):
     archive_path: str
     output_dir: str | None = None
+
+
+class ActivityItem(BaseModel):
+    id: int
+    activity_type: Literal["scan", "minify_zip_images", "move", "delete", "rename"]
+    message: str
+    target_path: str | None = None
+    created_at: int
+
+
+class RecentActivityResponse(BaseModel):
+    items: list[ActivityItem]
+
+
+class LibraryOverviewResponse(BaseModel):
+    archives: int
+    videos: int
+    images: int
+    audio: int
+    folders: int
 
 
 class PathOperationResponse(BaseModel):
@@ -1083,7 +1119,14 @@ def list_directory(
     
     if not validated_path.is_dir():
         raise HTTPException(status_code=400, detail="Path is not a directory")
-    
+
+    try:
+        with get_index_session() as session:
+            repo = IndexRepository(session)
+            repo.record_folder_open(str(validated_path))
+    except Exception as e:
+        logger.warning("record folder open failed for %s: %s", validated_path, e)
+
     items: list[FileSystemItem] = []
     folders_to_upsert: list[UpsertFolderInput] = []
     files_to_upsert: list[UpsertFileInput] = []
@@ -1385,6 +1428,7 @@ def move_file(request: MovePathRequest) -> PathOperationResponse:
         logger.warning("DB cleanup failed after move-file %s -> %s: %s", source, dest, e)
 
     _run_scan(dest.parent, False)
+    _log_activity("move", f"Moved file: {source.name} -> {dest.name}", str(dest))
     return PathOperationResponse(status="ok", message="File moved", path=str(source), dest_path=str(dest))
 
 
@@ -1424,6 +1468,7 @@ def move_folder(request: MovePathRequest) -> PathOperationResponse:
         logger.warning("DB cleanup failed after move-folder %s -> %s: %s", source, dest, e)
 
     _run_scan(dest, True)
+    _log_activity("move", f"Moved folder: {source.name} -> {dest.name}", str(dest))
     return PathOperationResponse(status="ok", message="Folder moved", path=str(source), dest_path=str(dest))
 
 
@@ -1458,6 +1503,7 @@ def delete_path(request: DeletePathRequest) -> PathOperationResponse:
         except Exception as e:
             logger.warning("DB cleanup failed after delete %s: %s", target, e)
 
+        _log_activity("delete", f"Deleted: {target.name}", str(target))
         return PathOperationResponse(status="ok", message=message, path=str(target))
     except PermissionError as e:
         operation = "delete file" if is_file_target else "delete folder"
@@ -1545,6 +1591,7 @@ def rename_path(request: RenameRequest) -> PathOperationResponse:
     else:
         _run_scan(dest.parent, False)
     
+    _log_activity("rename", f"Renamed: {source.name} -> {dest.name}", str(dest))
     return PathOperationResponse(status="ok", message="Renamed successfully", path=str(source), dest_path=str(dest))
 
 
@@ -1630,6 +1677,7 @@ async def scan_favorite(background_tasks: BackgroundTasks) -> ScanStartResponse:
         raise HTTPException(status_code=404, detail="Favorite directory not found")
 
     background_tasks.add_task(_run_scan, favorite_path, True)
+    _log_activity("scan", f"Started favorite scan: {favorite_path}", str(favorite_path))
     return ScanStartResponse(status="started", message="Favorite directory scan started", path=str(favorite_path))
 
 
@@ -1647,6 +1695,7 @@ async def scan_directory(background_tasks: BackgroundTasks, request: ScanRequest
         raise HTTPException(status_code=400, detail="Path is not a directory")
 
     background_tasks.add_task(_run_scan, validated_path, request.recursive)
+    _log_activity("scan", f"Started scan: {validated_path}", str(validated_path))
 
     return ScanStartResponse(
         status="started",
@@ -1844,6 +1893,7 @@ async def scan_and_watch(background_tasks: BackgroundTasks, request: ScanRequest
         finished_at=None,
     )
     background_tasks.add_task(_run_scan, validated_path, request.recursive)
+    _log_activity("scan", f"Started scan: {validated_path}", str(validated_path))
 
     return ScanStartResponse(
         status="started",
@@ -1864,6 +1914,41 @@ async def get_scan_status(path: str | None = Query(None, description="Optional p
             return [_build_scan_status_item(path, record)]
 
         return [_build_scan_status_item(path_key, record) for path_key, record in _scan_status.items()]
+
+
+# 接口说明：获取最近活动（默认10条）。
+@router.get("/recent-activity", response_model=RecentActivityResponse)
+def get_recent_activity(limit: int = Query(10, ge=1, le=50)) -> RecentActivityResponse:
+    with get_index_session() as session:
+        repo = IndexRepository(session)
+        rows = repo.list_activity_logs(limit=limit)
+
+    return RecentActivityResponse(
+        items=[
+            ActivityItem(
+                id=row.id or 0,
+                activity_type=row.activity_type,
+                message=row.message,
+                target_path=row.target_path,
+                created_at=row.created_at,
+            )
+            for row in rows
+        ]
+    )
+
+
+# 接口说明：获取全库总览统计。
+@router.get("/library-overview", response_model=LibraryOverviewResponse)
+def get_library_overview() -> LibraryOverviewResponse:
+    with get_index_session() as session:
+        repo = IndexRepository(session)
+        return LibraryOverviewResponse(
+            archives=repo.count_files_by_type("archive"),
+            videos=repo.count_files_by_type("video"),
+            images=repo.count_files_by_type("image"),
+            audio=repo.count_files_by_type("audio"),
+            folders=repo.count_folders(),
+        )
 
 
 # 接口说明：获取（或生成）文件缩略图。
@@ -2341,6 +2426,7 @@ async def compress_archive_images_endpoint(
             min_size=request.min_size,
         )
         
+        _log_activity("minify_zip_images", f"Minified archive images: {archive.name}", result.output_path)
         return CompressImagesResponse(
             success=result.success,
             original_path=result.original_path,

--- a/backend/app/file_processing/name_parser/parser.py
+++ b/backend/app/file_processing/name_parser/parser.py
@@ -151,6 +151,7 @@ def _parse_cosplay(text: str, b_matches: list[str], p_matches: list[str]) -> Par
         and t not in coser_set
         and not _classify_misc(t)
         and not is_useless_tag(t)
+        and not t.isdigit()
     ]
 
     # 去重保序
@@ -363,6 +364,7 @@ def parse(text: str) -> ParseResult | None:
         and t not in author_set
         and not is_useless_tag(t)
         and not is_media_type(t)
+        and not t.isdigit()
     ]
 
     # ------------------------------------------------------------------

--- a/backend/app/index_db/alembic/versions/20260217_0001_add_home_activity_tables.py
+++ b/backend/app/index_db/alembic/versions/20260217_0001_add_home_activity_tables.py
@@ -1,0 +1,46 @@
+"""add folder open history and activity logs
+
+Revision ID: 20260217_0001
+Revises: 20260215_0002
+Create Date: 2026-02-17 10:20:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260217_0001"
+down_revision = "20260215_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "folder_open_history",
+        sa.Column("folderpath", sa.String(), nullable=False),
+        sa.Column("last_opened_at", sa.Integer(), nullable=False),
+        sa.Column("open_count", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("updated_at", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["folderpath"], ["folders.filepath"]),
+        sa.PrimaryKeyConstraint("folderpath"),
+    )
+
+    op.create_table(
+        "activity_logs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("activity_type", sa.String(), nullable=False),
+        sa.Column("message", sa.String(), nullable=False),
+        sa.Column("target_path", sa.String(), nullable=True),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_activity_logs_created_at", "activity_logs", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_activity_logs_created_at", table_name="activity_logs")
+    op.drop_table("activity_logs")
+    op.drop_table("folder_open_history")

--- a/backend/app/index_db/models.py
+++ b/backend/app/index_db/models.py
@@ -100,6 +100,24 @@ class VideoMeta(SQLModel, table=True):
     scanned_at: int | None = None  # 视频元信息扫描时间
 
 
+class FolderOpenHistory(SQLModel, table=True):
+    __tablename__ = "folder_open_history"
+
+    folderpath: str = Field(primary_key=True, foreign_key="folders.filepath")
+    last_opened_at: int = Field(default_factory=_ts_now)
+    open_count: int = 1
+    updated_at: int = Field(default_factory=_ts_now)
+
+
+class ActivityLog(SQLModel, table=True):
+    __tablename__ = "activity_logs"
+
+    id: int | None = Field(default=None, primary_key=True)
+    activity_type: str
+    message: str
+    target_path: str | None = None
+    created_at: int = Field(default_factory=_ts_now)
+
 class Progress(SQLModel, table=True):
     __tablename__ = "progress"
 

--- a/backend/app/index_db/repository.py
+++ b/backend/app/index_db/repository.py
@@ -30,12 +30,14 @@ from sqlmodel import Session, func, select
 from app.index_db.db import index_write_guard
 from app.index_db.confidence import SCAN_FRESH_WINDOW_SEC
 from app.index_db.models import (
+    ActivityLog,
     ArchiveMeta,
     Artist,
     File,
     FileArtist,
     FileTag,
     Folder,
+    FolderOpenHistory,
     ParsedMetadata,
     Progress,
     Tag,
@@ -57,6 +59,14 @@ def _iter_chunks(items: list[T], chunk_size: int) -> Iterator[list[T]]:
     for i in range(0, len(items), chunk_size):
         yield items[i : i + chunk_size]
 
+
+
+
+@dataclass(slots=True)
+class ActivityLogInput:
+    activity_type: str
+    message: str
+    target_path: str | None = None
 
 @dataclass(slots=True)
 class UpsertFolderInput:
@@ -335,6 +345,54 @@ class IndexRepository:
         self._commit()
         self.session.refresh(meta)
         return meta
+
+    def record_folder_open(self, folderpath: str) -> FolderOpenHistory:
+        now = _now_ts()
+        row = self.session.get(FolderOpenHistory, folderpath)
+        if row is None:
+            row = FolderOpenHistory(
+                folderpath=folderpath,
+                last_opened_at=now,
+                open_count=1,
+                updated_at=now,
+            )
+            self.session.add(row)
+            self._commit()
+            self.session.refresh(row)
+            return row
+
+        row.last_opened_at = now
+        row.open_count += 1
+        row.updated_at = now
+        self.session.add(row)
+        self._commit()
+        self.session.refresh(row)
+        return row
+
+    def log_activity(self, data: ActivityLogInput) -> ActivityLog:
+        row = ActivityLog(
+            activity_type=data.activity_type,
+            message=data.message,
+            target_path=data.target_path,
+            created_at=_now_ts(),
+        )
+        self.session.add(row)
+        self._commit()
+        self.session.refresh(row)
+        return row
+
+    def list_activity_logs(self, limit: int = 10) -> list[ActivityLog]:
+        stmt = select(ActivityLog).order_by(ActivityLog.created_at.desc(), ActivityLog.id.desc()).limit(limit)
+        return list(self.session.exec(stmt).all())
+
+    def count_files_by_type(self, file_type: str) -> int:
+        stmt = select(func.count()).select_from(File).where(File.file_type == file_type).where(File.scan_state == 1)
+        return int(self.session.exec(stmt).one())
+
+    def count_folders(self) -> int:
+        stmt = select(func.count()).select_from(Folder).where(Folder.scan_state == 1)
+        return int(self.session.exec(stmt).one())
+
 
     def upsert_progress(
         self,

--- a/backend/tests/api/routes/test_fs.py
+++ b/backend/tests/api/routes/test_fs.py
@@ -12,6 +12,8 @@ from fastapi.testclient import TestClient
 from app.api.routes import fs as fs_route
 from app.core.config import settings
 from app.main import app
+from app.index_db.db import get_index_session
+from app.index_db.models import FolderOpenHistory
 
 
 @pytest.fixture
@@ -953,3 +955,36 @@ def test_build_folder_sync_mappings_creates_missing_parent_rows() -> None:
 
     updated_paths = {item["filepath"] for item in to_update}
     assert "/data/existing_dir" in updated_paths
+
+
+def test_list_directory_records_folder_open(client_with_root: TestClient, test_fs_root: Path) -> None:
+    response = client_with_root.get(f"/api/v1/fs/list?path={test_fs_root}")
+    assert response.status_code == 200
+
+    with get_index_session() as session:
+        row = session.get(FolderOpenHistory, str(test_fs_root))
+        assert row is not None
+        assert row.open_count >= 1
+
+
+def test_recent_activity_and_library_overview(client_with_root: TestClient, test_fs_root: Path) -> None:
+    (test_fs_root / "book.zip").write_bytes(b"zip")
+    (test_fs_root / "song.mp3").write_bytes(b"audio")
+
+    # 触发扫描并写入 activity
+    scan_resp = client_with_root.post(
+        "/api/v1/fs/scan",
+        json={"path": str(test_fs_root), "recursive": False},
+    )
+    assert scan_resp.status_code == 200
+
+    activity_resp = client_with_root.get("/api/v1/fs/recent-activity?limit=10")
+    assert activity_resp.status_code == 200
+    items = activity_resp.json()["items"]
+    assert len(items) >= 1
+    assert any(item["activity_type"] == "scan" for item in items)
+
+    overview_resp = client_with_root.get("/api/v1/fs/library-overview")
+    assert overview_resp.status_code == 200
+    payload = overview_resp.json()
+    assert set(payload.keys()) == {"archives", "videos", "images", "audio", "folders"}

--- a/backend/tests/file_processing/name_parser/test_parser.py
+++ b/backend/tests/file_processing/name_parser/test_parser.py
@@ -198,6 +198,16 @@ class TestTagExtraction:
         assert r is not None
         assert "修正版" not in r.raw_tags
 
+    def test_numeric_tags_filtered(self):
+        r = parse("[作者] 作品名 (131715678).zip")
+        assert r is not None
+        assert "131715678" not in r.raw_tags
+
+    def test_non_pure_numeric_tags_kept(self):
+        r = parse("[作者] 作品名 (C101).zip")
+        assert r is not None
+        assert "C101" in r.raw_tags or r.event == "C101"
+
 
 # ---------------------------------------------------------------------------
 # Title extraction

--- a/frontend/src/components/Home/HomeCard.tsx
+++ b/frontend/src/components/Home/HomeCard.tsx
@@ -1,0 +1,19 @@
+import { LucideIcon } from "lucide-react"
+
+interface HomeCardProps {
+    icon: LucideIcon
+    title: string
+    subtitle?: string
+}
+
+export function HomeCard({ icon: Icon, title, subtitle }: HomeCardProps) {
+    return (
+        <article className="home-card">
+            <Icon className="home-card__icon" />
+            <div className="home-card__content">
+                <div className="home-card__title" title={title}>{title}</div>
+                {subtitle && <div className="home-card__subtitle" title={subtitle}>{subtitle}</div>}
+            </div>
+        </article>
+    )
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -32,7 +32,9 @@
     "specialFolders": "Special Folders",
     "configuredDirs": "Configured Directories",
     "favorite": "Favorite",
-    "alreadyRead": "Already Read"
+    "alreadyRead": "Already Read",
+    "recentActivity": "Recent Activity",
+    "libraryOverview": "Library Overview"
   },
   "explorer": {
     "scan": "Scan",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -32,7 +32,9 @@
     "specialFolders": "特別フォルダー",
     "configuredDirs": "設定済みディレクトリ",
     "favorite": "お気に入り",
-    "alreadyRead": "既読"
+    "alreadyRead": "既読",
+    "recentActivity": "最近のアクティビティ",
+    "libraryOverview": "ライブラリ概要"
   },
   "explorer": {
     "scan": "スキャン",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -32,7 +32,9 @@
     "specialFolders": "特殊目录",
     "configuredDirs": "配置的目录",
     "favorite": "收藏",
-    "alreadyRead": "已读"
+    "alreadyRead": "已读",
+    "recentActivity": "最近活动",
+    "libraryOverview": "库总览"
   },
   "explorer": {
     "scan": "扫描",

--- a/frontend/src/routes/_layout/home.css
+++ b/frontend/src/routes/_layout/home.css
@@ -55,9 +55,19 @@
   flex-shrink: 0;
 }
 
+.home-card__content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .home-card__title {
   font-size: 14px;
   font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .home-card__subtitle {
@@ -104,36 +114,45 @@
   color: var(--muted-foreground);
 }
 
-.home-overview-grid {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-}
-
-.home-overview-card {
+.home-overview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
   border: 1px solid var(--border);
   border-radius: 10px;
+  background: var(--border);
+  overflow: hidden;
+}
+
+.home-overview-item {
   background: var(--background);
-  padding: 12px;
+  padding: 12px 16px;
   display: flex;
-  gap: 8px;
+  justify-content: space-between;
   align-items: center;
 }
 
-.home-overview-card__icon {
+.home-overview-item__label-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.home-overview-item__icon {
   width: 18px;
   height: 18px;
   color: var(--muted-foreground);
 }
 
-.home-overview-card__label {
-  color: var(--muted-foreground);
-  font-size: 12px;
+.home-overview-item__label {
+  font-size: 14px;
+  color: var(--foreground);
 }
 
-.home-overview-card__value {
-  font-size: 22px;
-  font-weight: 700;
+.home-overview-item__value {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--primary);
 }
 
 .home-empty {

--- a/frontend/src/routes/_layout/home.css
+++ b/frontend/src/routes/_layout/home.css
@@ -1,0 +1,142 @@
+.home-page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.home-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.home-section__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.home-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.home-grid--drives {
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.home-grid--folders {
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.home-card-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.home-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--background);
+  padding: 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.home-card:hover {
+  background: var(--accent);
+}
+
+.home-card__icon {
+  width: 20px;
+  height: 20px;
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+}
+
+.home-card__title {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.home-card__subtitle {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.home-panel {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--background);
+  padding: 8px;
+}
+
+.home-activity-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 8px;
+}
+
+.home-activity-item + .home-activity-item {
+  border-top: 1px solid var(--border);
+}
+
+.home-activity-item__icon {
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  color: var(--muted-foreground);
+}
+
+.home-activity-item__message {
+  font-size: 14px;
+}
+
+.home-activity-item__meta {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+
+.home-overview-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+}
+
+.home-overview-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--background);
+  padding: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.home-overview-card__icon {
+  width: 18px;
+  height: 18px;
+  color: var(--muted-foreground);
+}
+
+.home-overview-card__label {
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.home-overview-card__value {
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.home-empty {
+  color: var(--muted-foreground);
+  font-size: 13px;
+}

--- a/frontend/src/routes/_layout/index.tsx
+++ b/frontend/src/routes/_layout/index.tsx
@@ -1,11 +1,33 @@
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { Folder, HardDrive, Heart } from "lucide-react"
+import { Folder, HardDrive, Heart, History, BookOpen, Film, Image, Music2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { FilesystemService, OpenAPI } from "@/client"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Skeleton } from "@/components/ui/skeleton"
+
+import "./home.css"
+
+type ActivityType = "scan" | "minify_zip_images" | "move" | "delete" | "rename"
+
+type ActivityItem = {
+  id: number
+  activity_type: ActivityType
+  message: string
+  target_path: string | null
+  created_at: number
+}
+
+type RecentActivityResponse = {
+  items: ActivityItem[]
+}
+
+type LibraryOverviewResponse = {
+  archives: number
+  videos: number
+  images: number
+  audio: number
+  folders: number
+}
 
 export const Route = createFileRoute("/_layout/")({
   component: Dashboard,
@@ -48,130 +70,120 @@ function Dashboard() {
     },
   })
 
+  const { data: recentActivity } = useQuery({
+    queryKey: ["home-recent-activity"],
+    queryFn: async (): Promise<RecentActivityResponse> => {
+      const response = await fetch(`${OpenAPI.BASE}/api/v1/fs/recent-activity?limit=10`)
+      if (!response.ok) {
+        return { items: [] }
+      }
+      return response.json()
+    },
+  })
+
+  const { data: libraryOverview } = useQuery({
+    queryKey: ["home-library-overview"],
+    queryFn: async (): Promise<LibraryOverviewResponse | null> => {
+      const response = await fetch(`${OpenAPI.BASE}/api/v1/fs/library-overview`)
+      if (!response.ok) return null
+      return response.json()
+    },
+  })
+
   return (
-    <div className="space-y-6">
-      {/* Drives Section */}
-      {drives && drives.length > 0 && (
-        <div>
-          <h2 className="text-lg font-semibold mb-3">{t("home.drives")}</h2>
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+    <div className="home-page">
+      {drives && drives.length > 0 ? (
+        <section className="home-section">
+          <h2 className="home-section__title">{t("home.drives")}</h2>
+          <div className="home-grid home-grid--drives">
             {drives.map((drive) => (
-              <Link
-                key={drive.path}
-                to="/explorer"
-                search={{ path: drive.path }}
-                className="transition-transform hover:scale-[1.02]"
-              >
-                <Card className="cursor-pointer hover:border-primary">
-                  <CardHeader className="flex flex-row items-center gap-4">
-                    <div className="flex size-12 items-center justify-center rounded-lg bg-primary/10">
-                      <HardDrive className="size-6 text-primary" />
-                    </div>
-                    <CardTitle className="text-lg">{drive.dirname}</CardTitle>
-                  </CardHeader>
-                </Card>
+              <Link key={drive.path} to="/explorer" search={{ path: drive.path }} className="home-card-link">
+                <article className="home-card">
+                  <HardDrive className="home-card__icon" />
+                  <div>
+                    <div className="home-card__title">{drive.dirname}</div>
+                    <div className="home-card__subtitle">{drive.path}</div>
+                  </div>
+                </article>
               </Link>
             ))}
           </div>
-        </div>
-      )}
+        </section>
+      ) : null}
 
-      {/* Configured Roots Section */}
-      <div>
-        <h2 className="text-lg font-semibold mb-3">
-          {t("home.specialFolders")}
-        </h2>
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 mb-6">
+      <section className="home-section">
+        <h2 className="home-section__title">{t("home.specialFolders")}</h2>
+        <div className="home-grid home-grid--folders">
           {favoriteRoot ? (
-            <Link
-              key={`favorite-${favoriteRoot.path}`}
-              to="/explorer"
-              search={{ path: favoriteRoot.path }}
-              className="transition-transform hover:scale-[1.02]"
-            >
-              <Card className="cursor-pointer border-primary/40 hover:border-primary">
-                <CardHeader className="flex flex-row items-center gap-4">
-                  <div className="flex size-12 items-center justify-center rounded-lg bg-primary/10">
-                    <Heart className="size-6 text-primary" />
-                  </div>
-                  <CardTitle className="text-lg">
-                    {t("home.favorite")} · {favoriteRoot.dirname}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-muted-foreground truncate">
-                    {favoriteRoot.path}
-                  </p>
-                </CardContent>
-              </Card>
+            <Link to="/explorer" search={{ path: favoriteRoot.path }} className="home-card-link">
+              <article className="home-card">
+                <Heart className="home-card__icon" />
+                <div>
+                  <div className="home-card__title">{t("home.favorite")} · {favoriteRoot.dirname}</div>
+                  <div className="home-card__subtitle">{favoriteRoot.path}</div>
+                </div>
+              </article>
             </Link>
           ) : null}
 
           {alreadyReadRoot ? (
-            <Link
-              key={`already-read-${alreadyReadRoot.path}`}
-              to="/explorer"
-              search={{ path: alreadyReadRoot.path }}
-              className="transition-transform hover:scale-[1.02]"
-            >
-              <Card className="cursor-pointer border-primary/40 hover:border-primary">
-                <CardHeader className="flex flex-row items-center gap-4">
-                  <div className="flex size-12 items-center justify-center rounded-lg bg-primary/10">
-                    <Folder className="size-6 text-primary" />
-                  </div>
-                  <CardTitle className="text-lg">
-                    {t("home.alreadyRead")} · {alreadyReadRoot.dirname}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-muted-foreground truncate">
-                    {alreadyReadRoot.path}
-                  </p>
-                </CardContent>
-              </Card>
+            <Link to="/explorer" search={{ path: alreadyReadRoot.path }} className="home-card-link">
+              <article className="home-card">
+                <Folder className="home-card__icon" />
+                <div>
+                  <div className="home-card__title">{t("home.alreadyRead")} · {alreadyReadRoot.dirname}</div>
+                  <div className="home-card__subtitle">{alreadyReadRoot.path}</div>
+                </div>
+              </article>
             </Link>
           ) : null}
         </div>
+      </section>
 
-        <h2 className="text-lg font-semibold mb-3">
-          {t("home.configuredDirs")}
-        </h2>
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {isLoading
-            ? [1, 2, 3].map((i) => (
-                <Card key={i}>
-                  <CardHeader>
-                    <Skeleton className="h-6 w-3/4" />
-                  </CardHeader>
-                  <CardContent>
-                    <Skeleton className="h-4 w-full" />
-                  </CardContent>
-                </Card>
-              ))
-            : roots?.map((root) => (
-                <Link
-                  key={root.path}
-                  to="/explorer"
-                  search={{ path: root.path }}
-                  className="transition-transform hover:scale-[1.02]"
-                >
-                  <Card className="cursor-pointer hover:border-primary">
-                    <CardHeader className="flex flex-row items-center gap-4">
-                      <div className="flex size-12 items-center justify-center rounded-lg bg-primary/10">
-                        <Folder className="size-6 text-primary" />
-                      </div>
-                      <CardTitle className="text-lg">{root.dirname}</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      <p className="text-sm text-muted-foreground truncate">
-                        {root.path}
-                      </p>
-                    </CardContent>
-                  </Card>
-                </Link>
-              ))}
+      <section className="home-section">
+        <h2 className="home-section__title">{t("home.configuredDirs")}</h2>
+        <div className="home-grid home-grid--folders">
+          {isLoading ? <div className="home-empty">{t("common.loading")}</div> : null}
+          {roots?.map((root) => (
+            <Link key={root.path} to="/explorer" search={{ path: root.path }} className="home-card-link">
+              <article className="home-card">
+                <Folder className="home-card__icon" />
+                <div>
+                  <div className="home-card__title">{root.dirname}</div>
+                  <div className="home-card__subtitle">{root.path}</div>
+                </div>
+              </article>
+            </Link>
+          ))}
         </div>
-      </div>
+      </section>
+
+      <section className="home-section">
+        <h2 className="home-section__title">{t("home.recentActivity")}</h2>
+        <div className="home-panel">
+          {(recentActivity?.items ?? []).length === 0 ? <div className="home-empty">{t("common.noData")}</div> : null}
+          {recentActivity?.items.map((item) => (
+            <div key={item.id} className="home-activity-item">
+              <History className="home-activity-item__icon" />
+              <div className="home-activity-item__content">
+                <div className="home-activity-item__message">{item.message}</div>
+                <div className="home-activity-item__meta">{new Date(item.created_at * 1000).toLocaleString()}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="home-section">
+        <h2 className="home-section__title">{t("home.libraryOverview")}</h2>
+        <div className="home-overview-grid">
+          <article className="home-overview-card"><BookOpen className="home-overview-card__icon" /><div><div className="home-overview-card__label">Archives</div><div className="home-overview-card__value">{libraryOverview?.archives ?? 0}</div></div></article>
+          <article className="home-overview-card"><Film className="home-overview-card__icon" /><div><div className="home-overview-card__label">Videos</div><div className="home-overview-card__value">{libraryOverview?.videos ?? 0}</div></div></article>
+          <article className="home-overview-card"><Image className="home-overview-card__icon" /><div><div className="home-overview-card__label">Images</div><div className="home-overview-card__value">{libraryOverview?.images ?? 0}</div></div></article>
+          <article className="home-overview-card"><Music2 className="home-overview-card__icon" /><div><div className="home-overview-card__label">Audio</div><div className="home-overview-card__value">{libraryOverview?.audio ?? 0}</div></div></article>
+          <article className="home-overview-card"><Folder className="home-overview-card__icon" /><div><div className="home-overview-card__label">Folders</div><div className="home-overview-card__value">{libraryOverview?.folders ?? 0}</div></div></article>
+        </div>
+      </section>
     </div>
   )
 }

--- a/frontend/src/routes/_layout/index.tsx
+++ b/frontend/src/routes/_layout/index.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from "react-i18next"
 
 import { FilesystemService, OpenAPI } from "@/client"
 
+import { HomeCard } from "@/components/Home/HomeCard"
+
 import "./home.css"
 
 type ActivityType = "scan" | "minify_zip_images" | "move" | "delete" | "rename"
@@ -98,13 +100,7 @@ function Dashboard() {
           <div className="home-grid home-grid--drives">
             {drives.map((drive) => (
               <Link key={drive.path} to="/explorer" search={{ path: drive.path }} className="home-card-link">
-                <article className="home-card">
-                  <HardDrive className="home-card__icon" />
-                  <div>
-                    <div className="home-card__title">{drive.dirname}</div>
-                    <div className="home-card__subtitle">{drive.path}</div>
-                  </div>
-                </article>
+                <HomeCard icon={HardDrive} title={drive.dirname} />
               </Link>
             ))}
           </div>
@@ -116,43 +112,26 @@ function Dashboard() {
         <div className="home-grid home-grid--folders">
           {favoriteRoot ? (
             <Link to="/explorer" search={{ path: favoriteRoot.path }} className="home-card-link">
-              <article className="home-card">
-                <Heart className="home-card__icon" />
-                <div>
-                  <div className="home-card__title">{t("home.favorite")} · {favoriteRoot.dirname}</div>
-                  <div className="home-card__subtitle">{favoriteRoot.path}</div>
-                </div>
-              </article>
+              <HomeCard icon={Heart} title={favoriteRoot.dirname} />
             </Link>
           ) : null}
 
           {alreadyReadRoot ? (
             <Link to="/explorer" search={{ path: alreadyReadRoot.path }} className="home-card-link">
-              <article className="home-card">
-                <Folder className="home-card__icon" />
-                <div>
-                  <div className="home-card__title">{t("home.alreadyRead")} · {alreadyReadRoot.dirname}</div>
-                  <div className="home-card__subtitle">{alreadyReadRoot.path}</div>
-                </div>
-              </article>
+              <HomeCard icon={Folder} title={alreadyReadRoot.dirname} />
             </Link>
           ) : null}
         </div>
       </section>
 
+      {/* 快捷访问 */}
       <section className="home-section">
-        <h2 className="home-section__title">{t("home.configuredDirs")}</h2>
+        <h2 className="home-section__title">{t("settings.fsRoots")}</h2>
         <div className="home-grid home-grid--folders">
           {isLoading ? <div className="home-empty">{t("common.loading")}</div> : null}
           {roots?.map((root) => (
             <Link key={root.path} to="/explorer" search={{ path: root.path }} className="home-card-link">
-              <article className="home-card">
-                <Folder className="home-card__icon" />
-                <div>
-                  <div className="home-card__title">{root.dirname}</div>
-                  <div className="home-card__subtitle">{root.path}</div>
-                </div>
-              </article>
+              <HomeCard icon={Folder} title={root.dirname} />
             </Link>
           ))}
         </div>
@@ -176,12 +155,42 @@ function Dashboard() {
 
       <section className="home-section">
         <h2 className="home-section__title">{t("home.libraryOverview")}</h2>
-        <div className="home-overview-grid">
-          <article className="home-overview-card"><BookOpen className="home-overview-card__icon" /><div><div className="home-overview-card__label">Archives</div><div className="home-overview-card__value">{libraryOverview?.archives ?? 0}</div></div></article>
-          <article className="home-overview-card"><Film className="home-overview-card__icon" /><div><div className="home-overview-card__label">Videos</div><div className="home-overview-card__value">{libraryOverview?.videos ?? 0}</div></div></article>
-          <article className="home-overview-card"><Image className="home-overview-card__icon" /><div><div className="home-overview-card__label">Images</div><div className="home-overview-card__value">{libraryOverview?.images ?? 0}</div></div></article>
-          <article className="home-overview-card"><Music2 className="home-overview-card__icon" /><div><div className="home-overview-card__label">Audio</div><div className="home-overview-card__value">{libraryOverview?.audio ?? 0}</div></div></article>
-          <article className="home-overview-card"><Folder className="home-overview-card__icon" /><div><div className="home-overview-card__label">Folders</div><div className="home-overview-card__value">{libraryOverview?.folders ?? 0}</div></div></article>
+        <div className="home-overview-list">
+          <div className="home-overview-item">
+            <div className="home-overview-item__label-group">
+              <BookOpen className="home-overview-item__icon" />
+              <span className="home-overview-item__label">Archives</span>
+            </div>
+            <span className="home-overview-item__value">{libraryOverview?.archives ?? 0}</span>
+          </div>
+          <div className="home-overview-item">
+            <div className="home-overview-item__label-group">
+              <Film className="home-overview-item__icon" />
+              <span className="home-overview-item__label">Videos</span>
+            </div>
+            <span className="home-overview-item__value">{libraryOverview?.videos ?? 0}</span>
+          </div>
+          <div className="home-overview-item">
+            <div className="home-overview-item__label-group">
+              <Image className="home-overview-item__icon" />
+              <span className="home-overview-item__label">Images</span>
+            </div>
+            <span className="home-overview-item__value">{libraryOverview?.images ?? 0}</span>
+          </div>
+          <div className="home-overview-item">
+            <div className="home-overview-item__label-group">
+              <Music2 className="home-overview-item__icon" />
+              <span className="home-overview-item__label">Audio</span>
+            </div>
+            <span className="home-overview-item__value">{libraryOverview?.audio ?? 0}</span>
+          </div>
+          <div className="home-overview-item">
+            <div className="home-overview-item__label-group">
+              <Folder className="home-overview-item__icon" />
+              <span className="home-overview-item__label">Folders</span>
+            </div>
+            <span className="home-overview-item__value">{libraryOverview?.folders ?? 0}</span>
+          </div>
         </div>
       </section>
     </div>

--- a/frontend/src/routes/_layout/settings.tsx
+++ b/frontend/src/routes/_layout/settings.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Pencil, Trash2, Plus, RotateCcw } from "lucide-react"
+import { Trash2, Plus, RotateCcw } from "lucide-react"
 
 import { OpenAPI } from "@/client"
 import { Button } from "@/components/ui/button"
@@ -110,12 +110,8 @@ function SinglePathSection({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onBlur={onSave}
-          className="single-path-row__input"
         />
         <div className="single-path-row__actions">
-          <Button variant="ghost" size="icon-sm" onClick={onSave} aria-label="save">
-            <Pencil className="h-4 w-4" />
-          </Button>
           <Button variant="ghost" size="sm" onClick={onReset}>
             {value.trim() ? (
               <>
@@ -345,7 +341,7 @@ function SettingsPage() {
               <div className="path-table__header">
                 <span>#</span>
                 <span>{t("settings.path")}</span>
-                <span>{`${t("common.edit")}/${t("common.delete")}`}</span>
+                <span>{t("common.delete")}</span>
               </div>
 
               <div className="path-table__body">
@@ -361,15 +357,6 @@ function SettingsPage() {
                       className="path-row__input"
                     />
                     <div className="path-row__actions">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={saveFsRootsIfChanged}
-                        aria-label="save"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
                       <Button
                         type="button"
                         variant="ghost"


### PR DESCRIPTION
### Motivation
- 为 Home 页面提供后端数据能力：记录最近活动与目录打开历史，并统计全库的 `images`/`audio` 等，不新增单一聚合 `home-overview` 接口以保持多请求方案。 
- 前端按要求使用朴素风格（不使用 Tailwind），显示最近 10 条活动与库总览指标。 

### Description
- 数据库模型与迁移：新增 `FolderOpenHistory` 与 `ActivityLog` 模型并添加 Alembic 迁移 `20260217_0001_add_home_activity_tables.py`。 
- Repository 层扩展：新增 `record_folder_open`、`log_activity`、`list_activity_logs`、`count_files_by_type` 与 `count_folders` 接口用于写入与统计。 
- 后端路由变更：在 `GET /api/v1/fs/list` 自动记录 folder open，并在 `scan`/`scan-watch`/`scan-favorite`、`/archive/compress-images`、`move`/`move-folder`/`delete`/`rename` 等操作中写入活动日志，新增接口 `GET /api/v1/fs/recent-activity?limit=` 与 `GET /api/v1/fs/library-overview`（返回 archives/videos/images/audio/folders）。 
- 前端改动：重写 Home 页面为纯 CSS 实现（新增 `frontend/src/routes/_layout/home.css`）并在 `frontend/src/routes/_layout/index.tsx` 中接入 `recent-activity`（默认 10 条）和 `library-overview` 数据，且更新 i18n 文案键（`recentActivity`、`libraryOverview`）。 
- 测试：新增后端路由测试以验证 `list` 会记录目录打开历史以及新接口的基本返回。 

### Testing
- 已运行 `python -m compileall backend/app`，代码编译检查通过。 
- 运行 `pytest backend/tests/api/routes/test_fs.py -q` 未能完成，因运行环境缺少 Python 依赖 `fastapi`（测试未执行）。 
- 前端检查命令 `bun run lint` 与 `bun run dev` 未通过，因环境缺少前端工具依赖（`biome` / `vite`），因此前端 lint 与本地 dev 未能在此环境执行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699438f965bc8325a452cd58c9eafbfb)