### PR TITLE
feat(frontend): 将 Explorer/History 表格的文件名改为真实 Link 并新增共用 FileNameLinkCell

### DIFF
--- a/frontend/src/components/Common/FileNotFoundError.tsx
+++ b/frontend/src/components/Common/FileNotFoundError.tsx
@@ -1,7 +1,7 @@
-import { useNavigate } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 import { PathBreadcrumb } from "@/components/Common/PathBreadcrumb"
-import { Button } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 
 interface FileNotFoundErrorProps {
   path: string
@@ -19,7 +19,6 @@ export function FileNotFoundError({
   parentPath,
 }: FileNotFoundErrorProps) {
   const { t } = useTranslation()
-  const navigate = useNavigate()
 
   return (
     <div className="space-y-4 p-[10px]">
@@ -52,18 +51,17 @@ export function FileNotFoundError({
               : t("explorer.loadErrorMessage", { errorMessage })}
           </p>
           <div className="pt-4 flex gap-2 justify-center">
-            <Button variant="outline" onClick={() => navigate({ to: "/" })}>
+            <Link to="/" className={buttonVariants({ variant: "outline" })}>
               {t("explorer.returnHome")}
-            </Button>
+            </Link>
             {parentPath && (
-              <Button
-                variant="outline"
-                onClick={() =>
-                  navigate({ to: "/explorer", search: { path: parentPath } })
-                }
+              <Link
+                to="/explorer"
+                search={{ path: parentPath }}
+                className={buttonVariants({ variant: "outline" })}
               >
                 {t("explorer.openParent")}
-              </Button>
+              </Link>
             )}
           </div>
         </div>

--- a/frontend/src/components/Files/FileNameLinkCell.tsx
+++ b/frontend/src/components/Files/FileNameLinkCell.tsx
@@ -1,0 +1,50 @@
+import { Link } from "@tanstack/react-router"
+
+import type { FileSystemItem } from "@/client"
+import { cn } from "@/lib/utils"
+import { FileIcon } from "./FileIcon"
+import { FileNameWithPreview } from "./FileNameWithPreview"
+
+type LinkTarget = {
+  to: string
+  search?: Record<string, unknown>
+}
+
+interface FileNameLinkCellProps {
+  item: FileSystemItem
+  target?: LinkTarget | null
+  className?: string
+}
+
+export function FileNameLinkCell({ item, target, className }: FileNameLinkCellProps) {
+  const isFolder = item.item_type === "folder"
+
+  const content = (
+    <>
+      <FileIcon fileType={item.file_type} isFolder={isFolder} size="sm" />
+      <FileNameWithPreview
+        filename={item.name}
+        filepath={item.path}
+        thumbnailUrl={item.thumbnail_url}
+        className="min-w-0"
+      />
+    </>
+  )
+
+  if (!target) {
+    return <div className={cn("flex min-w-0 items-center gap-2", className)}>{content}</div>
+  }
+
+  return (
+    <Link
+      to={target.to}
+      search={target.search}
+      className={cn("flex min-w-0 items-center gap-2", className)}
+      onClick={(e) => {
+        e.stopPropagation()
+      }}
+    >
+      {content}
+    </Link>
+  )
+}

--- a/frontend/src/components/Files/FileTableView.tsx
+++ b/frontend/src/components/Files/FileTableView.tsx
@@ -2,12 +2,14 @@
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
+import { useIsMobile } from "@/hooks/useMobile"
+
 import type { FileSystemItem } from "@/client"
 import { ListTable, type ListTableColumn } from "@/components/Common/ListTable"
 import { cn } from "@/lib/utils"
 import { FileContextMenu, type FileContextMenuActions } from "./FileContextMenu"
-import { FileIcon } from "./FileIcon"
-import { FileNameWithPreview } from "./FileNameWithPreview"
+import { buildNavigationTarget } from "@/hooks/useFileNavigation"
+import { FileNameLinkCell } from "./FileNameLinkCell"
 import { formatDateTime, formatFileSize, formatFileType } from "./utils"
 
 export type SortField =
@@ -96,16 +98,15 @@ export function FileTableView({
 
 function TableRowCells({ item }: { item: FileSystemItem }) {
   const { t } = useTranslation()
+  const isMobile = useIsMobile()
   const isFolder = item.item_type === "folder"
   const isArchive = item.file_type === "archive"
+  const target = buildNavigationTarget(item, isMobile)
 
   return (
     <>
       <td className="p-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <FileIcon fileType={item.file_type} isFolder={isFolder} size="sm" />
-          <FileNameWithPreview filename={item.name} filepath={item.path} thumbnailUrl={item.thumbnail_url} className="min-w-0" />
-        </div>
+        <FileNameLinkCell item={item} target={target} />
       </td>
       <td className="p-2 text-muted-foreground">{item.mtime ? formatDateTime(item.mtime) : "-"}</td>
       <td className="p-2 text-muted-foreground">{isFolder ? t("file.folder") : formatFileType(item.file_type)}</td>

--- a/frontend/src/hooks/useFileNavigation.ts
+++ b/frontend/src/hooks/useFileNavigation.ts
@@ -7,7 +7,7 @@ import { useIsMobile } from "@/hooks/useMobile"
 import { getParentPath } from "@/lib/path-utils"
 
 /** 根据文件类型构建导航目标 */
-function buildNavigationTarget(item: FileSystemItem, isMobile: boolean) {
+export function buildNavigationTarget(item: FileSystemItem, isMobile: boolean) {
   const isFolder = item.item_type === "folder"
   const isArchive = item.file_type === "archive"
   const isVideo = item.file_type === "video"

--- a/frontend/src/routes/_layout/history.tsx
+++ b/frontend/src/routes/_layout/history.tsx
@@ -15,7 +15,7 @@ import { OpenAPI } from "@/client"
 import type { FileSystemItem } from "@/client/types.gen"
 import { ListTable, type ListTableColumn } from "@/components/Common/ListTable"
 import { FileItem } from "@/components/Files/FileItem"
-import { FileNameWithPreview } from "@/components/Files/FileNameWithPreview"
+import { FileNameLinkCell } from "@/components/Files/FileNameLinkCell"
 import {
   formatDateTime,
   formatFileSize,
@@ -114,27 +114,25 @@ function HistoryPage() {
     }
   }
 
-  const openHistoryItem = (item: HistoryItem) => {
+
+  const getHistoryItemLink = (item: HistoryItem) => {
     if (item.file_type === "archive") {
-      navigate({ to: "/archive", search: { path: item.filepath } })
-      return
+      return { to: "/archive", search: { path: item.filepath } } as const
     }
     if (item.file_type === "video") {
-      navigate({
+      return {
         to: "/video",
         search: { path: item.filepath, entry: undefined, media: "video" },
-      })
-      return
+      } as const
     }
     if (item.file_type === "audio") {
-      navigate({
+      return {
         to: "/audio",
         search: { path: item.filepath, entry: undefined },
-      })
-      return
+      } as const
     }
     if (item.file_type === "image") {
-      navigate({
+      return {
         to: isMobile ? "/read-mobile" : "/read",
         search: {
           path: getParentPath(item.filepath),
@@ -142,11 +140,19 @@ function HistoryPage() {
           page: 0,
           filePath: item.filepath,
         },
-      })
+      } as const
+    }
+
+    return null
+  }
+  const openHistoryItem = (item: HistoryItem) => {
+    const target = getHistoryItemLink(item)
+    if (!target) {
+      toast.info(t("history.unsupportedType"))
       return
     }
 
-    toast.info(t("history.unsupportedType"))
+    navigate(target)
   }
 
   const tableColumns: ListTableColumn[] = [
@@ -269,27 +275,23 @@ function HistoryPage() {
         <ListTable
           columns={tableColumns}
           rows={data?.items ?? []}
-          renderRow={(item) => (
-            <tr
-              key={`${item.filepath}-${item.read_at}`}
-              className="border-b last:border-b-0 text-sm cursor-pointer hover:bg-muted/50"
-              onClick={() => openHistoryItem(item)}
-            >
-              <td className="p-2">
-                <div className="flex items-center gap-2 min-w-0">
-                  <FileNameWithPreview
-                    filename={item.filename}
-                    filepath={item.filepath}
-                    thumbnailUrl={item.thumbnail_url}
-                    className="min-w-0"
-                  />
-                </div>
-              </td>
-              <td className="p-2 text-muted-foreground">{formatDateTime(item.read_at)}</td>
-              <td className="p-2 text-muted-foreground">{formatFileType(item.file_type)}</td>
-              <td className="p-2 text-right text-muted-foreground">{item.filesize ? formatFileSize(item.filesize) : "-"}</td>
-            </tr>
-          )}
+          renderRow={(item) => {
+            const target = getHistoryItemLink(item)
+
+            return (
+              <tr
+                key={`${item.filepath}-${item.read_at}`}
+                className="border-b last:border-b-0 text-sm hover:bg-muted/50"
+              >
+                <td className="p-2">
+                  <FileNameLinkCell item={toFileSystemItem(item)} target={target} />
+                </td>
+                <td className="p-2 text-muted-foreground">{formatDateTime(item.read_at)}</td>
+                <td className="p-2 text-muted-foreground">{formatFileType(item.file_type)}</td>
+                <td className="p-2 text-right text-muted-foreground">{item.filesize ? formatFileSize(item.filesize) : "-"}</td>
+              </tr>
+            )
+          }}
         />
       )}
 

--- a/frontend/src/routes/_layout/read.tsx
+++ b/frontend/src/routes/_layout/read.tsx
@@ -31,7 +31,7 @@ import { RenameDialog } from "@/components/Files/dialogs/RenameDialog"
 import { formatDateTime, formatFileSize } from "@/components/Files/utils"
 import { ExtractingIndicator } from "@/components/semantic/layout"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -496,23 +496,24 @@ function ReadPage() {
           <div className="reader-empty-header__actions">
             {!isFolderSource && (
               <>
-                <Button
-                  variant="default"
-                  size="sm"
-                  onClick={() => navigate({ to: "/archive", search: { path } })}
-                  className="animate-pulse"
+                <Link
+                  to="/archive"
+                  search={{ path }}
+                  className={buttonVariants({
+                    variant: "default",
+                    size: "sm",
+                    className: "animate-pulse",
+                  })}
                 >
                   Explorer
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    navigate({ to: "/read-waterfall", search: { path } })
-                  }
+                </Link>
+                <Link
+                  to="/read-waterfall"
+                  search={{ path }}
+                  className={buttonVariants({ variant: "outline", size: "sm" })}
                 >
                   Waterfall
-                </Button>
+                </Link>
               </>
             )}
           </div>
@@ -686,24 +687,28 @@ function ReadPage() {
           </Button> */}
             {!isFolderSource && (
               <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="reader-toolbar__text-button"
-                  onClick={() => navigate({ to: "/archive", search: { path } })}
+                <Link
+                  to="/archive"
+                  search={{ path }}
+                  className={buttonVariants({
+                    variant: "ghost",
+                    size: "sm",
+                    className: "reader-toolbar__text-button",
+                  })}
                 >
                   Explorer
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="reader-toolbar__text-button"
-                  onClick={() =>
-                    navigate({ to: "/read-waterfall", search: { path } })
-                  }
+                </Link>
+                <Link
+                  to="/read-waterfall"
+                  search={{ path }}
+                  className={buttonVariants({
+                    variant: "ghost",
+                    size: "sm",
+                    className: "reader-toolbar__text-button",
+                  })}
                 >
                   Waterfall
-                </Button>
+                </Link>
               </>
             )}
             {/* File Operations Dropdown */}


### PR DESCRIPTION
### Motivation
- 修复表格里文件名目前被当作 button/行点击处理的问题，使其成为真实的可导航 `Link`（支持中键 / Ctrl/Cmd+点击在新标签打开）并提升语义与可访问性。 
- 统一历史页缺失的图标显示与 Explorer 表格的文件名表现，避免重复实现并保证行为一致。 

### Description
- 新增 `FileNameLinkCell` 组件用于渲染「文件图标 + 可预览文件名 + 可选 `Link`」，并在 `Link` 点击时调用 `stopPropagation` 以避免触发行级别的副作用（文件：`frontend/src/components/Files/FileNameLinkCell.tsx`）。
- 将 Explorer 表格文件名从纯文本/行点击替换为 `FileNameLinkCell`，通过从 `useFileNavigation` 导出的 `buildNavigationTarget` 生成目标路由以保持导航一致性（文件：`frontend/src/components/Files/FileTableView.tsx`、`frontend/src/hooks/useFileNavigation.ts`）。
- 将 History 页表格文件名改为复用同一 `FileNameLinkCell`，同时补回文件图标并将原先行点击导航逻辑改为生成 `target` 后由 `Link` 处理（文件：`frontend/src/routes/_layout/history.tsx`）。
- 将阅读页与 404 页面中之前由 `Button asChild` 包裹 `Link` 的地方改为直接使用 `Link` 并通过 `buttonVariants(...)` 保持样式（文件：`frontend/src/routes/_layout/read.tsx`、`frontend/src/components/Common/FileNotFoundError.tsx`）。

### Testing
- 运行 `git diff --check` 校验无冲突或格式问题，结果通过。 
- 本地已暂存并提交改动（`git commit` 成功）。
- 尝试用 Playwright 截图验证交互但由于本地前端开发服务器未启动（`http://127.0.0.1:5173` 返回 `ERR_EMPTY_RESPONSE`）导致截图步骤失败，无法在本地完成 UI 交互截图验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699516cf41c083258d955cd5d13dbd43)