### PR TITLE
refactor(frontend): replace navigate-on-click with real links

### DIFF
--- a/frontend/src/components/Common/FileNotFoundError.tsx
+++ b/frontend/src/components/Common/FileNotFoundError.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { PathBreadcrumb } from "@/components/Common/PathBreadcrumb"
 import { Button } from "@/components/ui/button"
@@ -19,7 +19,6 @@ export function FileNotFoundError({
   parentPath,
 }: FileNotFoundErrorProps) {
   const { t } = useTranslation()
-  const navigate = useNavigate()
 
   return (
     <div className="space-y-4 p-[10px]">
@@ -52,17 +51,14 @@ export function FileNotFoundError({
               : t("explorer.loadErrorMessage", { errorMessage })}
           </p>
           <div className="pt-4 flex gap-2 justify-center">
-            <Button variant="outline" onClick={() => navigate({ to: "/" })}>
-              {t("explorer.returnHome")}
+            <Button variant="outline" asChild>
+              <Link to="/">{t("explorer.returnHome")}</Link>
             </Button>
             {parentPath && (
-              <Button
-                variant="outline"
-                onClick={() =>
-                  navigate({ to: "/explorer", search: { path: parentPath } })
-                }
-              >
-                {t("explorer.openParent")}
+              <Button variant="outline" asChild>
+                <Link to="/explorer" search={{ path: parentPath }}>
+                  {t("explorer.openParent")}
+                </Link>
               </Button>
             )}
           </div>

--- a/frontend/src/components/Common/FileNotFoundError.tsx
+++ b/frontend/src/components/Common/FileNotFoundError.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { PathBreadcrumb } from "@/components/Common/PathBreadcrumb"
-import { Button } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 
 interface FileNotFoundErrorProps {
   path: string
@@ -51,15 +51,17 @@ export function FileNotFoundError({
               : t("explorer.loadErrorMessage", { errorMessage })}
           </p>
           <div className="pt-4 flex gap-2 justify-center">
-            <Button variant="outline" asChild>
-              <Link to="/">{t("explorer.returnHome")}</Link>
-            </Button>
+            <Link to="/" className={buttonVariants({ variant: "outline" })}>
+              {t("explorer.returnHome")}
+            </Link>
             {parentPath && (
-              <Button variant="outline" asChild>
-                <Link to="/explorer" search={{ path: parentPath }}>
-                  {t("explorer.openParent")}
-                </Link>
-              </Button>
+              <Link
+                to="/explorer"
+                search={{ path: parentPath }}
+                className={buttonVariants({ variant: "outline" })}
+              >
+                {t("explorer.openParent")}
+              </Link>
             )}
           </div>
         </div>

--- a/frontend/src/routes/_layout/history.tsx
+++ b/frontend/src/routes/_layout/history.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import {
   ArrowDown,
   ArrowUp,
@@ -114,27 +114,25 @@ function HistoryPage() {
     }
   }
 
-  const openHistoryItem = (item: HistoryItem) => {
+
+  const getHistoryItemLink = (item: HistoryItem) => {
     if (item.file_type === "archive") {
-      navigate({ to: "/archive", search: { path: item.filepath } })
-      return
+      return { to: "/archive", search: { path: item.filepath } } as const
     }
     if (item.file_type === "video") {
-      navigate({
+      return {
         to: "/video",
         search: { path: item.filepath, entry: undefined, media: "video" },
-      })
-      return
+      } as const
     }
     if (item.file_type === "audio") {
-      navigate({
+      return {
         to: "/audio",
         search: { path: item.filepath, entry: undefined },
-      })
-      return
+      } as const
     }
     if (item.file_type === "image") {
-      navigate({
+      return {
         to: isMobile ? "/read-mobile" : "/read",
         search: {
           path: getParentPath(item.filepath),
@@ -142,11 +140,19 @@ function HistoryPage() {
           page: 0,
           filePath: item.filepath,
         },
-      })
+      } as const
+    }
+
+    return null
+  }
+  const openHistoryItem = (item: HistoryItem) => {
+    const target = getHistoryItemLink(item)
+    if (!target) {
+      toast.info(t("history.unsupportedType"))
       return
     }
 
-    toast.info(t("history.unsupportedType"))
+    navigate(target)
   }
 
   const tableColumns: ListTableColumn[] = [
@@ -269,27 +275,41 @@ function HistoryPage() {
         <ListTable
           columns={tableColumns}
           rows={data?.items ?? []}
-          renderRow={(item) => (
-            <tr
-              key={`${item.filepath}-${item.read_at}`}
-              className="border-b last:border-b-0 text-sm cursor-pointer hover:bg-muted/50"
-              onClick={() => openHistoryItem(item)}
-            >
-              <td className="p-2">
-                <div className="flex items-center gap-2 min-w-0">
-                  <FileNameWithPreview
-                    filename={item.filename}
-                    filepath={item.filepath}
-                    thumbnailUrl={item.thumbnail_url}
-                    className="min-w-0"
-                  />
-                </div>
-              </td>
-              <td className="p-2 text-muted-foreground">{formatDateTime(item.read_at)}</td>
-              <td className="p-2 text-muted-foreground">{formatFileType(item.file_type)}</td>
-              <td className="p-2 text-right text-muted-foreground">{item.filesize ? formatFileSize(item.filesize) : "-"}</td>
-            </tr>
-          )}
+          renderRow={(item) => {
+            const target = getHistoryItemLink(item)
+
+            return (
+              <tr
+                key={`${item.filepath}-${item.read_at}`}
+                className="border-b last:border-b-0 text-sm hover:bg-muted/50"
+              >
+                <td className="p-2">
+                  {target ? (
+                    <Link to={target.to} search={target.search} className="flex items-center gap-2 min-w-0">
+                      <FileNameWithPreview
+                        filename={item.filename}
+                        filepath={item.filepath}
+                        thumbnailUrl={item.thumbnail_url}
+                        className="min-w-0"
+                      />
+                    </Link>
+                  ) : (
+                    <div className="flex items-center gap-2 min-w-0">
+                      <FileNameWithPreview
+                        filename={item.filename}
+                        filepath={item.filepath}
+                        thumbnailUrl={item.thumbnail_url}
+                        className="min-w-0"
+                      />
+                    </div>
+                  )}
+                </td>
+                <td className="p-2 text-muted-foreground">{formatDateTime(item.read_at)}</td>
+                <td className="p-2 text-muted-foreground">{formatFileType(item.file_type)}</td>
+                <td className="p-2 text-right text-muted-foreground">{item.filesize ? formatFileSize(item.filesize) : "-"}</td>
+              </tr>
+            )
+          }}
         />
       )}
 

--- a/frontend/src/routes/_layout/read.tsx
+++ b/frontend/src/routes/_layout/read.tsx
@@ -31,7 +31,7 @@ import { RenameDialog } from "@/components/Files/dialogs/RenameDialog"
 import { formatDateTime, formatFileSize } from "@/components/Files/utils"
 import { ExtractingIndicator } from "@/components/semantic/layout"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -496,16 +496,24 @@ function ReadPage() {
           <div className="reader-empty-header__actions">
             {!isFolderSource && (
               <>
-                <Button variant="default" size="sm" className="animate-pulse" asChild>
-                  <Link to="/archive" search={{ path }}>
-                    Explorer
-                  </Link>
-                </Button>
-                <Button variant="outline" size="sm" asChild>
-                  <Link to="/read-waterfall" search={{ path }}>
-                    Waterfall
-                  </Link>
-                </Button>
+                <Link
+                  to="/archive"
+                  search={{ path }}
+                  className={buttonVariants({
+                    variant: "default",
+                    size: "sm",
+                    className: "animate-pulse",
+                  })}
+                >
+                  Explorer
+                </Link>
+                <Link
+                  to="/read-waterfall"
+                  search={{ path }}
+                  className={buttonVariants({ variant: "outline", size: "sm" })}
+                >
+                  Waterfall
+                </Link>
               </>
             )}
           </div>
@@ -679,26 +687,28 @@ function ReadPage() {
           </Button> */}
             {!isFolderSource && (
               <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="reader-toolbar__text-button"
-                  asChild
+                <Link
+                  to="/archive"
+                  search={{ path }}
+                  className={buttonVariants({
+                    variant: "ghost",
+                    size: "sm",
+                    className: "reader-toolbar__text-button",
+                  })}
                 >
-                  <Link to="/archive" search={{ path }}>
-                    Explorer
-                  </Link>
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="reader-toolbar__text-button"
-                  asChild
+                  Explorer
+                </Link>
+                <Link
+                  to="/read-waterfall"
+                  search={{ path }}
+                  className={buttonVariants({
+                    variant: "ghost",
+                    size: "sm",
+                    className: "reader-toolbar__text-button",
+                  })}
                 >
-                  <Link to="/read-waterfall" search={{ path }}>
-                    Waterfall
-                  </Link>
-                </Button>
+                  Waterfall
+                </Link>
               </>
             )}
             {/* File Operations Dropdown */}

--- a/frontend/src/routes/_layout/read.tsx
+++ b/frontend/src/routes/_layout/read.tsx
@@ -496,22 +496,15 @@ function ReadPage() {
           <div className="reader-empty-header__actions">
             {!isFolderSource && (
               <>
-                <Button
-                  variant="default"
-                  size="sm"
-                  onClick={() => navigate({ to: "/archive", search: { path } })}
-                  className="animate-pulse"
-                >
-                  Explorer
+                <Button variant="default" size="sm" className="animate-pulse" asChild>
+                  <Link to="/archive" search={{ path }}>
+                    Explorer
+                  </Link>
                 </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    navigate({ to: "/read-waterfall", search: { path } })
-                  }
-                >
-                  Waterfall
+                <Button variant="outline" size="sm" asChild>
+                  <Link to="/read-waterfall" search={{ path }}>
+                    Waterfall
+                  </Link>
                 </Button>
               </>
             )}
@@ -690,19 +683,21 @@ function ReadPage() {
                   variant="ghost"
                   size="sm"
                   className="reader-toolbar__text-button"
-                  onClick={() => navigate({ to: "/archive", search: { path } })}
+                  asChild
                 >
-                  Explorer
+                  <Link to="/archive" search={{ path }}>
+                    Explorer
+                  </Link>
                 </Button>
                 <Button
                   variant="ghost"
                   size="sm"
                   className="reader-toolbar__text-button"
-                  onClick={() =>
-                    navigate({ to: "/read-waterfall", search: { path } })
-                  }
+                  asChild
                 >
-                  Waterfall
+                  <Link to="/read-waterfall" search={{ path }}>
+                    Waterfall
+                  </Link>
                 </Button>
               </>
             )}


### PR DESCRIPTION
### Motivation
- 将以 `onClick` + `navigate` 执行页面跳转的交互替换为真实的 `<Link>`，以便支持用户使用中键或 Ctrl/Cmd+左键在新标签页打开目标页面。 
- 目标主要聚焦于阅读器（reader）工具栏 / 空状态按钮、历史记录（history）列表的表格视图以及文件未找到提示页的导航交互。 

### Description
- 把 `frontend/src/routes/_layout/read.tsx` 中空状态头部与顶部工具栏的 `Explorer` / `Waterfall` 按钮改为通过 `Button asChild` 包装真实的 `Link`，从而支持常规点击与新标签页打开。 
- 在 `frontend/src/routes/_layout/history.tsx` 中新增 `getHistoryItemLink` 辅助函数统一生成跳转目标，并将表格视图中文件名渲染为真实的 `Link`（grid 视图仍保留点击打开以支持原来的行为），确保表格左键跳转和 Ctrl/Cmd+点击新标签均可用。 
- 将 `frontend/src/components/Common/FileNotFoundError.tsx` 中的“返回首页 / 打开父目录”按钮改为 `Button asChild` + `Link` 实现，移除对 `useNavigate` 的直接依赖。 
- 涉及文件：`frontend/src/routes/_layout/read.tsx`、`frontend/src/routes/_layout/history.tsx`、`frontend/src/components/Common/FileNotFoundError.tsx`。 

### Testing
- 运行 `git diff --check` 检查代码风格/冲突，结果通过。 
- 尝试运行 `npm run build` 进行构建，构建过程在当前环境因缺少前端依赖和类型声明报大量 `Cannot find module` 错误导致失败，错误属于环境依赖缺失，与本次代码逻辑变更无关。 
- 使用 Playwright 脚本尝试对本地 dev 服务截图以验证页面交互，但本地未启动前端服务导致 `page.goto('http://127.0.0.1:5173')` 返回 `ERR_EMPTY_RESPONSE`，因此未生成运行时截图验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699516cf41c083258d955cd5d13dbd43)