### PR TITLE
修复(frontend): 缩小 Explorer 中 Sort by 下拉字体以避免被裁切

### DIFF
--- a/frontend/src/components/Files/FileViewContainer.tsx
+++ b/frontend/src/components/Files/FileViewContainer.tsx
@@ -580,15 +580,15 @@ export function FileViewContainer({
             value={sortField}
             onValueChange={(v) => setSortField(v as SortField)}
           >
-            <SelectTrigger className="w-[140px] h-8">
-              <SelectValue />
+            <SelectTrigger className="h-8 w-[140px] text-xs leading-none">
+              <SelectValue className="text-xs" />
             </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="name">Name</SelectItem>
-              <SelectItem value="type">Type</SelectItem>
-              <SelectItem value="mtime">Date Modified</SelectItem>
-              <SelectItem value="recommendation">Recommendation</SelectItem>
-              <SelectItem value="image_count">Image Count</SelectItem>
+            <SelectContent className="text-xs">
+              <SelectItem className="text-xs" value="name">Name</SelectItem>
+              <SelectItem className="text-xs" value="type">Type</SelectItem>
+              <SelectItem className="text-xs" value="mtime">Date Modified</SelectItem>
+              <SelectItem className="text-xs" value="recommendation">Recommendation</SelectItem>
+              <SelectItem className="text-xs" value="image_count">Image Count</SelectItem>
             </SelectContent>
           </Select>
           <SortDirectionToggle


### PR DESCRIPTION
### Motivation
- 解决 Explorer 页面“Sort by”右侧下拉触发器及下拉项字体过大导致被容器 `overflow: hidden` 裁切的问题，通过局部减小字号来避免显示异常。

### Description
- 在 `frontend/src/components/Files/FileViewContainer.tsx` 中将 `SelectTrigger` 增加 `text-xs leading-none`，并对 `SelectValue`、`SelectContent` 及每个 `SelectItem` 添加 `text-xs` 类以统一缩小字号。
- 修改范围仅限 `FileViewContainer` 内的排序选择器，未更改任何全局 `@layer` 或其它组件样式，属于局部低风险调整。

### Testing
- 运行 `bun run --filter frontend lint`，当前环境失败：`biome: command not found`（无法完成 lint 验证）。
- 运行 `bun run dev`，当前环境失败：`vite: command not found`（无法本地启动页面进行视觉验证）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699471f7c93883259adfdf68ac51d6f7)