### PR TITLE
chore: disable incorrect GitHub sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-github: [tiangolo]
+# Keep empty to disable "Sponsor this project" button on GitHub.
+github: []


### PR DESCRIPTION
### Motivation
- 仓库在页面显示错误的 “Sponsor this project @tiangolo” 入口，是因为 `.github/FUNDING.yml` 中原先写有 `github: [tiangolo]`，需要移除以避免误导用户。

### Description
- 更新了 ` .github/FUNDING.yml`，添加注释并将 `github` 列表设为空为 `github: []`，以禁用 GitHub 的赞助按钮。

### Testing
- 运行了 `sed -n '1,120p' .github/FUNDING.yml`、`git diff -- .github/FUNDING.yml` 和 `git status --short` 来验证文件内容和变更状态，命令执行并确认了预期修改。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948dad51288325bcfad58a0bad5b43)