### PR TITLE
refactor(files): 移除 FileItem 双击处理

### DIFF
--- a/frontend/src/components/Files/FileItem.tsx
+++ b/frontend/src/components/Files/FileItem.tsx
@@ -1,4 +1,4 @@
-// 文件系统项卡片组件 — 支持选择、双击导航、右键菜单
+// 文件系统项卡片组件 — 支持选择、右键菜单
 
 import { useTranslation } from "react-i18next"
 import type { FileSystemItem } from "@/client"
@@ -26,8 +26,6 @@ interface FileItemProps {
   actionSlot?: React.ReactNode
   /** 单击回调（处理选择） */
   onClick?: (e: React.MouseEvent) => void
-  /** 双击回调（打开） */
-  onDoubleClick?: (e: React.MouseEvent) => void
   /** 右键回调 */
   onContextMenu?: (e: React.MouseEvent) => void
 }
@@ -37,7 +35,6 @@ export function FileItem({
   isSelected,
   actionSlot,
   onClick,
-  onDoubleClick,
   onContextMenu,
 }: FileItemProps) {
   const { t } = useTranslation()
@@ -89,7 +86,6 @@ export function FileItem({
         if (target.closest("a")) return
         onClick?.(e)
       }}
-      onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}
     >
       <ItemCard className="file-item-card">

--- a/frontend/src/components/Files/FileItem.tsx
+++ b/frontend/src/components/Files/FileItem.tsx
@@ -81,6 +81,20 @@ export function FileItem({
     </FileName>
   )
 
+  const thumbcard = (<CardThumbnail className="file-card-thumbnail">
+            {item.thumbnail_url ? (
+              <ThumbnailImage
+                src={`${OpenAPI.BASE}${item.thumbnail_url}`}
+                alt={item.name}
+                fallback={
+                  <FileIcon fileType={item.file_type} isFolder={isFolder} />
+                }
+              />
+            ) : (
+              <FileIcon fileType={item.file_type} isFolder={isFolder} />
+            )}
+          </CardThumbnail>)
+
   return (
     <div
       className={cn("file-item-root", isSelected && "file-item-root--selected")}
@@ -97,34 +111,10 @@ export function FileItem({
 
         {href ? (
           <a href={href} className="file-item-thumbnail-link" draggable={false}>
-            <CardThumbnail className="file-card-thumbnail">
-              {item.thumbnail_url ? (
-                <ThumbnailImage
-                  src={`${OpenAPI.BASE}${item.thumbnail_url}`}
-                  alt={item.name}
-                  fallback={
-                    <FileIcon fileType={item.file_type} isFolder={isFolder} />
-                  }
-                />
-              ) : (
-                <FileIcon fileType={item.file_type} isFolder={isFolder} />
-              )}
-            </CardThumbnail>
+            {thumbcard}
           </a>
         ) : (
-          <CardThumbnail className="file-card-thumbnail">
-            {item.thumbnail_url ? (
-              <ThumbnailImage
-                src={`${OpenAPI.BASE}${item.thumbnail_url}`}
-                alt={item.name}
-                fallback={
-                  <FileIcon fileType={item.file_type} isFolder={isFolder} />
-                }
-              />
-            ) : (
-              <FileIcon fileType={item.file_type} isFolder={isFolder} />
-            )}
-          </CardThumbnail>
+          thumbcard
         )}
 
         <CardInfo className="file-item-info">

--- a/frontend/src/components/Files/FileViewContainer.tsx
+++ b/frontend/src/components/Files/FileViewContainer.tsx
@@ -713,7 +713,6 @@ export function FileViewContainer({
                             ? undefined
                             : (e) => handleItemClick(item, e)
                         }
-                        onDoubleClick={(e) => handleItemDoubleClick(item, e)}
                       />
                     </FileContextMenu>
                   )
@@ -755,7 +754,6 @@ export function FileViewContainer({
                       ? undefined
                       : (e) => handleItemClick(item, e)
                   }
-                  onDoubleClick={(e) => handleItemDoubleClick(item, e)}
                 />
               </FileContextMenu>
             )


### PR DESCRIPTION
### Motivation
- 删除组件中遗留的双击处理逻辑，因为双击行为不再需要且可能导致重复或冲突。

### Description
- 在 `frontend/src/components/Files/FileItem.tsx` 中移除了 `onDoubleClick` 的类型定义、入参解构与根节点上的 `onDoubleClick` 绑定，并在 `frontend/src/components/Files/FileViewContainer.tsx` 中移除了传给 `FileItem` 的两处 `onDoubleClick` 调用以同步改动。

### Testing
- 运行了 `cd frontend && bun run lint`，该命令在当前环境中因缺少 `biome` 可执行文件而失败（不是代码逻辑错误）；变更已本地提交。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947791e1f48325b228b1cb981805e9)