### PR TITLE
抽离并改造文件同步根目录推导为 allowlist-aware 模块

### DIFF
--- a/backend/app/api/routes/fs.py
+++ b/backend/app/api/routes/fs.py
@@ -37,6 +37,7 @@ from app.index_db.confidence import compute_confidence
 from app.index_db.db import get_index_session
 from app.index_db.models import File, Folder
 from app.index_db.repository import ActivityLogInput, IndexRepository, UpsertFileInput, UpsertFolderInput
+from app.services.file_sync_roots import derive_minimal_scan_roots, is_filesystem_root, normalize_allowed_roots
 from app.services.thumb_service import ThumbService
 from app.utils import detect_file_type, get_mime_type
 
@@ -814,18 +815,6 @@ def _is_target_extension(name: str) -> bool:
     return any(lowered.endswith(suffix) for suffix in _TARGET_SUFFIXES)
 
 
-def _derive_minimal_root_dirs(filepaths: Iterable[str]) -> list[Path]:
-    """从 file 表路径推导最小覆盖目录集合（不向上扩展）。"""
-    dir_paths = sorted({str(Path(filepath).parent) for filepath in filepaths if filepath}, key=lambda x: (x.count(os.sep), x))
-    selected: list[Path] = []
-    for dir_path in dir_paths:
-        candidate = Path(dir_path)
-        if any(candidate == root or candidate.is_relative_to(root) for root in selected):
-            continue
-        selected.append(candidate)
-    return selected
-
-
 def _snapshot_covers_root(snapshot_root: str, root: Path) -> bool:
     snapshot_path = Path(snapshot_root)
     return root == snapshot_path or root.is_relative_to(snapshot_path)
@@ -868,15 +857,6 @@ def _should_skip_sync_path(path: Path) -> bool:
     return any(fragment in normalized for fragment in skip_fragments)
 
 
-def _is_filesystem_root(path: Path) -> bool:
-    """判断路径是否为文件系统根目录（如 Windows 的 C:\\ 或 POSIX 的 /）。"""
-    try:
-        resolved = path.resolve()
-    except Exception:
-        resolved = path
-    return resolved.parent == resolved
-
-
 def _has_windows_reparse_point(path: Path | str) -> bool:
     """Windows 下判断路径是否为 reparse point（junction/symlink 等）。"""
     if os.name != "nt":
@@ -913,7 +893,7 @@ def _collect_allowed_sync_roots() -> list[Path]:
             except Exception:
                 logger.warning("[file-sync] skip invalid allowed root config: %s", optional_dir)
 
-    allowlist: list[Path] = []
+    existing_candidates: list[Path] = []
     for candidate in candidates:
         try:
             resolved = candidate.resolve()
@@ -921,19 +901,16 @@ def _collect_allowed_sync_roots() -> list[Path]:
             continue
         if not resolved.exists() or not resolved.is_dir():
             continue
-        if _is_filesystem_root(resolved):
+        if is_filesystem_root(resolved):
             logger.warning(
                 "[file-sync] skip allowed root because filesystem root is forbidden: %s",
                 resolved,
             )
             continue
 
-        if any(resolved == root or resolved.is_relative_to(root) for root in allowlist):
-            continue
-        allowlist = [root for root in allowlist if not root.is_relative_to(resolved)]
-        allowlist.append(resolved)
+        existing_candidates.append(resolved)
 
-    return allowlist
+    return normalize_allowed_roots(existing_candidates)
 
 
 def _scan_root_with_scandir(root: Path) -> dict[str, tuple[int, int]]:
@@ -944,7 +921,7 @@ def _scan_root_with_scandir(root: Path) -> dict[str, tuple[int, int]]:
 
     while pending:
         current = pending.pop()
-        if _is_filesystem_root(current):
+        if is_filesystem_root(current):
             logger.warning("[file-sync] skip filesystem root directory: %s", current)
             continue
         if _should_skip_sync_path(current):
@@ -963,7 +940,7 @@ def _scan_root_with_scandir(root: Path) -> dict[str, tuple[int, int]]:
                             if name.startswith(".") or should_ignore(name):
                                 continue
                             dir_path = Path(entry.path)
-                            if _is_filesystem_root(dir_path):
+                            if is_filesystem_root(dir_path):
                                 logger.warning("[file-sync] skip filesystem root directory: %s", dir_path)
                                 continue
                             if _should_skip_sync_path(dir_path):
@@ -1065,22 +1042,11 @@ def _sync_file_table_with_filesystem() -> None:
                 return
 
             db_map: dict[str, tuple[int, int, int]] = {fp: (int(size), int(mtime), int(scan_state)) for fp, size, mtime, scan_state in db_rows}
-            root_dirs = _derive_minimal_root_dirs(db_map.keys())
             allowed_roots = _collect_allowed_sync_roots()
