### PR TITLE
feat(home): 添加首页最常用文件夹 Top5（90 天衰减排行）

### DIFF
--- a/backend/app/api/routes/fs.py
+++ b/backend/app/api/routes/fs.py
@@ -313,6 +313,11 @@ class LibraryOverviewResponse(BaseModel):
     folders: int
 
 
+
+class TopOpenedFoldersResponse(BaseModel):
+    folder_ids: list[str]
+
+
 class PathOperationResponse(BaseModel):
     status: Literal["ok"]
     message: str
@@ -2155,6 +2160,15 @@ def get_recent_activity(
             for row in rows
         ]
     )
+
+
+
+@router.get("/top-opened-folders", response_model=TopOpenedFoldersResponse)
+def get_top_opened_folders(limit: int = Query(5, ge=1, le=20)) -> TopOpenedFoldersResponse:
+    with get_index_session() as session:
+        repo = IndexRepository(session)
+        folder_ids = repo.list_top_opened_folder_ids(limit=limit)
+    return TopOpenedFoldersResponse(folder_ids=folder_ids)
 
 
 # 接口说明：获取全库总览统计。

--- a/backend/app/index_db/alembic/versions/20260217_0003_add_top_opened_folder_indexes.py
+++ b/backend/app/index_db/alembic/versions/20260217_0003_add_top_opened_folder_indexes.py
@@ -1,0 +1,33 @@
+"""add indexes for top opened folders query
+
+Revision ID: 20260217_0003
+Revises: 20260217_0002
+Create Date: 2026-02-17
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20260217_0003"
+down_revision = "20260217_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_folder_open_history_last_opened_at",
+        "folder_open_history",
+        ["last_opened_at"],
+    )
+    op.create_index(
+        "idx_progress_last_opened_filepath",
+        "progress",
+        ["last_opened_at", "filepath"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_progress_last_opened_filepath", table_name="progress")
+    op.drop_index("idx_folder_open_history_last_opened_at", table_name="folder_open_history")

--- a/backend/app/index_db/repository.py
+++ b/backend/app/index_db/repository.py
@@ -26,7 +26,7 @@ import json
 from time import time
 from typing import Iterator, TypeVar
 
-from sqlalchemy import exists
+from sqlalchemy import exists, text
 from sqlmodel import Session, func, select
 
 from app.index_db.db import index_write_guard
@@ -373,6 +373,61 @@ class IndexRepository:
         self._commit()
         self.session.refresh(row)
         return row
+
+    def list_top_opened_folder_ids(
+        self,
+        *,
+        limit: int = 5,
+        now_ts: int | None = None,
+        lookback_days: int = 90,
+        tau_days: int = 14,
+    ) -> list[str]:
+        """Return top opened folder ids with time decay score in one SQLite SQL."""
+        if limit <= 0:
+            return []
+
+        now_ts = now_ts or _now_ts()
+        lookback_sec = max(1, lookback_days) * 24 * 60 * 60
+        tau_sec = max(1, tau_days) * 24 * 60 * 60
+        cutoff_ts = now_ts - lookback_sec
+
+        stmt = text(
+            """
+            WITH recent_events AS (
+                SELECT
+                    h.folderpath AS folder_id,
+                    h.last_opened_at AS opened_at_ts
+                FROM folder_open_history h
+                WHERE h.last_opened_at >= :cutoff_ts
+
+                UNION ALL
+
+                SELECT
+                    f.folderpath AS folder_id,
+                    p.last_opened_at AS opened_at_ts
+                FROM progress p
+                JOIN files f ON f.filepath = p.filepath
+                WHERE p.last_opened_at >= :cutoff_ts
+                  AND f.folderpath IS NOT NULL
+            )
+            SELECT folder_id
+            FROM recent_events
+            GROUP BY folder_id
+            ORDER BY SUM(exp(-((:now_ts - opened_at_ts) * 1.0) / :tau_sec)) DESC
+            LIMIT :limit;
+            """
+        )
+
+        rows = self.session.execute(
+            stmt,
+            {
+                "cutoff_ts": cutoff_ts,
+                "now_ts": now_ts,
+                "tau_sec": tau_sec,
+                "limit": limit,
+            },
+        ).all()
+        return [str(row[0]) for row in rows if row[0]]
 
     def log_activity(self, data: ActivityLogInput) -> ActivityLog:
         row = ActivityLog(

--- a/backend/tests/index_db/test_repository.py
+++ b/backend/tests/index_db/test_repository.py
@@ -6,6 +6,7 @@ import pytest
 from sqlmodel import Session, create_engine
 
 from app.index_db.bootstrap import ensure_index_db_initialized
+from app.index_db.models import File, Folder, FolderOpenHistory, Progress
 from app.index_db.repository import IndexRepository, UpsertFileInput, UpsertFolderInput
 
 
@@ -276,3 +277,34 @@ def test_batch_save_parse_results_handles_large_input_with_chunking(test_repo: I
     assert meta.title == "Title 1000"
     assert test_repo.get_file_artists(sample_fp)
     assert test_repo.get_file_tags(sample_fp)
+
+
+def test_list_top_opened_folder_ids_with_decay_and_lookback(test_repo: IndexRepository) -> None:
+    now_ts = 2_000_000_000
+
+    folder_a = Folder(filepath="/top/a", dirname="a")
+    folder_b = Folder(filepath="/top/b", dirname="b")
+    folder_old = Folder(filepath="/top/old", dirname="old")
+    file_b = File(
+        filepath="/top/b/file1.cbz",
+        folderpath="/top/b",
+        filename="file1.cbz",
+        mtime=now_ts,
+        filesize=100,
+        fingerprint="fp-top-b-1",
+    )
+
+    test_repo.session.add(folder_a)
+    test_repo.session.add(folder_b)
+    test_repo.session.add(folder_old)
+    test_repo.session.add(file_b)
+
+    test_repo.session.add(FolderOpenHistory(folderpath="/top/a", last_opened_at=now_ts - 3600, open_count=1, updated_at=now_ts - 3600))
+    test_repo.session.add(Progress(filepath="/top/b/file1.cbz", last_opened_at=now_ts - 60))
+    test_repo.session.add(FolderOpenHistory(folderpath="/top/old", last_opened_at=now_ts - 100 * 24 * 3600, open_count=1, updated_at=now_ts))
+    test_repo.session.commit()
+
+    folder_ids = test_repo.list_top_opened_folder_ids(limit=5, now_ts=now_ts)
+
+    assert folder_ids == ["/top/b", "/top/a"]
+

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -39,7 +39,9 @@
     "activityFilterSystem": "System Tasks",
     "activityEmptyHint": "Startup tasks will appear here after server boot.",
     "retry": "Retry",
-    "scannedFiles": "Scanned Files"
+    "scannedFiles": "Scanned Files",
+    "topOpenedFolders": "Most Opened Folders",
+    "noTopOpenedFolders": "No frequently opened folders in the last 90 days"
   },
   "explorer": {
     "scan": "Scan",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -39,7 +39,9 @@
     "activityFilterSystem": "システムタスク",
     "activityEmptyHint": "サーバー起動後、ここに自動タスクが表示されます。",
     "retry": "再試行",
-    "scannedFiles": "スキャン済みファイル"
+    "scannedFiles": "スキャン済みファイル",
+    "topOpenedFolders": "よく開くフォルダ",
+    "noTopOpenedFolders": "直近90日でよく開くフォルダのデータはありません"
   },
   "explorer": {
     "scan": "スキャン",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -40,7 +40,9 @@
     "activityFilterSystem": "시스템 작업",
     "activityEmptyHint": "서버 시작 후 자동 작업이 여기에 표시됩니다.",
     "retry": "재시도",
-    "scannedFiles": "스캔된 파일"
+    "scannedFiles": "스캔된 파일",
+    "topOpenedFolders": "자주 여는 폴더",
+    "noTopOpenedFolders": "최근 90일 자주 연 폴더 데이터가 없습니다"
   },
   "explorer": {
     "scan": "스캔",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -39,7 +39,9 @@
     "activityFilterSystem": "系统任务",
     "activityEmptyHint": "服务器启动后会自动执行扫描和同步任务。",
     "retry": "重试",
-    "scannedFiles": "已扫描文件"
+    "scannedFiles": "已扫描文件",
+    "topOpenedFolders": "最常用文件夹",
+    "noTopOpenedFolders": "最近 90 天暂无常用文件夹数据"
   },
   "explorer": {
     "scan": "扫描",

--- a/frontend/src/routes/_layout/index.tsx
+++ b/frontend/src/routes/_layout/index.tsx
@@ -22,6 +22,10 @@ type LibraryOverviewResponse = {
   folders: number
 }
 
+type TopOpenedFoldersResponse = {
+  folder_ids: string[]
+}
+
 export const Route = createFileRoute("/_layout/")({
   component: Dashboard,
   head: () => ({
@@ -69,6 +73,18 @@ function Dashboard() {
       const response = await fetch(`${OpenAPI.BASE}/api/v1/fs/recent-activity?limit=200&since_latest_startup=true`)
       if (!response.ok) {
         return { items: [] }
+      }
+      return response.json()
+    },
+  })
+
+
+  const { data: topOpenedFolders } = useQuery({
+    queryKey: ["home-top-opened-folders"],
+    queryFn: async (): Promise<TopOpenedFoldersResponse> => {
+      const response = await fetch(`${OpenAPI.BASE}/api/v1/fs/top-opened-folders?limit=5`)
+      if (!response.ok) {
+        return { folder_ids: [] }
       }
       return response.json()
     },
@@ -125,6 +141,19 @@ function Dashboard() {
               <HomeCard icon={Folder} title={root.dirname} />
             </Link>
           ))}
+        </div>
+      </section>
+
+
+      <section className="home-section">
+        <h2 className="home-section__title">{t("home.topOpenedFolders")}</h2>
+        <div className="home-grid home-grid--folders">
+          {topOpenedFolders?.folder_ids.map((folderPath) => (
+            <Link key={folderPath} to="/explorer" search={{ path: folderPath }} className="home-card-link">
+              <HomeCard icon={Folder} title={folderPath.split(/[\\/]/).filter(Boolean).at(-1) ?? folderPath} subtitle={folderPath} />
+            </Link>
+          ))}
+          {topOpenedFolders && topOpenedFolders.folder_ids.length === 0 ? <div className="home-empty">{t("home.noTopOpenedFolders")}</div> : null}
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- 首页需要展示“最常用文件夹”前五个，数据来源要综合 `folder_open_history` 与 `progress` 并考虑时间衰减与近 90 天窗口。 
- 要求在数据库端用一条 SQL 完成聚合与排序以减少 Python 端二次聚合开销。 
- 需要考虑查询性能并给出索引支持以应对较大数据量。 

### Description
- 在 `IndexRepository` 中新增 `list_top_opened_folder_ids`，使用单条 SQLite SQL（CTE + `UNION ALL` + 聚合）统计最近 90 天事件并按公式 `sum(exp(-(now - opened_at_ts)/tau))` 降序返回 `folder_id` 列表，默认 `limit=5` 且 `tau=14 天`（实现见 `backend/app/index_db/repository.py`）。
- 新增后端 API `GET /api/v1/fs/top-opened-folders`，返回模型 `TopOpenedFoldersResponse`（实现见 `backend/app/api/routes/fs.py`）。
- 增加 Alembic 迁移 `20260217_0003_add_top_opened_folder_indexes.py`，创建索引 `folder_open_history(last_opened_at)` 与 `progress(last_opened_at, filepath)` 以优化本查询（文件：`backend/app/index_db/alembic/versions/20260217_0003_add_top_opened_folder_indexes.py`）。
- 前端在首页复用现有“快捷访问”卡片样式新增“最常用文件夹”区块并调用新接口显示结果，新增类型与渲染逻辑（修改：`frontend/src/routes/_layout/index.tsx`），同时补充多语言键 `home.topOpenedFolders` 与 `home.noTopOpenedFolders`（zh/en/ja/ko）。
- 新增仓储层单元测试 `test_list_top_opened_folder_ids_with_decay_and_lookback`，验证来自 `folder_open_history` 与 `progress` 的合并、90 天过滤与衰减排序逻辑（文件：`backend/tests/index_db/test_repository.py`）。

### Testing
- 已对修改的 Python 文件运行 `python -m py_compile backend/app/index_db/repository.py backend/app/api/routes/fs.py backend/tests/index_db/test_repository.py`，编译检查通过。
- 运行 `pytest backend/tests/index_db/test_repository.py` 时测试加载失败，原因是运行环境缺少 `fastapi` 等依赖，导致 `ModuleNotFoundError: No module named 'fastapi'`，测试未能在 CI 环境完成。
- 尝试使用 Playwright 进行页面截图以验证前端展示时遇到本地服务不可达（`ERR_EMPTY_RESPONSE`），因此前端运行时验证未能完成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a8cc30788325ae3ba9ee0260dfdd)