### PR TITLE
i18n: 为侧边栏和 coser 页面标题添加 `preview` 后缀

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -23,7 +23,7 @@
     "history": "History",
     "tags": "Tags",
     "authors": "Authors",
-    "cosers": "Cosers preview",
+    "cosers": "Cosers (preview)",
     "search": "Search",
     "admin": "Admin"
   },
@@ -121,7 +121,7 @@
     "empty": "No authors data"
   },
   "cosers": {
-    "title": "Cosers preview",
+    "title": "Cosers (preview)",
     "description": "Browse file collections by cosers",
     "sortByField": "Sort Field",
     "fileCount": "File Count",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -23,7 +23,7 @@
     "history": "History",
     "tags": "Tags",
     "authors": "Authors",
-    "cosers": "Cosers",
+    "cosers": "Cosers preview",
     "search": "Search",
     "admin": "Admin"
   },
@@ -121,7 +121,7 @@
     "empty": "No authors data"
   },
   "cosers": {
-    "title": "Cosers",
+    "title": "Cosers preview",
     "description": "Browse file collections by cosers",
     "sortByField": "Sort Field",
     "fileCount": "File Count",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -23,7 +23,7 @@
     "history": "履歴",
     "tags": "タグ",
     "authors": "作者",
-    "cosers": "Coser preview",
+    "cosers": "Coser (preview)",
     "search": "検索",
     "admin": "管理"
   },
@@ -121,7 +121,7 @@
     "empty": "作者データがありません"
   },
   "cosers": {
-    "title": "Coser preview",
+    "title": "Coser (preview)",
     "description": "Coser 別にファイルを閲覧",
     "sortByField": "並び替え項目",
     "fileCount": "ファイル数",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -23,7 +23,7 @@
     "history": "履歴",
     "tags": "タグ",
     "authors": "作者",
-    "cosers": "Coser",
+    "cosers": "Coser preview",
     "search": "検索",
     "admin": "管理"
   },
@@ -121,7 +121,7 @@
     "empty": "作者データがありません"
   },
   "cosers": {
-    "title": "Coser",
+    "title": "Coser preview",
     "description": "Coser 別にファイルを閲覧",
     "sortByField": "並び替え項目",
     "fileCount": "ファイル数",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -24,7 +24,7 @@
     "history": "기록",
     "tags": "태그",
     "authors": "작가",
-    "cosers": "코서 preview",
+    "cosers": "코서 (preview)",
     "search": "검색",
     "admin": "관리"
   },
@@ -122,7 +122,7 @@
     "empty": "작가 데이터가 없습니다"
   },
   "cosers": {
-    "title": "코서 preview",
+    "title": "코서 (preview)",
     "description": "코서별로 파일 컬렉션을 탐색",
     "sortByField": "정렬 항목",
     "fileCount": "파일 수",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -24,7 +24,7 @@
     "history": "기록",
     "tags": "태그",
     "authors": "작가",
-    "cosers": "코서",
+    "cosers": "코서 preview",
     "search": "검색",
     "admin": "관리"
   },
@@ -122,7 +122,7 @@
     "empty": "작가 데이터가 없습니다"
   },
   "cosers": {
-    "title": "코서",
+    "title": "코서 preview",
     "description": "코서별로 파일 컬렉션을 탐색",
     "sortByField": "정렬 항목",
     "fileCount": "파일 수",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -23,7 +23,7 @@
     "history": "历史",
     "tags": "标签",
     "authors": "作者",
-    "cosers": "Coser preview",
+    "cosers": "Coser (preview)",
     "search": "搜索",
     "admin": "管理"
   },
@@ -121,7 +121,7 @@
     "empty": "暂无作者数据"
   },
   "cosers": {
-    "title": "Coser preview",
+    "title": "Coser (preview)",
     "description": "按 coser 浏览图包集合",
     "sortByField": "排序字段",
     "fileCount": "文件数量",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -23,7 +23,7 @@
     "history": "历史",
     "tags": "标签",
     "authors": "作者",
-    "cosers": "Coser",
+    "cosers": "Coser preview",
     "search": "搜索",
     "admin": "管理"
   },
@@ -121,7 +121,7 @@
     "empty": "暂无作者数据"
   },
   "cosers": {
-    "title": "Coser",
+    "title": "Coser preview",
     "description": "按 coser 浏览图包集合",
     "sortByField": "排序字段",
     "fileCount": "文件数量",


### PR DESCRIPTION
### Motivation
- 需在侧边栏显示的 coser 文案与 coser 页面标题上追加 `preview` 后缀以区分预览场景。

### Description
- 在 `frontend/src/i18n/locales/en.json`、`frontend/src/i18n/locales/zh.json`、`frontend/src/i18n/locales/ja.json`、`frontend/src/i18n/locales/ko.json` 中，将 `nav.cosers` 与 `cosers.title` 的值分别从原文更新为追加 ` preview` 后缀（例如 `"Cosers"` → `"Cosers preview"`）。

### Testing
- 使用 `python -m json.tool` 对上述四个 JSON 文件进行了语法校验，校验通过。
- 尝试用 Playwright 打开 `http://127.0.0.1:5173` 进行截图以本地验证界面，但由于前端服务未启动导致 `ERR_EMPTY_RESPONSE`，截图未生成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69955028f33c832583906ba1fccd1ae7)