### PR TITLE
fix(frontend): restore real Link navigation in explorer/history filename cells

### DIFF
--- a/frontend/src/components/Files/FileNameLinkCell.tsx
+++ b/frontend/src/components/Files/FileNameLinkCell.tsx
@@ -1,0 +1,53 @@
+import { Link } from "@tanstack/react-router"
+
+import { FileIcon } from "./FileIcon"
+import { FileNameWithPreview } from "./FileNameWithPreview"
+
+type LinkTarget = {
+  to: string
+  search: Record<string, unknown>
+}
+
+interface FileNameLinkCellProps {
+  filename: string
+  filepath: string
+  thumbnailUrl?: string | null
+  fileType: "image" | "video" | "archive" | "audio" | "unknown"
+  isFolder?: boolean
+  target: LinkTarget | null
+}
+
+export function FileNameLinkCell({
+  filename,
+  filepath,
+  thumbnailUrl,
+  fileType,
+  isFolder = false,
+  target,
+}: FileNameLinkCellProps) {
+  const content = (
+    <>
+      <FileIcon fileType={fileType} isFolder={isFolder} size="sm" />
+      <FileNameWithPreview
+        filename={filename}
+        filepath={filepath}
+        thumbnailUrl={thumbnailUrl}
+        className="min-w-0"
+      />
+    </>
+  )
+
+  if (!target) {
+    return <div className="flex min-w-0 items-center gap-2">{content}</div>
+  }
+
+  return (
+    <Link
+      to={target.to as any}
+      search={target.search as any}
+      className="flex min-w-0 items-center gap-2"
+    >
+      {content}
+    </Link>
+  )
+}

--- a/frontend/src/components/Files/FileTableView.tsx
+++ b/frontend/src/components/Files/FileTableView.tsx
@@ -4,18 +4,14 @@ import { useTranslation } from "react-i18next"
 
 import type { FileSystemItem } from "@/client"
 import { ListTable, type ListTableColumn } from "@/components/Common/ListTable"
+import { buildNavigationTarget } from "@/hooks/useFileNavigation"
+import { useIsMobile } from "@/hooks/useMobile"
 import { cn } from "@/lib/utils"
 import { FileContextMenu, type FileContextMenuActions } from "./FileContextMenu"
-import { FileIcon } from "./FileIcon"
-import { FileNameWithPreview } from "./FileNameWithPreview"
+import { FileNameLinkCell } from "./FileNameLinkCell"
 import { formatDateTime, formatFileSize, formatFileType } from "./utils"
 
