### PR TITLE
统一 History/Explorer 表格样式并复用 History FileItem 组件

### DIFF
--- a/frontend/src/components/Common/ListTable.tsx
+++ b/frontend/src/components/Common/ListTable.tsx
@@ -1,0 +1,36 @@
+import type React from "react"
+import { cn } from "@/lib/utils"
+
+export interface ListTableColumn {
+  key: string
+  header: React.ReactNode
+  headerClassName?: string
+}
+
+interface ListTableProps<T> {
+  columns: ListTableColumn[]
+  rows: T[]
+  renderRow: (row: T) => React.ReactNode
+}
+
+export function ListTable<T>({ columns, rows, renderRow }: ListTableProps<T>) {
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <table className="w-full">
+        <thead className="bg-muted/50 border-b">
+          <tr className="text-sm">
+            {columns.map((column) => (
+              <th
+                key={column.key}
+                className={cn("text-left p-2 font-medium", column.headerClassName)}
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{rows.map(renderRow)}</tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/Files/FileItem.css
+++ b/frontend/src/components/Files/FileItem.css
@@ -74,3 +74,23 @@
   font-size: 0.75rem;
   color: hsl(var(--muted-foreground));
 }
+
+.file-item-meta-text {
+  margin-bottom: 0.25rem;
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.file-item-root--compact .file-item-name-link {
+  min-height: 1.8em;
+  margin-bottom: 4px;
+}
+
+.file-item-root--compact .file-item-name-text {
+  font-size: 0.8rem;
+}
+
+.file-item-root--compact .card-info {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+}

--- a/frontend/src/components/Files/FileItem.tsx
+++ b/frontend/src/components/Files/FileItem.tsx
@@ -19,6 +19,9 @@ import { formatFileSize } from "./utils"
 import "./FileItem.css"
 
 interface FileItemProps {
+  className?: string
+  metaText?: string
+
   item: FileSystemItem
   /** 是否选中 */
   isSelected?: boolean
@@ -36,6 +39,8 @@ export function FileItem({
   actionSlot,
   onClick,
   onContextMenu,
+  className,
+  metaText,
 }: FileItemProps) {
   const { t } = useTranslation()
   const isMobile = useIsMobile()
@@ -94,7 +99,7 @@ export function FileItem({
 
   return (
     <div
-      className={cn("file-item-root", isSelected && "file-item-root--selected")}
+      className={cn("file-item-root", isSelected && "file-item-root--selected", className)}
       onClick={(e) => {
         const target = e.target as HTMLElement
         if (target.closest("a")) return
@@ -117,6 +122,7 @@ export function FileItem({
           {actionSlot && (
             <div className="file-item-action-slot">{actionSlot}</div>
           )}
+          {metaText && <p className="file-item-meta-text">{metaText}</p>}
           {infoMetrics.length > 0 && (
             <div className="file-item-info-metrics">
               {infoMetrics.map((metric) => (

--- a/frontend/src/components/Files/FileTableView.tsx
+++ b/frontend/src/components/Files/FileTableView.tsx
@@ -2,12 +2,12 @@
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react"
 
 import type { FileSystemItem } from "@/client"
+import { ListTable, type ListTableColumn } from "@/components/Common/ListTable"
 import { cn } from "@/lib/utils"
 import { FileContextMenu, type FileContextMenuActions } from "./FileContextMenu"
 import { FileIcon } from "./FileIcon"
 import { FileNameWithPreview } from "./FileNameWithPreview"
 import { formatDateTime, formatFileSize, formatFileType } from "./utils"
-import "./FileTableView.css"
 
 export type SortField =
   | "name"
@@ -22,12 +22,10 @@ interface FileTableViewProps {
   onSort: (field: SortField) => void
   sortField: SortField
   sortOrder: SortOrder
-  /** 选择相关 */
   isSelected?: (path: string) => boolean
   onItemClick?: (item: FileSystemItem, e: React.MouseEvent) => void
   onItemDoubleClick?: (item: FileSystemItem, e: React.MouseEvent) => void
   onItemContextMenu?: (item: FileSystemItem) => void
-  /** 右键菜单 */
   buildContextMenuActions?: (item: FileSystemItem) => FileContextMenuActions
   isOpenable?: (item: FileSystemItem) => boolean
 }
@@ -45,160 +43,73 @@ export function FileTableView({
   isOpenable,
 }: FileTableViewProps) {
   const SortIcon = ({ field }: { field: SortField }) => {
-    if (sortField !== field) {
-      return <ArrowUpDown className="size-3 ml-1 opacity-50" />
-    }
-    return sortOrder === "asc" ? (
-      <ArrowUp className="size-3 ml-1" />
-    ) : (
-      <ArrowDown className="size-3 ml-1" />
-    )
+    if (sortField !== field) return <ArrowUpDown className="size-3 ml-1 opacity-50" />
+    return sortOrder === "asc" ? <ArrowUp className="size-3 ml-1" /> : <ArrowDown className="size-3 ml-1" />
   }
 
+  const columns: ListTableColumn[] = [
+    { key: "name", header: <button className="inline-flex items-center" onClick={() => onSort("name")}>Name<SortIcon field="name" /></button> },
+    { key: "mtime", header: <button className="inline-flex items-center" onClick={() => onSort("mtime")}>Date Modified<SortIcon field="mtime" /></button>, headerClassName: "w-[180px]" },
+    { key: "type", header: <button className="inline-flex items-center" onClick={() => onSort("type")}>Type<SortIcon field="type" /></button>, headerClassName: "w-[120px]" },
+    { key: "size", header: "Size", headerClassName: "w-[100px] text-right" },
+    { key: "recommendation", header: <button className="ml-auto inline-flex items-center" onClick={() => onSort("recommendation")}>Recommendation<SortIcon field="recommendation" /></button>, headerClassName: "w-[130px] text-right" },
+    { key: "image_count", header: <button className="ml-auto inline-flex items-center" onClick={() => onSort("image_count")}>Image Count<SortIcon field="image_count" /></button>, headerClassName: "w-[110px] text-right" },
+  ]
+
   return (
-    <div className="file-table-view">
-      <table className="file-table-view__table">
-        <thead className="file-table-view__head">
-          <tr className="file-table-view__head-row">
-            <th
-              className="file-table-view__head-cell file-table-view__head-cell--sortable"
-              onClick={() => onSort("name")}
-            >
-              <div className="file-table-view__head-cell-content">
-                Name
-                <SortIcon field="name" />
-              </div>
-            </th>
-            <th
-              className="file-table-view__head-cell file-table-view__head-cell--sortable file-table-view__head-cell--mtime"
-              onClick={() => onSort("mtime")}
-            >
-              <div className="file-table-view__head-cell-content">
-                Date Modified
-                <SortIcon field="mtime" />
-              </div>
-            </th>
-            <th
-              className="file-table-view__head-cell file-table-view__head-cell--sortable file-table-view__head-cell--type"
-              onClick={() => onSort("type")}
-            >
-              <div className="file-table-view__head-cell-content">
-                Type
-                <SortIcon field="type" />
-              </div>
-            </th>
-            <th className="file-table-view__head-cell file-table-view__head-cell--align-right file-table-view__head-cell--size">
-              Size
-            </th>
-            <th
-              className="file-table-view__head-cell file-table-view__head-cell--sortable file-table-view__head-cell--align-right file-table-view__head-cell--recommendation"
-              onClick={() => onSort("recommendation")}
-            >
-              <div className="file-table-view__head-cell-content file-table-view__head-cell-content--align-right">
-                Recommendation
-                <SortIcon field="recommendation" />
-              </div>
-            </th>
-            <th
-              className="file-table-view__head-cell file-table-view__head-cell--sortable file-table-view__head-cell--align-right file-table-view__head-cell--image-count"
-              onClick={() => onSort("image_count")}
-            >
-              <div className="file-table-view__head-cell-content file-table-view__head-cell-content--align-right">
-                Image Count
-                <SortIcon field="image_count" />
-              </div>
-            </th>
+    <ListTable
+      columns={columns}
+      rows={items}
+      renderRow={(item) => {
+        const row = (
+          <tr
+            key={item.path}
+            className={cn(
+              "border-b last:border-b-0 text-sm cursor-pointer hover:bg-muted/50",
+              isSelected?.(item.path) && "bg-primary/10",
+            )}
+            onClick={(e) => onItemClick?.(item, e)}
+            onDoubleClick={(e) => onItemDoubleClick?.(item, e)}
+          >
+            <TableRowCells item={item} />
           </tr>
-        </thead>
-        <tbody>
-          {items.map((item) => {
-            const row = (
-              <TableRowItem
-                key={item.path}
-                item={item}
-                selected={isSelected?.(item.path) ?? false}
-                onClick={onItemClick}
-                onDoubleClick={onItemDoubleClick}
-              />
-            )
+        )
 
-            if (buildContextMenuActions) {
-              return (
-                <FileContextMenu
-                  key={item.path}
-                  item={item}
-                  isOpenable={isOpenable?.(item) ?? false}
-                  actions={buildContextMenuActions(item)}
-                  onContextMenuOpen={() => onItemContextMenu?.(item)}
-                >
-                  {row}
-                </FileContextMenu>
-              )
-            }
+        if (!buildContextMenuActions) return row
 
-            return row
-          })}
-        </tbody>
-      </table>
-    </div>
+        return (
+          <FileContextMenu
+            key={item.path}
+            item={item}
+            isOpenable={isOpenable?.(item) ?? false}
+            actions={buildContextMenuActions(item)}
+            onContextMenuOpen={() => onItemContextMenu?.(item)}
+          >
+            {row}
+          </FileContextMenu>
+        )
+      }}
+    />
   )
 }
 
-function TableRowItem({
-  item,
-  selected,
-  onClick,
-  onDoubleClick,
-}: {
-  item: FileSystemItem
-  selected: boolean
-  onClick?: (item: FileSystemItem, e: React.MouseEvent) => void
-  onDoubleClick?: (item: FileSystemItem, e: React.MouseEvent) => void
-}) {
+function TableRowCells({ item }: { item: FileSystemItem }) {
   const isFolder = item.item_type === "folder"
   const isArchive = item.file_type === "archive"
 
   return (
-    <tr
-      className={cn(
-        "file-table-row",
-        selected ? "file-table-row--selected" : "file-table-row--hoverable",
-      )}
-      onClick={(e) => onClick?.(item, e)}
-      onDoubleClick={(e) => onDoubleClick?.(item, e)}
-    >
-      <td className="file-table-cell">
-        <div className="file-table-name-cell">
-          <FileIcon
-            fileType={item.file_type}
-            isFolder={isFolder}
-            size="sm"
-          />
-          <FileNameWithPreview
-            filename={item.name}
-            filepath={item.path}
-            thumbnailUrl={item.thumbnail_url}
-            className="min-w-0"
-          />
+    <>
+      <td className="p-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <FileIcon fileType={item.file_type} isFolder={isFolder} size="sm" />
+          <FileNameWithPreview filename={item.name} filepath={item.path} thumbnailUrl={item.thumbnail_url} className="min-w-0" />
         </div>
       </td>
-      <td className="file-table-cell file-table-cell--muted">
-        {item.mtime ? formatDateTime(item.mtime) : "-"}
-      </td>
-      <td className="file-table-cell file-table-cell--muted">
-        {isFolder ? "Folder" : formatFileType(item.file_type)}
-      </td>
-      <td className="file-table-cell file-table-cell--align-right file-table-cell--muted">
-        {!isFolder && item.filesize ? formatFileSize(item.filesize) : "-"}
-      </td>
-      <td className="file-table-cell file-table-cell--align-right file-table-cell--muted">
-        {!isFolder ? ((item as any).recommendation_score ?? 0).toFixed(3) : "-"}
-      </td>
-      <td className="file-table-cell file-table-cell--align-right file-table-cell--muted">
-        {isArchive && (item as any).image_count
-          ? (item as any).image_count
-          : "-"}
-      </td>
-    </tr>
+      <td className="p-2 text-muted-foreground">{item.mtime ? formatDateTime(item.mtime) : "-"}</td>
+      <td className="p-2 text-muted-foreground">{isFolder ? "Folder" : formatFileType(item.file_type)}</td>
+      <td className="p-2 text-right text-muted-foreground">{!isFolder && item.filesize ? formatFileSize(item.filesize) : "-"}</td>
+      <td className="p-2 text-right text-muted-foreground">{!isFolder ? ((item as any).recommendation_score ?? 0).toFixed(3) : "-"}</td>
+      <td className="p-2 text-right text-muted-foreground">{isArchive && (item as any).image_count ? (item as any).image_count : "-"}</td>
+    </>
   )
 }

--- a/frontend/src/routes/_layout/history.tsx
+++ b/frontend/src/routes/_layout/history.tsx
@@ -12,14 +12,15 @@ import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 
 import { OpenAPI } from "@/client"
-import { FileIcon } from "@/components/Files/FileIcon"
+import type { FileSystemItem } from "@/client/types.gen"
+import { ListTable, type ListTableColumn } from "@/components/Common/ListTable"
+import { FileItem } from "@/components/Files/FileItem"
 import { FileNameWithPreview } from "@/components/Files/FileNameWithPreview"
 import {
   formatDateTime,
   formatFileSize,
   formatFileType,
 } from "@/components/Files/utils"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Pagination,
@@ -148,15 +149,30 @@ function HistoryPage() {
     toast.info(t("history.unsupportedType"))
   }
 
+  const tableColumns: ListTableColumn[] = [
+    { key: "name", header: t("history.name") },
+    { key: "readAt", header: t("history.readAt"), headerClassName: "w-[180px]" },
+    { key: "type", header: t("history.type"), headerClassName: "w-[120px]" },
+    { key: "size", header: t("history.size"), headerClassName: "w-[100px] text-right" },
+  ]
+
+  const toFileSystemItem = (item: HistoryItem): FileSystemItem => ({
+    name: item.filename,
+    path: item.filepath,
+    item_type: "file",
+    file_type: item.file_type,
+    filesize: item.filesize,
+    mtime: item.mtime,
+    thumbnail_url: item.thumbnail_url,
+  })
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-4 pb-2 border-b">
         <div className="flex items-center gap-2">
           <HistoryIcon className="size-5" />
           <h1 className="text-xl font-semibold">{t("history.title")}</h1>
-          <span className="text-sm text-muted-foreground">
-            {t("history.subtitle")}
-          </span>
+          <span className="text-sm text-muted-foreground">{t("history.subtitle")}</span>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -214,7 +230,7 @@ function HistoryPage() {
 
       {isLoading ? (
         view === "grid" ? (
-          <div className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          <div className="grid gap-3 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
             {[...Array(12)].map((_, i) => (
               <div key={i} className="space-y-2">
                 <Skeleton className="aspect-square w-full rounded-lg" />
@@ -234,112 +250,47 @@ function HistoryPage() {
           <p className="text-muted-foreground">{t("history.empty")}</p>
         </div>
       ) : view === "grid" ? (
-        <div className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        <div className="grid gap-3 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
           {data?.items.map((item) => (
-            <button
+            <div
               key={`${item.filepath}-${item.read_at}`}
-              type="button"
               onClick={() => openHistoryItem(item)}
-              className="group relative rounded-lg border bg-card transition-all text-left cursor-pointer hover:border-primary hover:shadow-md"
+              className="cursor-pointer"
             >
-              <div className="aspect-square w-full overflow-hidden rounded-t-lg bg-muted flex items-center justify-center relative">
-                {item.thumbnail_url ? (
-                  <img
-                    src={`${OpenAPI.BASE}${item.thumbnail_url}`}
-                    alt={item.filename}
-                    className="size-full object-contain"
-                    loading="lazy"
-                  />
-                ) : (
-                  <FileIcon fileType={item.file_type} isFolder={false} />
-                )}
-                {/*
-                  不需要显示这个了，用户点开reader就知道有没有就好了
-                {!item.file_exists && (
-                  <Badge
-                    variant="destructive"
-                    className="absolute top-2 right-2"
-                  >
-                    {t("history.unknown")}
-                  </Badge>
-                )} */}
-              </div>
-              <div className="p-2 space-y-1">
-                <FileNameWithPreview
-                  filename={item.filename}
-                  filepath={item.filepath}
-                  thumbnailUrl={item.thumbnail_url}
-                  className="text-sm block"
-                />
-                <p className="text-xs text-muted-foreground">
-                  {t("history.readAt")}：{formatDateTime(item.read_at)}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {item.filesize
-                    ? formatFileSize(item.filesize)
-                    : formatFileType(item.file_type)}
-                </p>
-              </div>
-            </button>
+              <FileItem
+                item={toFileSystemItem(item)}
+                className="file-item-root--compact"
+                metaText={`${t("history.readAt")}：${formatDateTime(item.read_at)}`}
+              />
+            </div>
           ))}
         </div>
       ) : (
-        <div className="border rounded-lg overflow-hidden">
-          <table className="w-full">
-            <thead className="bg-muted/50 border-b">
-              <tr className="text-sm">
-                <th className="text-left p-2 font-medium">
-                  {t("history.name")}
-                </th>
-                <th className="text-left p-2 font-medium w-[180px]">
-                  {t("history.readAt")}
-                </th>
-                <th className="text-left p-2 font-medium w-[120px]">
-                  {t("history.type")}
-                </th>
-                <th className="text-right p-2 font-medium w-[100px]">
-                  {t("history.size")}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {data?.items.map((item) => (
-                <tr
-                  key={`${item.filepath}-${item.read_at}`}
-                  className="border-b last:border-b-0 text-sm cursor-pointer hover:bg-muted/50"
-                  onClick={() => openHistoryItem(item)}
-                >
-                  <td className="p-2">
-                    <div className="flex items-center gap-2 min-w-0">
-                      <div className="shrink-0">
-                        <FileIcon
-                          fileType={item.file_type}
-                          isFolder={false}
-                          size="sm"
-                        />
-                      </div>
-                      <FileNameWithPreview
-                        filename={item.filename}
-                        filepath={item.filepath}
-                        thumbnailUrl={item.thumbnail_url}
-                        className="min-w-0"
-                      />
-                    </div>
-                  </td>
-                  <td className="p-2 text-muted-foreground">
-                    {formatDateTime(item.read_at)}
-                  </td>
-                  <td className="p-2 text-muted-foreground">
-                    {formatFileType(item.file_type)}
-                  </td>
-                  <td className="p-2 text-right text-muted-foreground">
-                    {item.filesize ? formatFileSize(item.filesize) : "-"}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ListTable
+          columns={tableColumns}
+          rows={data?.items ?? []}
+          renderRow={(item) => (
+            <tr
+              key={`${item.filepath}-${item.read_at}`}
+              className="border-b last:border-b-0 text-sm cursor-pointer hover:bg-muted/50"
+              onClick={() => openHistoryItem(item)}
+            >
+              <td className="p-2">
+                <div className="flex items-center gap-2 min-w-0">
+                  <FileNameWithPreview
+                    filename={item.filename}
+                    filepath={item.filepath}
+                    thumbnailUrl={item.thumbnail_url}
+                    className="min-w-0"
+                  />
+                </div>
+              </td>
+              <td className="p-2 text-muted-foreground">{formatDateTime(item.read_at)}</td>
+              <td className="p-2 text-muted-foreground">{formatFileType(item.file_type)}</td>
+              <td className="p-2 text-right text-muted-foreground">{item.filesize ? formatFileSize(item.filesize) : "-"}</td>
+            </tr>
+          )}
+        />
       )}
 
       {(data?.total ?? 0) > 0 && (
@@ -353,9 +304,7 @@ function HistoryPage() {
                     e.preventDefault()
                     goToPage(1)
                   }}
-                  className={
-                    page <= 1 ? "pointer-events-none opacity-50" : undefined
-                  }
+                  className={page <= 1 ? "pointer-events-none opacity-50" : undefined}
                 />
               </PaginationItem>
 
@@ -366,9 +315,7 @@ function HistoryPage() {
                     e.preventDefault()
                     goToPage(page - 1)
                   }}
-                  className={
-                    page <= 1 ? "pointer-events-none opacity-50" : undefined
-                  }
+                  className={page <= 1 ? "pointer-events-none opacity-50" : undefined}
                 />
               </PaginationItem>
 
@@ -394,11 +341,7 @@ function HistoryPage() {
                     e.preventDefault()
                     goToPage(page + 1)
                   }}
-                  className={
-                    page >= totalPages
-                      ? "pointer-events-none opacity-50"
-                      : undefined
-                  }
+                  className={page >= totalPages ? "pointer-events-none opacity-50" : undefined}
                 />
               </PaginationItem>
 
@@ -409,11 +352,7 @@ function HistoryPage() {
                     e.preventDefault()
                     goToPage(totalPages)
                   }}
-                  className={
-                    page >= totalPages
-                      ? "pointer-events-none opacity-50"
-                      : undefined
-                  }
+                  className={page >= totalPages ? "pointer-events-none opacity-50" : undefined}
                 />
               </PaginationItem>
             </PaginationContent>


### PR DESCRIPTION
### Motivation
- 让 History 页的文件项复用与 Explorer 一致的前端组件以保持行为和样式统一并避免重复实现。 
- 抽取通用表格实现以保持 Explorer 与 History 的表格外观一致，仅通过列定义差异化。 

### Description
- 新增通用表格组件 `frontend/src/components/Common/ListTable.tsx`，提供统一的表头/表体容器与列定义接口以复用样式。 
- 将 `FileTableView` 改为基于 `ListTable` 渲染表格列并保留排序、点击、双击与右键菜单等行为。 
- 将 History Grid 的自定义 card 替换为复用 `FileItem` 组件，`FileItem` 增加 `metaText` 与 `className` 属性用于显示“上次阅读时间”并支持紧凑样式。 
- 新增/调整样式 `frontend/src/components/Files/FileItem.css`，添加 `file-item-root--compact` 与 `file-item-meta-text`，并修改 `frontend/src/routes/_layout/history.tsx` 以使用新的组件/表格。 

### Testing
- 运行 `bun run lint`（失败）：当前环境缺少 `biome` 命令导致 lint 无法执行。 
- 运行 `npm run -w frontend build`（失败）：构建在当前环境中因未安装前端依赖（缺少 React/Vite/Playwright 等）而中止。 
- 尝试 `npm run -w frontend dev -- --host 0.0.0.0 --port 4173`（失败）：环境中未找到 `vite`，无法启动开发服务器。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699481bdcce883259389a2d53590f38a)