### PR TITLE
Codex-generated pull request

### DIFF
--- a/backend/app/file_processing/name_parser/parser.py
+++ b/backend/app/file_processing/name_parser/parser.py
@@ -86,6 +86,26 @@ def _normalize_person_name(token: str) -> str:
     return name.strip(" -_")
 
 
+
+
+def _normalize_cosers_by_db(candidates: list[str]) -> list[str]:
+    """Keep only coser names that can be mapped by coser DB (main name / alias)."""
+    if not candidates:
+        return []
+
+    try:
+        from app.file_processing.name_parser.coser_db import lookup_coser
+    except Exception:
+        return []
+
+    normalized: list[str] = []
+    for name in candidates:
+        mapped = lookup_coser(name)
+        if mapped:
+            normalized.append(mapped)
+
+    return list(dict.fromkeys(normalized))
+
 def _parse_cosplay(text: str, b_matches: list[str], p_matches: list[str]) -> ParseResult | None:
     """Cosplay filename parser.
     """
@@ -158,18 +178,8 @@ def _parse_cosplay(text: str, b_matches: list[str], p_matches: list[str]) -> Par
     cosers = list(dict.fromkeys(cosers))
     raw_tags = list(dict.fromkeys(raw_tags))
 
-    # 标准化 coser 名字（使用数据库查找）
-    # 直接从原始文本中用 Aho-Corasick 查找，避免循环
-    try:
-        from app.file_processing.name_parser.coser_db import find_cosers_in_text
-        # 从原始文本中查找所有匹配的coser（比循环快得多）
-        db_cosers = find_cosers_in_text(text)
-        if db_cosers:
-            # 如果数据库找到了coser，使用数据库结果
-            cosers = db_cosers
-    except Exception:
-        # 如果数据库不存在或出错，保持原解析结果
-        pass
+    # 只保留名单内（主名/别名可映射）的 coser，避免误识别漫画家名
+    cosers = _normalize_cosers_by_db(cosers)
 
     title = _BRACKET_RE.sub("", text)
     title = _PAREN_RE.sub("", title)

--- a/backend/tests/file_processing/name_parser/test_parser.py
+++ b/backend/tests/file_processing/name_parser/test_parser.py
@@ -289,3 +289,26 @@ class TestRealWorldFilenames:
         assert r is not None
         assert r.type == "成年コミック"
         assert r.authors == ["作者名"]
+
+
+class TestCosplayCoserNormalization:
+    def test_only_keep_cosers_in_db(self, monkeypatch: pytest.MonkeyPatch):
+        from app.file_processing.name_parser import coser_db
+
+        mapping = {
+            "RealCoser": "RealCoser",
+            "RC": "RealCoser",
+        }
+        monkeypatch.setattr(coser_db, "lookup_coser", lambda name: mapping.get(name))
+
+        r = parse("[Cosplay] [RealCoser] [武田弘光] Set.zip")
+        assert r is not None
+        assert r.cosers == ["RealCoser"]
+
+    def test_no_db_match_results_in_no_coser(self, monkeypatch: pytest.MonkeyPatch):
+        from app.file_processing.name_parser import coser_db
+
+        monkeypatch.setattr(coser_db, "lookup_coser", lambda _name: None)
+
+        r = parse("[Cosplay] [武田弘光] Set.zip")
+        assert r is None or r.cosers == []

--- a/frontend/src/components/Common/PathBreadcrumb.tsx
+++ b/frontend/src/components/Common/PathBreadcrumb.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import { ChevronRight, Folder, Home } from "lucide-react"
 import type { MouseEvent, ReactNode } from "react"
+import { toast } from "sonner"
 
 import { joinPath, splitPath } from "@/lib/path-utils"
 import { cn } from "@/lib/utils"
@@ -29,6 +30,7 @@ async function copyText(text: string) {
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)
+    toast.success("已复制", { position: "top-right" })
   } catch {
     const el = document.createElement("textarea")
     el.value = text
@@ -39,6 +41,7 @@ async function copyText(text: string) {
     el.select()
     document.execCommand("copy")
     document.body.removeChild(el)
+    toast.success("已复制", { position: "top-right" })
   }
 }
 

--- a/frontend/src/components/Common/PathBreadcrumb.tsx
+++ b/frontend/src/components/Common/PathBreadcrumb.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router"
 import { ChevronRight, Folder, Home } from "lucide-react"
-import type { ReactNode } from "react"
+import type { MouseEvent, ReactNode } from "react"
 
 import { joinPath, splitPath } from "@/lib/path-utils"
 import { cn } from "@/lib/utils"
