### PR TITLE
feat(explorer): 添加 URL 持久化的分页与按图片数可控排序

### DIFF
--- a/frontend/src/components/Files/FileViewContainer.tsx
+++ b/frontend/src/components/Files/FileViewContainer.tsx
@@ -45,6 +45,15 @@ import { FileTableView, type SortField, type SortOrder } from "./FileTableView"
 
 type ViewMode = "grid" | "table" | "mixed"
 
+type PaginationState = {
+  page: number
+  pageSize: number
+}
+
+type PaginationConfig = PaginationState & {
+  onChange: (next: PaginationState) => void
+}
+
 export function FileViewContainer({
   items,
   isLoading,
@@ -52,6 +61,11 @@ export function FileViewContainer({
   initialViewMode = "grid",
   initialSortField = "type",
   initialSortOrder = "asc",
+  sortField: controlledSortField,
+  sortOrder: controlledSortOrder,
+  onSortFieldChange,
+  onSortOrderChange,
+  pagination,
   storageKeyPrefix = "file-list",
   toolbarExtra,
   emptyText = "This folder is empty",
@@ -62,6 +76,11 @@ export function FileViewContainer({
   initialViewMode?: ViewMode
   initialSortField?: SortField
   initialSortOrder?: SortOrder
+  sortField?: SortField
+  sortOrder?: SortOrder
+  onSortFieldChange?: (field: SortField) => void
+  onSortOrderChange?: (order: SortOrder) => void
+  pagination?: PaginationConfig
   storageKeyPrefix?: string
   toolbarExtra?: ReactNode
   emptyText?: string
@@ -75,24 +94,53 @@ export function FileViewContainer({
     if (saved === "details") return "table"
     return (saved as ViewMode) || initialViewMode
   })
-  const [sortField, setSortField] = useState<SortField>(() => {
+  const [internalSortField, setInternalSortField] = useState<SortField>(() => {
     const saved = localStorage.getItem(`${storageKeyPrefix}-sort-field`)
     return (saved as SortField) || initialSortField
   })
-  const [sortOrder, setSortOrder] = useState<SortOrder>(() => {
+  const [internalSortOrder, setInternalSortOrder] = useState<SortOrder>(() => {
     const saved = localStorage.getItem(`${storageKeyPrefix}-sort-order`)
     return (saved as SortOrder) || initialSortOrder
   })
+
+  const sortField = controlledSortField ?? internalSortField
+  const sortOrder = controlledSortOrder ?? internalSortOrder
 
   useEffect(() => {
     localStorage.setItem(`${storageKeyPrefix}-view-mode`, viewMode)
   }, [storageKeyPrefix, viewMode])
   useEffect(() => {
-    localStorage.setItem(`${storageKeyPrefix}-sort-field`, sortField)
-  }, [storageKeyPrefix, sortField])
+    if (controlledSortField === undefined) {
+      localStorage.setItem(`${storageKeyPrefix}-sort-field`, internalSortField)
+    }
+  }, [storageKeyPrefix, internalSortField, controlledSortField])
   useEffect(() => {
-    localStorage.setItem(`${storageKeyPrefix}-sort-order`, sortOrder)
-  }, [storageKeyPrefix, sortOrder])
+    if (controlledSortOrder === undefined) {
+      localStorage.setItem(`${storageKeyPrefix}-sort-order`, internalSortOrder)
+    }
+  }, [storageKeyPrefix, internalSortOrder, controlledSortOrder])
+
+  const setSortField = useCallback(
+    (field: SortField) => {
+      if (onSortFieldChange) {
+        onSortFieldChange(field)
+        return
+      }
+      setInternalSortField(field)
+    },
+    [onSortFieldChange],
+  )
+
+  const setSortOrder = useCallback(
+    (order: SortOrder) => {
+      if (onSortOrderChange) {
+        onSortOrderChange(order)
+        return
+      }
+      setInternalSortOrder(order)
+    },
+    [onSortOrderChange],
+  )
 
   // Sorted items
   const sortedItems = useMemo(() => {
@@ -142,6 +190,24 @@ export function FileViewContainer({
 
     return list
   }, [items, sortField, sortOrder])
+
+  const currentPage = pagination?.page ?? 1
+  const pageSize = pagination?.pageSize ?? sortedItems.length
+  const totalPages = Math.max(1, Math.ceil(sortedItems.length / pageSize))
+  const normalizedPage = Math.min(Math.max(currentPage, 1), totalPages)
+
+  const pagedItems = useMemo(() => {
+    if (!pagination) return sortedItems
+    const start = (normalizedPage - 1) * pageSize
+    return sortedItems.slice(start, start + pageSize)
+  }, [pagination, sortedItems, normalizedPage, pageSize])
+
+  useEffect(() => {
+    if (!pagination) return
+    if (pagination.page !== normalizedPage) {
+      pagination.onChange({ page: normalizedPage, pageSize })
+    }
+  }, [pagination, normalizedPage, pageSize])
 
   // Selection
   const selection = useFileSelection()
@@ -423,15 +489,15 @@ export function FileViewContainer({
   // Mixed view: group items by type
   const mixedGroups = useMemo(() => {
     if (viewMode !== "mixed") return { folders: [], videos: [], archives: [] }
-    const folders = sortedItems.filter((i) => i.item_type === "folder")
-    const videos = sortedItems.filter(
+    const folders = pagedItems.filter((i) => i.item_type === "folder")
+    const videos = pagedItems.filter(
       (i) => i.item_type === "file" && i.file_type === "video",
     )
-    const archives = sortedItems.filter(
+    const archives = pagedItems.filter(
       (i) => i.item_type === "file" && i.file_type !== "video",
     )
     return { folders, videos, archives }
-  }, [viewMode, sortedItems])
+  }, [viewMode, pagedItems])
 
   // 混合视图：文件名列表行渲染（用于 folder / video section）
   const renderNameListItem = useCallback(
@@ -650,7 +716,7 @@ export function FileViewContainer({
             ))}
           </div>
         )
-      ) : sortedItems.length === 0 ? (
+      ) : pagedItems.length === 0 ? (
         <div className="empty-state flex flex-col items-center justify-center py-12 text-center">
           <p className="text-muted-foreground">{emptyText}</p>
         </div>
@@ -726,7 +792,7 @@ export function FileViewContainer({
         </div>
       ) : viewMode === "grid" ? (
         <ResponsiveGrid className="grid-content">
-          {sortedItems.map((item) => {
+          {pagedItems.map((item) => {
             const useIconDropdown = Boolean(item.thumbnail_url)
             return (
               <FileContextMenu
@@ -764,7 +830,7 @@ export function FileViewContainer({
         </ResponsiveGrid>
       ) : (
         <FileTableView
-          items={sortedItems}
+          items={pagedItems}
           onSort={handleSortFieldChange}
           sortField={sortField}
           sortOrder={sortOrder}
@@ -830,6 +896,35 @@ export function FileViewContainer({
         onConfirm={handleConfirmMoveToAlreadyRead}
         isPending={operations.moveToAlreadyReadMutation.isPending}
       />
+      {pagination && sortedItems.length > 0 && (
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <span className="text-xs text-muted-foreground">
+            {normalizedPage} / {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8"
+            disabled={normalizedPage <= 1}
+            onClick={() =>
+              pagination.onChange({ page: normalizedPage - 1, pageSize })
+            }
+          >
+            Prev
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8"
+            disabled={normalizedPage >= totalPages}
+            onClick={() =>
+              pagination.onChange({ page: normalizedPage + 1, pageSize })
+            }
+          >
+            Next
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/Files/FileViewContainer.tsx
+++ b/frontend/src/components/Files/FileViewContainer.tsx
@@ -27,6 +27,16 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Pagination,
+  PaginationContent,
+  PaginationFirst,
+  PaginationItem,
+  PaginationLast,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination"
 import { useFileExplorerKeyboard } from "@/hooks/useFileExplorerKeyboard"
 import { useFileNavigation } from "@/hooks/useFileNavigation"
 import { useFileOperations } from "@/hooks/useFileOperations"
@@ -897,33 +907,65 @@ export function FileViewContainer({
         isPending={operations.moveToAlreadyReadMutation.isPending}
       />
       {pagination && sortedItems.length > 0 && (
-        <div className="flex items-center justify-end gap-2 pt-2">
-          <span className="text-xs text-muted-foreground">
-            {normalizedPage} / {totalPages}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8"
-            disabled={normalizedPage <= 1}
-            onClick={() =>
-              pagination.onChange({ page: normalizedPage - 1, pageSize })
-            }
-          >
-            Prev
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8"
-            disabled={normalizedPage >= totalPages}
-            onClick={() =>
-              pagination.onChange({ page: normalizedPage + 1, pageSize })
-            }
-          >
-            Next
-          </Button>
-        </div>
+        <Pagination className="justify-end pt-2">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationFirst
+                href="#"
+                className={cn(normalizedPage <= 1 && "pointer-events-none opacity-50")}
+                onClick={(e) => {
+                  e.preventDefault()
+                  if (normalizedPage <= 1) return
+                  pagination.onChange({ page: 1, pageSize })
+                }}
+              />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                className={cn(normalizedPage <= 1 && "pointer-events-none opacity-50")}
+                onClick={(e) => {
+                  e.preventDefault()
+                  if (normalizedPage <= 1) return
+                  pagination.onChange({ page: normalizedPage - 1, pageSize })
+                }}
+              />
+            </PaginationItem>
+
+            <PaginationItem>
+              <PaginationLink href="#" isActive onClick={(e) => e.preventDefault()}>
+                {normalizedPage} / {totalPages}
+              </PaginationLink>
+            </PaginationItem>
+
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                className={cn(
+                  normalizedPage >= totalPages && "pointer-events-none opacity-50",
+                )}
+                onClick={(e) => {
+                  e.preventDefault()
+                  if (normalizedPage >= totalPages) return
+                  pagination.onChange({ page: normalizedPage + 1, pageSize })
+                }}
+              />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLast
+                href="#"
+                className={cn(
+                  normalizedPage >= totalPages && "pointer-events-none opacity-50",
+                )}
+                onClick={(e) => {
+                  e.preventDefault()
+                  if (normalizedPage >= totalPages) return
+                  pagination.onChange({ page: totalPages, pageSize })
+                }}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
       )}
     </div>
   )

--- a/frontend/src/components/Files/FileViewContainer.tsx
+++ b/frontend/src/components/Files/FileViewContainer.tsx
@@ -205,6 +205,24 @@ export function FileViewContainer({
   const pageSize = pagination?.pageSize ?? sortedItems.length
   const totalPages = Math.max(1, Math.ceil(sortedItems.length / pageSize))
   const normalizedPage = Math.min(Math.max(currentPage, 1), totalPages)
+  const visiblePages = useMemo(() => {
+    const out: number[] = []
+    const start = Math.max(1, normalizedPage - 2)
+    const end = Math.min(totalPages, start + 4)
+    for (let i = start; i <= end; i += 1) out.push(i)
+    return out
+  }, [normalizedPage, totalPages])
+
+  const goToPage = useCallback(
+    (nextPage: number) => {
+      if (!pagination) return
+      const target = Math.min(totalPages, Math.max(1, nextPage))
+      if (target !== normalizedPage) {
+        pagination.onChange({ page: target, pageSize })
+      }
+    },
+    [pagination, totalPages, normalizedPage, pageSize],
+  )
 
   const pagedItems = useMemo(() => {
     if (!pagination) return sortedItems
@@ -233,6 +251,7 @@ export function FileViewContainer({
     useState<CompressAction>("zip-folder")
   const [confirmFavoriteOpen, setConfirmFavoriteOpen] = useState(false)
   const [confirmAlreadyReadOpen, setConfirmAlreadyReadOpen] = useState(false)
+  const [jumpPage, setJumpPage] = useState("")
   // 右键菜单操作的目标项
   const [contextItem, setContextItem] = useState<FileSystemItem | null>(null)
 
@@ -907,65 +926,99 @@ export function FileViewContainer({
         isPending={operations.moveToAlreadyReadMutation.isPending}
       />
       {pagination && sortedItems.length > 0 && (
-        <Pagination className="justify-end pt-2">
-          <PaginationContent>
-            <PaginationItem>
-              <PaginationFirst
-                href="#"
-                className={cn(normalizedPage <= 1 && "pointer-events-none opacity-50")}
-                onClick={(e) => {
-                  e.preventDefault()
-                  if (normalizedPage <= 1) return
-                  pagination.onChange({ page: 1, pageSize })
-                }}
-              />
-            </PaginationItem>
-            <PaginationItem>
-              <PaginationPrevious
-                href="#"
-                className={cn(normalizedPage <= 1 && "pointer-events-none opacity-50")}
-                onClick={(e) => {
-                  e.preventDefault()
-                  if (normalizedPage <= 1) return
-                  pagination.onChange({ page: normalizedPage - 1, pageSize })
-                }}
-              />
-            </PaginationItem>
+        <div className="flex flex-col items-center gap-3 pt-2">
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationFirst
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    goToPage(1)
+                  }}
+                  className={normalizedPage <= 1 ? "pointer-events-none opacity-50" : undefined}
+                />
+              </PaginationItem>
 
-            <PaginationItem>
-              <PaginationLink href="#" isActive onClick={(e) => e.preventDefault()}>
-                {normalizedPage} / {totalPages}
-              </PaginationLink>
-            </PaginationItem>
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    goToPage(normalizedPage - 1)
+                  }}
+                  className={normalizedPage <= 1 ? "pointer-events-none opacity-50" : undefined}
+                />
+              </PaginationItem>
 
-            <PaginationItem>
-              <PaginationNext
-                href="#"
-                className={cn(
-                  normalizedPage >= totalPages && "pointer-events-none opacity-50",
-                )}
-                onClick={(e) => {
-                  e.preventDefault()
-                  if (normalizedPage >= totalPages) return
-                  pagination.onChange({ page: normalizedPage + 1, pageSize })
-                }}
-              />
-            </PaginationItem>
-            <PaginationItem>
-              <PaginationLast
-                href="#"
-                className={cn(
-                  normalizedPage >= totalPages && "pointer-events-none opacity-50",
-                )}
-                onClick={(e) => {
-                  e.preventDefault()
-                  if (normalizedPage >= totalPages) return
-                  pagination.onChange({ page: totalPages, pageSize })
-                }}
-              />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
+              {visiblePages.map((p) => (
+                <PaginationItem key={p}>
+                  <PaginationLink
+                    href="#"
+                    isActive={p === normalizedPage}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      goToPage(p)
+                    }}
+                  >
+                    {p}
+                  </PaginationLink>
+                </PaginationItem>
+              ))}
+
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    goToPage(normalizedPage + 1)
+                  }}
+                  className={normalizedPage >= totalPages ? "pointer-events-none opacity-50" : undefined}
+                />
+              </PaginationItem>
+
+              <PaginationItem>
+                <PaginationLast
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    goToPage(totalPages)
+                  }}
+                  className={normalizedPage >= totalPages ? "pointer-events-none opacity-50" : undefined}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-muted-foreground">Go to</span>
+            <input
+              type="number"
+              min={1}
+              max={totalPages}
+              value={jumpPage}
+              onChange={(e) => setJumpPage(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  const n = Number(jumpPage)
+                  if (!Number.isNaN(n)) goToPage(n)
+                }
+              }}
+              className="h-8 w-20 rounded-md border bg-background px-2"
+              placeholder={`1-${totalPages}`}
+            />
+            <button
+              type="button"
+              className="h-8 rounded-md border px-3"
+              onClick={() => {
+                const n = Number(jumpPage)
+                if (!Number.isNaN(n)) goToPage(n)
+              }}
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/routes/_layout/explorer.tsx
+++ b/frontend/src/routes/_layout/explorer.tsx
@@ -25,13 +25,40 @@ import {
   getBaseName,
   getParentPath,
 } from "@/lib/path-utils"
+import type { SortField, SortOrder } from "@/components/Files/FileTableView"
 import "./explorer.css"
 
 export const Route = createFileRoute("/_layout/explorer")({
   component: Explorer,
   validateSearch: (search: Record<string, unknown>) => {
+    const rawPage = Number(search.page)
+    const rawPageSize = Number(search.pageSize)
+    const page = Number.isFinite(rawPage) && rawPage > 0 ? Math.floor(rawPage) : 1
+    const pageSize =
+      Number.isFinite(rawPageSize) && rawPageSize > 0
+        ? Math.floor(rawPageSize)
+        : 48
+    const sortFieldCandidates: SortField[] = [
+      "name",
+      "type",
+      "mtime",
+      "likeScore",
+      "image_count",
+    ]
+    const sortOrderCandidates: SortOrder[] = ["asc", "desc"]
+    const rawSortField = String(search.sortField || "")
+    const rawSortOrder = String(search.sortOrder || "")
+
     return {
       path: (search.path as string) || "",
+      page,
+      pageSize,
+      sortField: sortFieldCandidates.includes(rawSortField as SortField)
+        ? (rawSortField as SortField)
+        : "type",
+      sortOrder: sortOrderCandidates.includes(rawSortOrder as SortOrder)
+        ? (rawSortOrder as SortOrder)
+        : "asc",
     }
   },
   head: () => ({
@@ -46,7 +73,7 @@ export const Route = createFileRoute("/_layout/explorer")({
 function Explorer() {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { path } = Route.useSearch()
+  const { path, page, pageSize, sortField, sortOrder } = Route.useSearch()
   const folderName = path
     ? getBaseName(path, t("nav.explorer"))
     : t("nav.explorer")
@@ -85,11 +112,19 @@ function Explorer() {
     (newPath) => {
       navigate({
         to: "/explorer",
-        search: { path: newPath },
+        search: { path: newPath, page: 1, pageSize, sortField, sortOrder },
         replace: true,
       })
     },
   )
+
+  const buildSearchForPath = (nextPath: string) => ({
+    path: nextPath,
+    page: 1,
+    pageSize,
+    sortField,
+    sortOrder,
+  })
 
   const filteredItems = useMemo(() => {
     const items = data?.items || []
@@ -172,7 +207,7 @@ function Explorer() {
             ) : (
               <Link
                 to="/explorer"
-                search={{ path: crumb.path }}
+                search={buildSearchForPath(crumb.path)}
                 className="explorer-breadcrumb__link"
               >
                 {crumb.name}
@@ -187,6 +222,41 @@ function Explorer() {
         isLoading={isLoading}
         currentPath={path}
         initialViewMode="mixed"
+        sortField={sortField}
+        sortOrder={sortOrder}
+        onSortFieldChange={(nextSortField) =>
+          navigate({
+            search: (prev) => ({
+              ...prev,
+              sortField: nextSortField,
+              page: 1,
+            }),
+            replace: true,
+          })
+        }
+        onSortOrderChange={(nextSortOrder) =>
+          navigate({
+            search: (prev) => ({
+              ...prev,
+              sortOrder: nextSortOrder,
+              page: 1,
+            }),
+            replace: true,
+          })
+        }
+        pagination={{
+          page,
+          pageSize,
+          onChange: ({ page: nextPage, pageSize: nextPageSize }) =>
+            navigate({
+              search: (prev) => ({
+                ...prev,
+                page: nextPage,
+                pageSize: nextPageSize,
+              }),
+              replace: true,
+            }),
+        }}
         storageKeyPrefix="explorer"
         toolbarExtra={
           <>


### PR DESCRIPTION
### Motivation
- 为 Explorer 页面增加分页支持并能根据 `image_count` 进行排序，同时把分页和排序状态保存在 URL 里以便分享与恢复页面状态。

### Description
- 在 `frontend/src/routes/_layout/explorer.tsx` 中解析并校验 URL search 参数 `page`、`pageSize`、`sortField` 和 `sortOrder`，并将这些参数注入页面状态与导航回写逻辑；面包屑跳转与移动后重定向会保留/重置相应参数。
- 将 `FileViewContainer` 扩展为可受控的排序组件，新增 `sortField`/`sortOrder` 的受控 props 与回调，同时兼容原有通过 `localStorage` 的非受控逻辑以保持向后兼容。
- 在 `FileViewContainer` 中新增分页能力（`pagination` 配置类型），实现对 `sortedItems` 的切片 `pagedItems` 并在 mixed/grid/table 视图下统一渲染分页结果，底部增加 `Prev/Next` 按钮与页码展示；分页越界会归一化并通过回调同步到外部（例如 URL）。
- 变更影响文件：`frontend/src/routes/_layout/explorer.tsx`、`frontend/src/components/Files/FileViewContainer.tsx`，并在排序字段列表中包含 `image_count` 用于按图片数排序。

### Testing
- 运行 `npm run build`（workdir: `frontend`）以进行 TypeScript 检查与打包，构建在当前环境失败，因缺少前端依赖导致大量 `Cannot find module` 错误；构建未通过（非本 PR 逻辑错误，而是环境依赖缺失）。
- 尝试使用 Playwright 脚本访问本地 `http://127.0.0.1:5173/explorer` 截图以验证前端运行时效果，但因本地前端服务器未运行导致 `ERR_EMPTY_RESPONSE`，未能生成截图验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951cf2875483259c0182d9a3270ed1)