### PR TITLE
refactor: 提取通用 `requestJson` 工具并在文件 hooks 中复用

### DIFF
--- a/frontend/src/components/Files/FileViewContainer.tsx
+++ b/frontend/src/components/Files/FileViewContainer.tsx
@@ -41,7 +41,7 @@ import { useFileExplorerKeyboard } from "@/hooks/useFileExplorerKeyboard"
 import { useFileNavigation } from "@/hooks/useFileNavigation"
 import { useFileOperations } from "@/hooks/useFileOperations"
 import { useFileSelection } from "@/hooks/useFileSelection"
-import { getBaseName } from "@/lib/path-utils"
+import { detectPathSeparator, getBaseName } from "@/lib/path-utils"
 import { cn } from "@/lib/utils"
 import { type CompressAction, CompressDialog } from "./dialogs/CompressDialog"
 import { ConfirmMoveDialog } from "./dialogs/ConfirmMoveDialog"
@@ -622,7 +622,9 @@ export function FileViewContainer({
       const item = sortedItems.find((i) => i.path === sourcePath)
       if (item) {
         const fileName = getBaseName(sourcePath)
-        const destPath = `${destDir}/${fileName}`
+        const separator = detectPathSeparator(destDir || sourcePath)
+        const normalizedDestDir = destDir.replace(/[\\/]+$/, "")
+        const destPath = `${normalizedDestDir}${separator}${fileName}`
         operations.move(sourcePath, destPath, item.item_type === "folder")
       }
       setMoveDialogOpen(false)

--- a/frontend/src/hooks/useFileOperations.ts
+++ b/frontend/src/hooks/useFileOperations.ts
@@ -1,12 +1,10 @@
 // 文件操作 API 封装 — 统一 mutation hooks
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import axios from "axios"
 import { toast } from "sonner"
 
 import { ApiError, FilesystemService } from "@/client"
+import { requestJson } from "@/utils/http"
 
-// 使用相对路径，始终走当前页面同源，避免 localhost/127.0.0.1 混用触发 CORS。
-const api = axios.create()
 
 function normalizeDetail(detail: unknown): string | null {
   if (typeof detail === "string" && detail.trim()) return detail
@@ -26,9 +24,9 @@ function extractErrorMessage(err: unknown): string {
     return detail || err.message
   }
 
-  if (axios.isAxiosError(err)) {
-    const detail = normalizeDetail((err.response?.data as any)?.detail)
-    return detail || err.message
+  if (typeof err === "object" && err !== null && "detail" in err) {
+    const detail = normalizeDetail((err as any).detail)
+    if (detail) return detail
   }
 
   if (err instanceof Error) return err.message
@@ -37,31 +35,40 @@ function extractErrorMessage(err: unknown): string {
 
 /** 重命名文件/文件夹 */
 function apiRename(path: string, newName: string) {
-  return api.post("/api/v1/fs/rename", { path, new_name: newName })
+  return requestJson("/api/v1/fs/rename", {
+    method: "POST",
+    body: { path, new_name: newName },
+  })
 }
 
 /** 压缩 archive 内大图 */
 function apiCompressArchiveImages(archivePath: string) {
-  return api.post("/api/v1/fs/archive/compress-images", {
-    archive_path: archivePath,
+  return requestJson("/api/v1/fs/archive/compress-images", {
+    method: "POST",
+    body: {
+      archive_path: archivePath,
+    },
   })
 }
 
 /** 为目录补全缺失的 thumbnail/meta（含子目录） */
 function apiBackfillFolder(folderPath: string) {
-  return api.post("/api/v1/fs/backfill", {
-    path: folderPath,
-    recursive: true,
-    fill_thumbnail: true,
-    fill_meta: true,
+  return requestJson("/api/v1/fs/backfill", {
+    method: "POST",
+    body: {
+      path: folderPath,
+      recursive: true,
+      fill_thumbnail: true,
+      fill_meta: true,
+    },
   })
 }
 
 /** 移动到收藏夹目录（可选子文件夹，如 good_2026_02_01） */
 async function apiMoveToFavorite(sourcePath: string, isFolder: boolean, subfolder?: string) {
   // 先获取收藏夹目录
-  const favResp = await api.get("/api/v1/fs/favorite")
-  const favDir = favResp.data?.path
+  const favResp = await requestJson<{ path?: string }>("/api/v1/fs/favorite")
+  const favDir = favResp.path
   if (!favDir) throw new Error("Favorite directory not configured")
 
   const targetDir = subfolder ? `${favDir}/${subfolder}` : favDir
@@ -71,7 +78,10 @@ async function apiMoveToFavorite(sourcePath: string, isFolder: boolean, subfolde
   // 如果使用子文件夹，先确保目录存在（后端 move 会检查 parent）
   if (subfolder) {
     try {
-      await api.post("/api/v1/fs/ensure-dir", { path: targetDir })
+      await requestJson("/api/v1/fs/ensure-dir", {
+        method: "POST",
+        body: { path: targetDir },
+      })
     } catch {
       // 忽略：后端可能没有 ensure-dir，靠 move 自身报错
     }
@@ -90,18 +100,21 @@ async function apiMoveToFavorite(sourcePath: string, isFolder: boolean, subfolde
 /** 移动到已读目录 */
 async function apiMoveToAlreadyRead(sourcePath: string, isFolder: boolean) {
   // 优先使用 fs/already-read；若目录尚未创建，回退读取 settings 并尝试自动创建。
-  let resp = await api.get("/api/v1/fs/already-read")
-  let dir = resp.data?.path as string | undefined
+  let resp = await requestJson<{ path?: string }>("/api/v1/fs/already-read")
+  let dir = resp.path
 
   if (!dir) {
-    const settingsResp = await api.get("/api/v1/settings")
-    const configuredDir = (settingsResp.data?.already_read_dir as string | undefined)?.trim()
+    const settingsResp = await requestJson<{ already_read_dir?: string }>("/api/v1/settings")
+    const configuredDir = settingsResp.already_read_dir?.trim()
     if (configuredDir) {
       dir = configuredDir
       try {
-        await api.post("/api/v1/fs/ensure-dir", { path: dir })
-        resp = await api.get("/api/v1/fs/already-read")
-        dir = (resp.data?.path as string | undefined) || dir
+        await requestJson("/api/v1/fs/ensure-dir", {
+          method: "POST",
+          body: { path: dir },
+        })
+        resp = await requestJson<{ path?: string }>("/api/v1/fs/already-read")
+        dir = resp.path || dir
       } catch {
         // 忽略：若后端不支持 ensure-dir，后续 move 会给出明确错误。
       }
@@ -284,7 +297,7 @@ export function useFileOperations(currentPath: string) {
   const backfillFolderMutation = useMutation({
     mutationFn: (folderPath: string) => apiBackfillFolder(folderPath),
     onSuccess: (resp) => {
-      const payload = resp?.data || {}
+      const payload = resp || {}
       const scanned = payload.scanned_files ?? 0
       const thumbs = payload.backfilled_thumbnails ?? 0
       const meta = payload.backfilled_meta ?? 0

--- a/frontend/src/hooks/useFileOperations.ts
+++ b/frontend/src/hooks/useFileOperations.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 
 import { ApiError, FilesystemService } from "@/client"
+import { detectPathSeparator, getBaseName } from "@/lib/path-utils"
 import { requestJson } from "@/utils/http"
 
 
@@ -31,6 +32,13 @@ function extractErrorMessage(err: unknown): string {
 
   if (err instanceof Error) return err.message
   return "Unknown error"
+}
+
+function buildDestPath(destDir: string, sourcePath: string): string {
+  const fileName = getBaseName(sourcePath)
+  const separator = detectPathSeparator(destDir || sourcePath)
+  const normalizedDestDir = destDir.replace(/[\\/]+$/, "")
+  return `${normalizedDestDir}${separator}${fileName}`
 }
 
 /** 重命名文件/文件夹 */
@@ -72,8 +80,7 @@ async function apiMoveToFavorite(sourcePath: string, isFolder: boolean, subfolde
   if (!favDir) throw new Error("Favorite directory not configured")
 
   const targetDir = subfolder ? `${favDir}/${subfolder}` : favDir
-  const fileName = sourcePath.split("/").pop() || sourcePath.split("\\").pop()
-  const destPath = `${targetDir}/${fileName}`
+  const destPath = buildDestPath(targetDir, sourcePath)
 
   // 如果使用子文件夹，先确保目录存在（后端 move 会检查 parent）
   if (subfolder) {
@@ -123,8 +130,7 @@ async function apiMoveToAlreadyRead(sourcePath: string, isFolder: boolean) {
 
   if (!dir) throw new Error("Already-read directory not configured")
 
-  const fileName = sourcePath.split("/").pop() || sourcePath.split("\\").pop()
-  const destPath = `${dir}/${fileName}`
+  const destPath = buildDestPath(dir, sourcePath)
 
   if (isFolder) {
     return FilesystemService.moveFolder({

--- a/frontend/src/hooks/useResolveMovedFile.ts
+++ b/frontend/src/hooks/useResolveMovedFile.ts
@@ -1,5 +1,6 @@
-import axios from "axios"
 import { useEffect, useRef, useState } from "react"
+
+import { requestJson } from "@/utils/http"
 
 /**
  * 当文件/文件夹被移动后，通过 filetable 查找新路径并自动跳转。
@@ -36,12 +37,11 @@ export function useResolveMovedFile(
 
     setResolving(true)
 
-    axios
-      .get("/api/v1/fs/resolve-path", {
-        params: { filename, old_path: path },
-      })
-      .then((resp) => {
-        const newPath = resp.data?.path
+    requestJson<{ path?: string }>("/api/v1/fs/resolve-path", {
+      query: { filename, old_path: path },
+    })
+      .then((data) => {
+        const newPath = data?.path
         if (newPath && newPath !== path) {
           onResolvedRef.current(newPath)
         }

--- a/frontend/src/utils/http.ts
+++ b/frontend/src/utils/http.ts
@@ -1,0 +1,33 @@
+import { OpenAPI } from "@/client"
+
+export type JsonRequestOptions = {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+  body?: unknown
+  query?: Record<string, string | number | boolean | null | undefined>
+}
+
+export async function requestJson<T>(path: string, options: JsonRequestOptions = {}): Promise<T> {
+  const queryString = options.query
+    ? `?${new URLSearchParams(
+      Object.entries(options.query)
+        .filter(([, value]) => value !== undefined && value !== null)
+        .map(([key, value]) => [key, String(value)]),
+    ).toString()}`
+    : ""
+
+  const response = await fetch(`${OpenAPI.BASE}${path}${queryString}`, {
+    method: options.method ?? "GET",
+    headers: options.body ? { "Content-Type": "application/json" } : undefined,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  })
+
+  const payload = await response
+    .json()
+    .catch(() => ({}))
+
+  if (!response.ok) {
+    throw payload
+  }
+
+  return payload as T
+}


### PR DESCRIPTION
### Motivation
- 统一 hooks 内对后端的 API 调用逻辑，避免在每个 hook 中重复拼装 `fetch` 并支持更多 HTTP 方法与查询参数。
- 回应代码评审中关于 `apiJson` 仅用于 POST 的质疑，将其扩展为通用工具以便复用。
- 检查是否可以移除 `axios` 并评估影响范围以避免误删仍被依赖的包。

### Description
- 新增通用工具 `frontend/src/utils/http.ts`，导出 `requestJson`，支持 `GET/POST/PUT/PATCH/DELETE`、JSON `body` 与 `query` 参数并统一拼接 `OpenAPI.BASE`。
- 将 `frontend/src/hooks/useFileOperations.ts` 中原先内联的 `apiJson` 替换为 `requestJson` 并移除对 `axios` 的直接使用与 `axios.isAxiosError` 分支，保留对 `ApiError` 的处理与通用 `detail` 字段解析逻辑。
- 将 `frontend/src/hooks/useResolveMovedFile.ts` 改为使用 `requestJson`（通过 `query` 传参）替代原先的 `fetch`/`axios` 拼装逻辑。
- 评估后未在此 PR 中移除 `axios`，因为项目的 OpenAPI 生成配置仍使用 `legacy/axios`，且 `frontend/src/client/*` 与 `frontend/src/utils.ts` 仍显式依赖 `axios`，需先调整生成器或 client 层才能安全移除。

### Testing
- 使用 `rg` / 搜索确认已替换 hooks 中的内联请求并新增 `frontend/src/utils/http.ts`，搜索结果显示 `axios` 仍在 `frontend/src/client`、`frontend/src/utils.ts` 与 `openapi-ts` 配置中被引用，验证通过。
- 运行 `pnpm -C frontend exec tsc --noEmit` 尝试做全量类型检查但因当前环境缺少前端依赖导致大量 `Cannot find module` 错误，该失败与本次局部改动无直接关系并已记录。
- 运行局部文件差异与内容检查以确认所有 `apiJson`/`fetch` 调用已替换为 `requestJson`，检查通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699576bc52348325a3e756d537a9fe36)