@@ -14,6 +14,32 @@ type ExtraCrumb = {
   className?: string
   wrapperClassName?: string
   icon?: ReactNode
+}
+
+
+
+function getTitleText(value: ReactNode): string | undefined {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value)
+  }
+  return undefined
+}
+
+async function copyText(text: string) {
+  if (!text) return
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch {
+    const el = document.createElement("textarea")
+    el.value = text
+    el.setAttribute("readonly", "")
+    el.style.position = "fixed"
+    el.style.opacity = "0"
+    document.body.appendChild(el)
+    el.select()
+    document.execCommand("copy")
+    document.body.removeChild(el)
+  }
 }
 
 interface PathBreadcrumbProps {
@@ -104,6 +130,7 @@ export function PathBreadcrumb({
             to={dirTo}
             search={{ path: crumb.path }}
             className={dirLinkClassName}
+            title={crumb.name}
           >
             {showFolderIcon ? <Folder className={folderIconClassName} /> : null}
             {crumb.name}
@@ -128,11 +155,12 @@ export function PathBreadcrumb({
                 to={crumb.to}
                 search={crumb.search}
                 className={extraClassName}
+                title={getTitleText(crumb.label)}
               >
                 {content}
               </Link>
             ) : (
-              <span className={extraClassName}>{content}</span>
+              <span className={extraClassName} title={getTitleText(crumb.label)}>{content}</span>
             )}
           </div>
         )
@@ -145,12 +173,23 @@ export function PathBreadcrumb({
             <Link
               to={currentTo}
               search={currentSearch}
-              className={currentClassName}
+              className={cn(currentClassName, "cursor-copy")}
+              title={getTitleText(currentLabel)}
+              onClick={(e: MouseEvent<HTMLAnchorElement>) => {
+                e.preventDefault()
+                copyText(getTitleText(currentLabel) ?? "")
+              }}
             >
               {currentLabel}
             </Link>
           ) : (
-            <span className={currentClassName}>{currentLabel}</span>
+            <span
+              className={cn(currentClassName, "cursor-copy")}
+              title={getTitleText(currentLabel)}
+              onClick={() => copyText(getTitleText(currentLabel) ?? "")}
+            >
+              {currentLabel}
+            </span>
           )}
         </>
       ) : null}

--- a/frontend/src/components/Common/SortDirectionToggle.tsx
+++ b/frontend/src/components/Common/SortDirectionToggle.tsx
@@ -1,0 +1,34 @@
+import { ArrowDown, ArrowUp } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+
+type SortDirection = "asc" | "desc"
+
+export function SortDirectionToggle({
+  value,
+  onToggle,
+  title,
+  className,
+}: {
+  value: SortDirection
+  onToggle: () => void
+  title?: string
+  className?: string
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onToggle}
+      className={className ?? "h-8 w-8 p-0"}
+      title={title}
+      aria-label={title ?? "Toggle sort direction"}
+    >
+      {value === "asc" ? (
+        <ArrowUp className="size-4" />
+      ) : (
+        <ArrowDown className="size-4" />
+      )}
+    </Button>
+  )
+}

--- a/frontend/src/components/Files/FileViewContainer.tsx
+++ b/frontend/src/components/Files/FileViewContainer.tsx
@@ -1,5 +1,5 @@
 // 文件视图容器 — 集成选择、右键菜单、键盘快捷键、对话框