-
-            filtered_roots: list[Path] = []
-            for root_dir in root_dirs:
-                if _is_filesystem_root(root_dir):
-                    logger.warning("[file-sync] skip filesystem root directory: %s", root_dir)
-                    continue
-
-                if allowed_roots and not any(root_dir == ar or root_dir.is_relative_to(ar) for ar in allowed_roots):
-                    logger.info("[file-sync] skip root outside allowlist: %s", root_dir)
-                    continue
-
-                filtered_roots.append(root_dir)
-
-            root_dirs = filtered_roots
+            root_dirs = derive_minimal_scan_roots(
+                db_map.keys(),
+                allowed_roots=allowed_roots,
+            )
 
             real_map: dict[str, tuple[int, int]] = {}
             for root_dir in root_dirs:

--- a/backend/app/services/file_sync_roots.py
+++ b/backend/app/services/file_sync_roots.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+
+def is_filesystem_root(path: Path) -> bool:
+    """判断路径是否为文件系统根目录（如 Windows 的 C:\\ 或 POSIX 的 /）。"""
+    try:
+        resolved = path.resolve()
+    except Exception:
+        resolved = path
+    return resolved.parent == resolved
+
+
+def normalize_allowed_roots(allowed_roots: Iterable[Path]) -> list[Path]:
+    """标准化允许扫描根目录，并折叠嵌套目录。"""
+    normalized: list[Path] = []
+    for candidate in allowed_roots:
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            continue
+
+        if any(resolved == root or resolved.is_relative_to(root) for root in normalized):
+            continue
+        normalized = [root for root in normalized if not root.is_relative_to(resolved)]
+        normalized.append(resolved)
+
+    return normalized
+
+
+def derive_minimal_scan_roots(
+    filepaths: Iterable[str],
+    *,
+    allowed_roots: Iterable[Path] = (),
+) -> list[Path]:
+    """从文件路径推导最小扫描根目录集合，并在推导过程中剔除不可扫描目录。"""
+    normalized_allowed = normalize_allowed_roots(allowed_roots)
+
+    candidates: set[Path] = set()
+    for filepath in filepaths:
+        if not filepath:
+            continue
+
+        parent = Path(filepath).parent
+        try:
+            candidate = parent.resolve()
+        except Exception:
+            candidate = parent
+
+        if is_filesystem_root(candidate):
+            continue
+
+        if normalized_allowed and not any(candidate == root or candidate.is_relative_to(root) for root in normalized_allowed):
+            continue
+
+        candidates.add(candidate)
+
+    ordered = sorted(candidates, key=lambda p: (len(p.parts), str(p)))
+    selected: list[Path] = []
+    for candidate in ordered:
+        if any(candidate == root or candidate.is_relative_to(root) for root in selected):
+            continue
+        selected.append(candidate)
+
+    return selected

--- a/backend/tests/api/routes/test_fs.py
+++ b/backend/tests/api/routes/test_fs.py
@@ -887,15 +887,6 @@ def test_backfill_directory_non_recursive(
     assert payload["backfilled_meta"] >= 2
 
 
-def test_derive_minimal_root_dirs_removes_nested_dirs() -> None:
-    roots = fs_route._derive_minimal_root_dirs([
-        "/data/library/a/1.jpg",
-        "/data/library/a/sub/2.jpg",
-        "/data/library/b/3.jpg",
-    ])
-
-    assert roots == [Path('/data/library/a'), Path('/data/library/b')]
-
 
 def test_scan_root_with_scandir_skips_hidden_and_ignored(tmp_path: Path) -> None:
     root = tmp_path / "root"

--- a/backend/tests/services/test_file_sync_roots.py
+++ b/backend/tests/services/test_file_sync_roots.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
+
+import pytest
 
 from app.services import file_sync_roots
 
@@ -49,3 +51,54 @@ def test_normalize_allowed_roots_collapses_nested_entries() -> None:
     )
 
     assert allowlist == [Path('/safe')]
