### PR TITLE
test: 停用 users 路由并补齐缺失 API 的基础 UT

### DIFF
--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.routes import authors, cosers, fs, history, parse, private, search, tags, users, utils
+from app.api.routes import authors, cosers, fs, history, parse, private, search, tags, utils
 from app.api.routes import settings as settings_router
 from app.core.config import settings
 
@@ -14,7 +14,8 @@ api_router.include_router(authors.router)
 api_router.include_router(cosers.router)
 api_router.include_router(history.router)
 api_router.include_router(settings_router.router)
-api_router.include_router(users.router)
+# 暂时未使用用户相关 API，先注释路由挂载，避免无效维护成本。
+# api_router.include_router(users.router)
 
 
 if settings.ENVIRONMENT == "local":

--- a/backend/tests/api/routes/test_misc_routes.py
+++ b/backend/tests/api/routes/test_misc_routes.py
@@ -1,0 +1,86 @@
+"""Smoke tests for API routes that previously lacked UT coverage."""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.index_db.bootstrap import ensure_index_db_initialized
+from app.index_db.db import clear_index_engine_cache
+
+
+@pytest.fixture
+def misc_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Bind index DB to a temporary sqlite file and return API client."""
+    db_file = tmp_path / "misc_test_index.db"
+    db_url = f"sqlite:///{db_file.as_posix()}"
+    ensure_index_db_initialized(db_url)
+
+    clear_index_engine_cache()
+    monkeypatch.setattr(settings, "INDEX_SQLITE_URL", db_url)
+    clear_index_engine_cache()
+
+    from app.main import app
+
+    with TestClient(app) as client:
+        yield client
+
+    clear_index_engine_cache()
+
+
+def test_history_list_empty(misc_client: TestClient) -> None:
+    response = misc_client.get("/api/v1/history/list")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+
+
+def test_authors_and_cosers_empty(misc_client: TestClient) -> None:
+    authors_resp = misc_client.get("/api/v1/authors")
+    cosers_resp = misc_client.get("/api/v1/cosers")
+
+    assert authors_resp.status_code == 200
+    assert authors_resp.json()["items"] == []
+
+    assert cosers_resp.status_code == 200
+    assert cosers_resp.json()["items"] == []
+
+
+def test_parse_batch_with_unknown_filename(misc_client: TestClient) -> None:
+    response = misc_client.post(
+        "/api/v1/parse/batch",
+        json={"filepaths": ["/tmp/just_a_normal_name.txt"]},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 1
+    assert len(data["items"]) == 1
+
+
+def test_settings_read(misc_client: TestClient) -> None:
+    response = misc_client.get("/api/v1/settings")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "favorite_dir" in data
+    assert "fs_roots" in data
+    assert "already_read_dir" in data
+
+
+def test_private_create_user(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/private/users/",
+        json={
+            "email": "private-user@example.com",
+            "password": "pass123456",
+            "full_name": "private user",
+            "is_verified": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["email"] == "private-user@example.com"

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytestmark = pytest.mark.skip(reason="user API 已停用，相关 UT 暂停维护")
+
 """Tests for app/api/routes/users.py user management endpoints."""
 
 from fastapi.testclient import TestClient


### PR DESCRIPTION
### Motivation

- 停用未使用的用户管理 API，降低维护成本并避免无用暴露。 
- 由于用户 API 不再使用，相关单测需要暂时停用以避免影响 CI 稳定性。 
- 为此前缺少 UT 的路由补上基础的 smoke 测试，提升最小覆盖率。 

### Description

- 在 `backend/app/api/main.py` 注释掉 `users` 路由挂载，使用注释保留历史上下文（`# api_router.include_router(users.router)`）。
- 在 `backend/tests/api/routes/test_users.py` 顶部增加模块级跳过标记：`pytestmark = pytest.mark.skip(...)`，将 users 相关 UT 暂时停用。
- 新增 `backend/tests/api/routes/test_misc_routes.py`，添加对 `history/authors/cosers/parse/settings` 等路由的基础 smoke 测试以及 `POST /api/v1/private/users/` 的简单用例以补齐缺失的 API UT。 
- 已将变更提交到本分支（包含上述 3 个文件的修改/新增）。

### Testing

- 运行 `pytest -q tests/api/routes/test_misc_routes.py tests/api/routes/test_users.py` 以执行新增与被跳过的测试；测试无法启动因为当前环境缺少依赖，报错为 `ModuleNotFoundError: No module named 'fastapi'`。
- 由于运行环境缺少 `fastapi`，未能在本地完成通过/失败确认，新增的 smoke 测试在具备依赖的 CI/本地环境中应能运行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949194f9f483259d25314c95466ff0)