-import { ArrowDown, ArrowUp, LayoutGrid, LayoutList, List } from "lucide-react"
+import { LayoutGrid, LayoutList, List } from "lucide-react"
 import { Link } from "@tanstack/react-router"
 import {
   type ReactNode,
@@ -16,6 +16,7 @@ import {
   Toolbar,
   ToolbarGroup,
 } from "@/components/semantic/layout"
+import { SortDirectionToggle } from "@/components/Common/SortDirectionToggle"
 import { Button } from "@/components/ui/button"
 import {
   Select,
@@ -590,18 +591,10 @@ export function FileViewContainer({
               <SelectItem value="image_count">Image Count</SelectItem>
             </SelectContent>
           </Select>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
-            className="h-8 w-8 p-0"
-          >
-            {sortOrder === "asc" ? (
-              <ArrowUp className="size-4" />
-            ) : (
-              <ArrowDown className="size-4" />
-            )}
-          </Button>
+          <SortDirectionToggle
+            value={sortOrder}
+            onToggle={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
+          />
           {toolbarExtra}
         </ToolbarGroup>
 

--- a/frontend/src/routes/_layout/authors.tsx
+++ b/frontend/src/routes/_layout/authors.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { OpenAPI } from "@/client"
 import { EntityGrid } from "@/components/Common/EntityGrid"
+import { SortDirectionToggle } from "@/components/Common/SortDirectionToggle"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -119,30 +120,24 @@ function AuthorsPage() {
           </Select>
         </div>
 
-        <div className="flex items-center gap-2">
-          <Label className="text-sm">{t("authors.sortDirection")}</Label>
-          <Select
-            value={sort_order}
-            onValueChange={(v) => {
-              navigate({
-                to: "/authors",
-                search: {
-                  page: 1,
-                  sort_by,
-                  sort_order: v as SortOrder,
-                },
-              })
-            }}
-          >
-            <SelectTrigger className="w-[140px] h-8">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="desc">{t("authors.descending")}</SelectItem>
-              <SelectItem value="asc">{t("authors.ascending")}</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+        <SortDirectionToggle
+          value={sort_order}
+          title={
+            sort_order === "asc"
+              ? t("authors.ascending")
+              : t("authors.descending")
+          }
+          onToggle={() => {
+            navigate({
+              to: "/authors",
+              search: {
+                page: 1,
+                sort_by,
+                sort_order: sort_order === "asc" ? "desc" : "asc",
+              },
+            })
+          }}
+        />
       </div>
 
       <EntityGrid

--- a/frontend/src/routes/_layout/cosers.tsx
+++ b/frontend/src/routes/_layout/cosers.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { OpenAPI } from "@/client"
 import { EntityGrid } from "@/components/Common/EntityGrid"
+import { SortDirectionToggle } from "@/components/Common/SortDirectionToggle"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -119,30 +120,24 @@ function CosersPage() {
           </Select>
         </div>
 
-        <div className="flex items-center gap-2">
-          <Label className="text-sm">{t("cosers.sortDirection")}</Label>
-          <Select
-            value={sort_order}
-            onValueChange={(v) => {
-              navigate({
-                to: "/cosers",
-                search: {
-                  page: 1,
-                  sort_by,
-                  sort_order: v as SortOrder,
-                },
-              })
-            }}
-          >
-            <SelectTrigger className="w-[140px] h-8">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="desc">{t("cosers.descending")}</SelectItem>
-              <SelectItem value="asc">{t("cosers.ascending")}</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+        <SortDirectionToggle
+          value={sort_order}
+          title={
+            sort_order === "asc"
+              ? t("cosers.ascending")
+              : t("cosers.descending")
+          }
+          onToggle={() => {
+            navigate({
+              to: "/cosers",
+              search: {
+                page: 1,
+                sort_by,
+                sort_order: sort_order === "asc" ? "desc" : "asc",
+              },
+            })
+          }}
+        />
       </div>
 
       <EntityGrid

--- a/frontend/src/routes/_layout/search.tsx
+++ b/frontend/src/routes/_layout/search.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { Search } from "lucide-react"
+import { ExternalLink, Search } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -168,6 +168,21 @@ function SearchPage() {
     }
   }
 
+  const trimmedQ = submittedQ.trim()
+  const externalLinks = useMemo(
+    () => [
+      {
+        label: "ExHentai",
+        href: `https://exhentai.org/?f_search=${encodeURIComponent(trimmedQ)}`,
+      },
+      {
+        label: "Sukebei",
+        href: `https://sukebei.nyaa.si/?f=0&c=0_0&q=${encodeURIComponent(trimmedQ)}`,
+      },
+    ],
+    [trimmedQ],
+  )
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -193,6 +208,25 @@ function SearchPage() {
             <Search className="size-4 mr-1" />
             {t("search.searchButton")}
           </Button>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Label className="text-sm text-muted-foreground">Open in new tab</Label>
+          {externalLinks.map((item) => (
+            <Button
+              key={item.label}
+              asChild
+              variant="outline"
+              size="sm"
+              disabled={!trimmedQ}
+              className="h-8"
+            >
+              <a href={item.href} target="_blank" rel="noreferrer noopener">
+                <ExternalLink className="size-3.5 mr-1" />
+                {item.label}
+              </a>
+            </Button>
+          ))}
         </div>
 
         <div className="flex flex-wrap items-center gap-6">

--- a/frontend/src/routes/_layout/tags.tsx
+++ b/frontend/src/routes/_layout/tags.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { OpenAPI } from "@/client"
 import { EntityGrid } from "@/components/Common/EntityGrid"
+import { SortDirectionToggle } from "@/components/Common/SortDirectionToggle"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -119,27 +120,22 @@ function TagsPage() {
 
         <div className="flex items-center gap-2">
           <Label className="text-sm">{t("tags.sortDirection")}</Label>
-          <Select
+          <SortDirectionToggle
             value={sort_order}
-            onValueChange={(v) => {
+            title={
+              sort_order === "asc" ? t("tags.ascending") : t("tags.descending")
+            }
+            onToggle={() => {
               navigate({
                 to: "/tags",
                 search: {
                   page: 1,
                   sort_by,
-                  sort_order: v as SortOrder,
+                  sort_order: sort_order === "asc" ? "desc" : "asc",
                 },
               })
             }}
-          >
-            <SelectTrigger className="w-[140px] h-8">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="desc">{t("tags.descending")}</SelectItem>
-              <SelectItem value="asc">{t("tags.ascending")}</SelectItem>
-            </SelectContent>
-          </Select>
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## 前端task
search页面需要加一个link，点下去可以open in a new tab。

https://exhentai.org/?f_search={刚才的搜索词}
https://sukebei.nyaa.si/?f=0&c=0_0&q={刚才的搜索词}

你想一下怎么设计好看


## 前端task
tag page的sort direction要和explorer页面的一样。考虑用共通component 

## frontend\src\components\Common\PathBreadcrumb.tsx
里面能被省略的label全部都要带title attribute

### 前端task
breadcrumb 的最后一个filename/foldername点击下去行为不统一
统一成点击下去 等于 ctrl + c filename/foldername