-export type SortField =
-  | "name"
-  | "type"
-  | "mtime"
-  | "likeScore"
-  | "image_count"
+export type SortField = "name" | "type" | "mtime" | "likeScore" | "image_count"
 export type SortOrder = "asc" | "desc"
 
 interface FileTableViewProps {
@@ -44,18 +40,94 @@ export function FileTableView({
   isOpenable,
 }: FileTableViewProps) {
   const { t } = useTranslation()
+  const isMobile = useIsMobile()
+
   const SortIcon = ({ field }: { field: SortField }) => {
-    if (sortField !== field) return <ArrowUpDown className="size-3 ml-1 opacity-50" />
-    return sortOrder === "asc" ? <ArrowUp className="size-3 ml-1" /> : <ArrowDown className="size-3 ml-1" />
+    if (sortField !== field) {
+      return <ArrowUpDown className="ml-1 size-3 opacity-50" />
+    }
+    return sortOrder === "asc" ? (
+      <ArrowUp className="ml-1 size-3" />
+    ) : (
+      <ArrowDown className="ml-1 size-3" />
+    )
   }
 
   const columns: ListTableColumn[] = [
-    { key: "name", header: <button className="inline-flex items-center" onClick={() => onSort("name")}>{t("explorer.table.name")}<SortIcon field="name" /></button> },
-    { key: "mtime", header: <button className="inline-flex items-center" onClick={() => onSort("mtime")}>{t("explorer.table.dateModified")}<SortIcon field="mtime" /></button>, headerClassName: "w-[180px]" },
-    { key: "type", header: <button className="inline-flex items-center" onClick={() => onSort("type")}>{t("explorer.table.type")}<SortIcon field="type" /></button>, headerClassName: "w-[120px]" },
-    { key: "size", header: t("explorer.table.size"), headerClassName: "w-[100px] text-right" },
-    { key: "likeScore", header: <button className="ml-auto inline-flex items-center" onClick={() => onSort("likeScore")}>{t("explorer.table.likeScore")}<SortIcon field="likeScore" /></button>, headerClassName: "w-[130px] text-right" },
-    { key: "image_count", header: <button className="ml-auto inline-flex items-center" onClick={() => onSort("image_count")}>{t("explorer.table.imageCount")}<SortIcon field="image_count" /></button>, headerClassName: "w-[110px] text-right" },
+    {
+      key: "name",
+      header: (
+        <button
+          type="button"
+          className="inline-flex items-center"
+          onClick={() => onSort("name")}
+        >
+          {t("explorer.table.name")}
+          <SortIcon field="name" />
+        </button>
+      ),
+    },
+    {
+      key: "mtime",
+      header: (
+        <button
+          type="button"
+          className="inline-flex items-center"
+          onClick={() => onSort("mtime")}
+        >
+          {t("explorer.table.dateModified")}
+          <SortIcon field="mtime" />
+        </button>
+      ),
+      headerClassName: "w-[180px]",
+    },
+    {
+      key: "type",
+      header: (
+        <button
+          type="button"
+          className="inline-flex items-center"
+          onClick={() => onSort("type")}
+        >
+          {t("explorer.table.type")}
+          <SortIcon field="type" />
+        </button>
+      ),
+      headerClassName: "w-[120px]",
+    },
+    {
+      key: "size",
+      header: t("explorer.table.size"),
+      headerClassName: "w-[100px] text-right",
+    },
+    {
+      key: "likeScore",
+      header: (
+        <button
+          type="button"
+          className="ml-auto inline-flex items-center"
+          onClick={() => onSort("likeScore")}
+        >
+          {t("explorer.table.likeScore")}
+          <SortIcon field="likeScore" />
+        </button>
+      ),
+      headerClassName: "w-[130px] text-right",
+    },
+    {
+      key: "image_count",
+      header: (
+        <button
+          type="button"
+          className="ml-auto inline-flex items-center"
+          onClick={() => onSort("image_count")}
+        >
+          {t("explorer.table.imageCount")}
+          <SortIcon field="image_count" />
+        </button>
+      ),
+      headerClassName: "w-[110px] text-right",
+    },
   ]
 
   return (
@@ -67,12 +139,13 @@ export function FileTableView({
           <tr
             key={item.path}
             className={cn(
-              "border-b last:border-b-0 text-sm cursor-pointer hover:bg-muted/50",
+              "cursor-pointer border-b text-sm last:border-b-0 hover:bg-muted/50",
               isSelected?.(item.path) && "bg-primary/10",
             )}
             onClick={(e) => onItemClick?.(item, e)}
+            onDoubleClick={(e) => onItemDoubleClick?.(item, e)}
           >
-            <TableRowCells item={item} />
+            <TableRowCells item={item} isMobile={isMobile} />
           </tr>
         )
 
@@ -94,24 +167,47 @@ export function FileTableView({
   )
 }
 
-function TableRowCells({ item }: { item: FileSystemItem }) {
+function TableRowCells({
+  item,
+  isMobile,
+}: {
+  item: FileSystemItem
+  isMobile: boolean
+}) {
   const { t } = useTranslation()
   const isFolder = item.item_type === "folder"
   const isArchive = item.file_type === "archive"
+  const target = buildNavigationTarget(item, isMobile)
 
   return (
     <>
       <td className="p-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <FileIcon fileType={item.file_type} isFolder={isFolder} size="sm" />
-          <FileNameWithPreview filename={item.name} filepath={item.path} thumbnailUrl={item.thumbnail_url} className="min-w-0" />
-        </div>
+        <FileNameLinkCell
+          filename={item.name}
+          filepath={item.path}
+          thumbnailUrl={item.thumbnail_url}
+          fileType={item.file_type ?? "unknown"}
+          isFolder={isFolder}
+          target={target}
+        />
       </td>
-      <td className="p-2 text-muted-foreground">{item.mtime ? formatDateTime(item.mtime) : "-"}</td>
-      <td className="p-2 text-muted-foreground">{isFolder ? t("file.folder") : formatFileType(item.file_type)}</td>
-      <td className="p-2 text-right text-muted-foreground">{!isFolder && item.filesize ? formatFileSize(item.filesize) : "-"}</td>
-      <td className="p-2 text-right text-muted-foreground">{!isFolder ? ((item as any).recommendation_score ?? 0).toFixed(3) : "-"}</td>
-      <td className="p-2 text-right text-muted-foreground">{isArchive && (item as any).image_count ? (item as any).image_count : "-"}</td>
+      <td className="p-2 text-muted-foreground">
+        {item.mtime ? formatDateTime(item.mtime) : "-"}
+      </td>
+      <td className="p-2 text-muted-foreground">
+        {isFolder ? t("file.folder") : formatFileType(item.file_type)}
+      </td>
+      <td className="p-2 text-right text-muted-foreground">
+        {!isFolder && item.filesize ? formatFileSize(item.filesize) : "-"}
+      </td>
+      <td className="p-2 text-right text-muted-foreground">
+        {!isFolder ? ((item as any).recommendation_score ?? 0).toFixed(3) : "-"}
+      </td>
+      <td className="p-2 text-right text-muted-foreground">
+        {isArchive && (item as any).image_count
+          ? (item as any).image_count
+          : "-"}
+      </td>
     </>
   )
 }

--- a/frontend/src/hooks/useFileNavigation.ts
+++ b/frontend/src/hooks/useFileNavigation.ts
@@ -7,7 +7,7 @@ import { useIsMobile } from "@/hooks/useMobile"
 import { getParentPath } from "@/lib/path-utils"
 
 /** 根据文件类型构建导航目标 */
-function buildNavigationTarget(item: FileSystemItem, isMobile: boolean) {
+export function buildNavigationTarget(item: FileSystemItem, isMobile: boolean) {
   const isFolder = item.item_type === "folder"
   const isArchive = item.file_type === "archive"
   const isVideo = item.file_type === "video"

--- a/frontend/src/routes/_layout/history.tsx
+++ b/frontend/src/routes/_layout/history.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import {
   ArrowDown,
   ArrowUp,
@@ -15,7 +15,7 @@ import { OpenAPI } from "@/client"
 import type { FileSystemItem } from "@/client/types.gen"
 import { ListTable, type ListTableColumn } from "@/components/Common/ListTable"
 import { FileItem } from "@/components/Files/FileItem"
-import { FileNameWithPreview } from "@/components/Files/FileNameWithPreview"
+import { FileNameLinkCell } from "@/components/Files/FileNameLinkCell"
 import {
   formatDateTime,
   formatFileSize,
@@ -33,8 +33,8 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination"
 import { Skeleton } from "@/components/ui/skeleton"
+import { buildNavigationTarget } from "@/hooks/useFileNavigation"
 import { useIsMobile } from "@/hooks/useMobile"
-import { getParentPath } from "@/lib/path-utils"
 
 type SortOrder = "asc" | "desc"
 
@@ -114,39 +114,8 @@ function HistoryPage() {
     }
   }
 
-
-  const getHistoryItemLink = (item: HistoryItem) => {
-    if (item.file_type === "archive") {
-      return { to: "/archive", search: { path: item.filepath } } as const
-    }
-    if (item.file_type === "video") {
-      return {
-        to: "/video",
-        search: { path: item.filepath, entry: undefined, media: "video" },
-      } as const
-    }
-    if (item.file_type === "audio") {
-      return {
-        to: "/audio",
-        search: { path: item.filepath, entry: undefined },
-      } as const
-    }
-    if (item.file_type === "image") {
-      return {
-        to: isMobile ? "/read-mobile" : "/read",
-        search: {
-          path: getParentPath(item.filepath),
-          source: "folder",
-          page: 0,
-          filePath: item.filepath,
-        },
-      } as const
-    }
-
-    return null
-  }
   const openHistoryItem = (item: HistoryItem) => {
-    const target = getHistoryItemLink(item)
+    const target = buildNavigationTarget(toFileSystemItem(item), isMobile)
     if (!target) {
       toast.info(t("history.unsupportedType"))
       return
@@ -157,9 +126,17 @@ function HistoryPage() {
 
   const tableColumns: ListTableColumn[] = [
     { key: "name", header: t("history.name") },
-    { key: "readAt", header: t("history.readAt"), headerClassName: "w-[180px]" },
+    {
+      key: "readAt",
+      header: t("history.readAt"),
+      headerClassName: "w-[180px]",
+    },
     { key: "type", header: t("history.type"), headerClassName: "w-[120px]" },
-    { key: "size", header: t("history.size"), headerClassName: "w-[100px] text-right" },
+    {
+      key: "size",
+      header: t("history.size"),
+      headerClassName: "w-[100px] text-right",
+    },
   ]
 
   const toFileSystemItem = (item: HistoryItem): FileSystemItem => ({
@@ -178,7 +155,9 @@ function HistoryPage() {
         <div className="flex items-center gap-2">
           <HistoryIcon className="size-5" />
           <h1 className="text-xl font-semibold">{t("history.title")}</h1>
-          <span className="text-sm text-muted-foreground">{t("history.subtitle")}</span>
+          <span className="text-sm text-muted-foreground">
+            {t("history.subtitle")}
+          </span>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -276,7 +255,10 @@ function HistoryPage() {
           columns={tableColumns}
           rows={data?.items ?? []}
           renderRow={(item) => {
-            const target = getHistoryItemLink(item)
+            const target = buildNavigationTarget(
+              toFileSystemItem(item),
+              isMobile,
+            )
 
             return (
               <tr
@@ -284,29 +266,23 @@ function HistoryPage() {
                 className="border-b last:border-b-0 text-sm hover:bg-muted/50"
               >
                 <td className="p-2">
-                  {target ? (
-                    <Link to={target.to} search={target.search} className="flex items-center gap-2 min-w-0">
-                      <FileNameWithPreview
-                        filename={item.filename}
-                        filepath={item.filepath}
-                        thumbnailUrl={item.thumbnail_url}
-                        className="min-w-0"
-                      />
-                    </Link>
-                  ) : (
-                    <div className="flex items-center gap-2 min-w-0">
-                      <FileNameWithPreview
-                        filename={item.filename}
-                        filepath={item.filepath}
-                        thumbnailUrl={item.thumbnail_url}
-                        className="min-w-0"
-                      />
-                    </div>
-                  )}
+                  <FileNameLinkCell
+                    filename={item.filename}
+                    filepath={item.filepath}
+                    thumbnailUrl={item.thumbnail_url}
+                    fileType={item.file_type}
+                    target={target}
+                  />
                 </td>
-                <td className="p-2 text-muted-foreground">{formatDateTime(item.read_at)}</td>
-                <td className="p-2 text-muted-foreground">{formatFileType(item.file_type)}</td>
-                <td className="p-2 text-right text-muted-foreground">{item.filesize ? formatFileSize(item.filesize) : "-"}</td>
+                <td className="p-2 text-muted-foreground">
+                  {formatDateTime(item.read_at)}
+                </td>
+                <td className="p-2 text-muted-foreground">
+                  {formatFileType(item.file_type)}
+                </td>
+                <td className="p-2 text-right text-muted-foreground">
+                  {item.filesize ? formatFileSize(item.filesize) : "-"}
+                </td>
               </tr>
             )
           }}
@@ -324,7 +300,9 @@ function HistoryPage() {
                     e.preventDefault()
                     goToPage(1)
                   }}
-                  className={page <= 1 ? "pointer-events-none opacity-50" : undefined}
+                  className={
+                    page <= 1 ? "pointer-events-none opacity-50" : undefined
+                  }
                 />
               </PaginationItem>
 
@@ -335,7 +313,9 @@ function HistoryPage() {
                     e.preventDefault()
                     goToPage(page - 1)
                   }}
-                  className={page <= 1 ? "pointer-events-none opacity-50" : undefined}
+                  className={
+                    page <= 1 ? "pointer-events-none opacity-50" : undefined
+                  }
                 />
               </PaginationItem>
 
@@ -361,7 +341,11 @@ function HistoryPage() {
                     e.preventDefault()
                     goToPage(page + 1)
                   }}
-                  className={page >= totalPages ? "pointer-events-none opacity-50" : undefined}
+                  className={
+                    page >= totalPages
+                      ? "pointer-events-none opacity-50"
+                      : undefined
+                  }
                 />
               </PaginationItem>
 
@@ -372,7 +356,11 @@ function HistoryPage() {
                     e.preventDefault()
                     goToPage(totalPages)
                   }}
-                  className={page >= totalPages ? "pointer-events-none opacity-50" : undefined}
+                  className={
+                    page >= totalPages
+                      ? "pointer-events-none opacity-50"
+                      : undefined
+                  }
                 />
               </PaginationItem>
             </PaginationContent>


### PR DESCRIPTION
### Motivation

- 将表格中依赖 `click` + `navigate` 的虚拟跳转改成真实的 `<Link>`，以支持左键正常导航与浏览器原生的新标签打开（Ctrl/Cmd+点击 / 中键）。
- 统一 History 与 Explorer 对文件名单元格的渲染与路由目标逻辑，避免重复实现导致行为不一致或冲突。
- 去除“Button 包裹 Link”的不当结构，并把文件名列抽成可复用组件以便统一样式与图标展示。

### Description

- 新增组件 `FileNameLinkCell`（`frontend/src/components/Files/FileNameLinkCell.tsx`），负责渲染 `icon + filename 预览 + Link`，在无跳转目标时降级为普通容器。
- 在 `FileTableView`（`frontend/src/components/Files/FileTableView.tsx`）中将 filename 单元格替换为 `FileNameLinkCell`，并使用共享的 `buildNavigationTarget` 计算 Link 目标；同时为表头排序按钮显式添加 `type="button"`，并暴露行的 `onDoubleClick`。 
- 在 History 页（`frontend/src/routes/_layout/history.tsx`）把文件名列改为复用 `FileNameLinkCell`，并使用 `buildNavigationTarget` 生成链接，移除 History 专有的路由分叉逻辑。 
- 将 `buildNavigationTarget` 从 `useFileNavigation` 导出（`frontend/src/hooks/useFileNavigation.ts`），供表格组件复用以保证路由目标一致性。 
- 对文件类型使用默认值处理（避免 `undefined` 类型问题），并微调若干样式/可访问性细节以通过局部检查。 

### Testing

- 运行局部静态检查：`cd frontend && ./node_modules/.bin/biome check src/components/Files/FileNameLinkCell.tsx src/components/Files/FileTableView.tsx src/routes/_layout/history.tsx src/hooks/useFileNavigation.ts`，该检查在修改范围内通过（已修复相关问题）。
- 本地尝试构建：`npm -C frontend run build`，构建在仓库中存在的与本 PR 无关的其它 TypeScript 错误处中止，因此未能完成全项目成功构建（错误属既有代码问题，不影响本次改动的行为逻辑）。
- 启动 dev 服务并用 Playwright 自动化脚本访问页面并截图以验证前端行为（访问 `http://127.0.0.1:4173/history?view=table&page=1&sort_order=desc` 并产出截图），截图已保存为构建产物以便人工验收。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995299fa0cc83258641e753018e03c2)