+
+
+def test_derive_minimal_scan_roots_windows_multi_drive_large_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows 场景：覆盖 C/D/E 多盘、多层级、100+ 文件路径，确保不会导出非法根。"""
+    class _TestWindowsPath(PureWindowsPath):
+        def resolve(self) -> "_TestWindowsPath":
+            return self
+
+    monkeypatch.setattr(file_sync_roots, "Path", _TestWindowsPath)
+
+    filepaths: list[str] = []
+    # 3 个盘符 * 40 条 = 120 条，覆盖不同层级
+    for drive in ("C", "D", "E"):
+        for idx in range(40):
+            depth = (idx % 5) + 1
+            parts = [f"lvl{n}_{idx % 7}" for n in range(depth)]
+            filename = f"file_{idx}.jpg"
+            filepaths.append(str(PureWindowsPath(f"{drive}:/").joinpath(*parts, filename)))
+
+    # 补充几类边界样本：盘符根文件、允许目录深层文件、明显越界路径
+    filepaths.extend(
+        [
+            r"C:\root_level.mp4",
+            r"D:\root_level.mp4",
+            r"E:\root_level.mp4",
+            r"C:\media\books\sub\ok_1.zip",
+            r"D:\library\novels\sub\ok_2.zip",
+            r"E:\outside\forbidden\x.zip",
+        ]
+    )
+
+    roots = file_sync_roots.derive_minimal_scan_roots(
+        filepaths,
+        allowed_roots=[
+            file_sync_roots.Path(r"C:\media"),
+            file_sync_roots.Path(r"D:\library"),
+        ],
+    )
+
+    # 所有结果都应在 allowlist 内
+    allowed = [file_sync_roots.Path(r"C:\media"), file_sync_roots.Path(r"D:\library")]
+    assert roots
+    assert all(any(root == ar or root.is_relative_to(ar) for ar in allowed) for root in roots)
+
+    # 不应出现盘符根目录，避免误扫整盘
+    forbidden_roots = {PureWindowsPath("C:/"), PureWindowsPath("D:/"), PureWindowsPath("E:/")}
+    assert all(root not in forbidden_roots for root in roots)
+
+    # 不应出现 E 盘路径（不在 allowlist）
+    assert all(str(root).startswith(("C:\\", "D:\\")) for root in roots)
+    assert all(not str(root).startswith("E:\\") for root in roots)

--- a/backend/tests/services/test_file_sync_roots.py
+++ b/backend/tests/services/test_file_sync_roots.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services import file_sync_roots
+
+
+def test_derive_minimal_scan_roots_removes_nested_dirs() -> None:
+    roots = file_sync_roots.derive_minimal_scan_roots(
+        [
+            "/data/library/a/1.jpg",
+            "/data/library/a/sub/2.jpg",
+            "/data/library/b/3.jpg",
+        ]
+    )
+
+    assert roots == [Path('/data/library/a'), Path('/data/library/b')]
+
+
+def test_derive_minimal_scan_roots_skips_filesystem_root() -> None:
+    roots = file_sync_roots.derive_minimal_scan_roots([
+        "/a.jpg",
+        "/safe/lib/book.jpg",
+    ])
+
+    assert roots == [Path('/safe/lib')]
+
+
+def test_derive_minimal_scan_roots_applies_allowlist_during_derivation() -> None:
+    roots = file_sync_roots.derive_minimal_scan_roots(
+        [
+            "/safe/library/a.jpg",
+            "/outside/data/b.jpg",
+            "/safe/library/sub/c.jpg",
+        ],
+        allowed_roots=[Path('/safe')],
+    )
+
+    assert roots == [Path('/safe/library')]
+
+
+def test_normalize_allowed_roots_collapses_nested_entries() -> None:
+    allowlist = file_sync_roots.normalize_allowed_roots(
+        [
+            Path('/safe/library'),
+            Path('/safe'),
+            Path('/safe/books'),
+        ]
+    )
+
+    assert allowlist == [Path('/safe')]


### PR DESCRIPTION
### Motivation

- 避免先从 DB 路径推导出根目录再去过滤不可扫描的根（如 C:\ 或 `/`），应在推导过程中就考虑 allowlist 与文件系统根排除，以降低误扫描风险并保持所有索引文件被覆盖。 
- 将该逻辑独立成模块以便更好地单元测试与复用，减少 `fs.py` 的职责与重复代码。 

### Description

- 新增 `backend/app/services/file_sync_roots.py`，实现 `derive_minimal_scan_roots`、`normalize_allowed_roots`、`is_filesystem_root` 三个函数，推导过程中直接排除文件系统根并在有 allowlist 时只保留 allowlist 范围内的根。 
- 在 `backend/app/api/routes/fs.py` 中引入并复用上述模块，移除原有的 `_derive_minimal_root_dirs` 与 `_is_filesystem_root` 局部实现，`_collect_allowed_sync_roots` 改为使用 `normalize_allowed_roots`，扫描与目录检查处统一使用 `is_filesystem_root`，以及在同步流程中用 `derive_minimal_scan_roots(..., allowed_roots=...)` 直接推导可扫描根。 
- 新增单元测试 `backend/tests/services/test_file_sync_roots.py`，覆盖去重最小根目录、跳过文件系统根、推导时应用 allowlist 以及 allowlist 折叠等场景，并移除了原来路由层关于旧 `_derive_minimal_root_dirs` 的冗余测试用例。 

### Testing

- 成功对相关模块与测试文件运行了编译检查：`python -m compileall -q backend/app/services/file_sync_roots.py backend/app/api/routes/fs.py backend/tests/services/test_file_sync_roots.py backend/tests/api/routes/test_fs.py`（编译通过）。
- 在当前执行环境尝试跑定位用的 `pytest` 时触发环境依赖问题导致失败：`ModuleNotFoundError: No module named 'fastapi'`，因此路由级联的部分测试未能在本环境跑通。 
- 已将修改提交到仓库（包括新增模块与测试）并形成 PR。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699515d498b083258069456281840f04)