### PR TITLE
前端：统一分页组件并替换重复实现

### DIFF
--- a/frontend/src/components/Common/EntityGrid.tsx
+++ b/frontend/src/components/Common/EntityGrid.tsx
@@ -1,18 +1,8 @@
 // 实体网格布局组件，支持分页
-import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ResponsiveGrid } from "@/components/semantic/layout"
-import {
-  Pagination,
-  PaginationContent,
-  PaginationFirst,
-  PaginationItem,
-  PaginationLast,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination"
 import { Skeleton } from "@/components/ui/skeleton"
+import { UnifiedPagination } from "@/components/Common/UnifiedPagination"
 
 import { EntityCard, type EntityCardItem } from "./EntityCard"
 
@@ -40,20 +30,6 @@ export function EntityGrid({
   const finalEmptyText = emptyText ?? defaultEmptyText
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
-  const [jumpPage, setJumpPage] = useState("")
-
-  const visiblePages = []
-  const start = Math.max(1, page - 2)
-  const end = Math.min(totalPages, start + 4)
-  for (let i = start; i <= end; i += 1) {
-    visiblePages.push(i)
-  }
-
-  const goToPage = (nextPage: number) => {
-    const target = Math.min(totalPages, Math.max(1, nextPage))
-    if (target !== page) onPageChange(target)
-  }
-
   return (
     <div className="entity-grid-container space-y-6">
       {isLoading ? (
@@ -83,111 +59,14 @@ export function EntityGrid({
       )}
 
       {total > 0 && (
-        <div className="flex flex-col items-center gap-3">
-          <Pagination className="grid-pagination">
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationFirst
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(1)
-                  }}
-                  className={
-                    page <= 1 ? "pointer-events-none opacity-50" : undefined
-                  }
-                />
-              </PaginationItem>
-
-              <PaginationItem>
-                <PaginationPrevious
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(page - 1)
-                  }}
-                  className={
-                    page <= 1 ? "pointer-events-none opacity-50" : undefined
-                  }
-                />
-              </PaginationItem>
-
-              {visiblePages.map((p) => (
-                <PaginationItem key={p}>
-                  <PaginationLink
-                    href="#"
-                    isActive={p === page}
-                    onClick={(e) => {
-                      e.preventDefault()
-                      goToPage(p)
-                    }}
-                  >
-                    {p}
-                  </PaginationLink>
-                </PaginationItem>
-              ))}
-
-              <PaginationItem>
-                <PaginationNext
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(page + 1)
-                  }}
-                  className={
-                    page >= totalPages
-                      ? "pointer-events-none opacity-50"
-                      : undefined
-                  }
-                />
-              </PaginationItem>
-
-              <PaginationItem>
-                <PaginationLast
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(totalPages)
-                  }}
-                  className={
-                    page >= totalPages
-                      ? "pointer-events-none opacity-50"
-                      : undefined
-                  }
-                />
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
-
-          <div className="flex items-center gap-2 text-sm">
-            <span className="text-muted-foreground">{t("history.goTo")}</span>
-            <input
-              type="number"
-              min={1}
-              max={totalPages}
-              value={jumpPage}
-              onChange={(e) => setJumpPage(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  const n = Number(jumpPage)
-                  if (!Number.isNaN(n)) goToPage(n)
-                }
-              }}
-              className="h-8 w-20 rounded-md border bg-background px-2"
-              placeholder={`1-${totalPages}`}
-            />
-            <button
-              type="button"
-              className="h-8 rounded-md border px-3"
-              onClick={() => {
-                const n = Number(jumpPage)
-                if (!Number.isNaN(n)) goToPage(n)
-              }}
-            >
-              {t("history.confirm")}
-            </button>
-          </div>
-        </div>
+        <UnifiedPagination
+          page={page}
+          totalPages={totalPages}
+          onPageChange={onPageChange}
+          paginationClassName="grid-pagination"
+          jumpLabel={t("history.goTo")}
+          confirmLabel={t("history.confirm")}
+        />
       )}
     </div>
   )

--- a/frontend/src/components/Common/UnifiedPagination.tsx
+++ b/frontend/src/components/Common/UnifiedPagination.tsx
@@ -1,0 +1,163 @@
+import { type ReactNode, useMemo, useState } from "react"
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationFirst,
+  PaginationItem,
+  PaginationLast,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination"
+
+type UnifiedPaginationProps = {
+  page: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  paginationClassName?: string
+  containerClassName?: string
+  showJump?: boolean
+  jumpLabel?: ReactNode
+  confirmLabel?: ReactNode
+  jumpInputClassName?: string
+  confirmButtonClassName?: string
+}
+
+export function UnifiedPagination({
+  page,
+  totalPages,
+  onPageChange,
+  paginationClassName,
+  containerClassName = "flex flex-col items-center gap-3",
+  showJump = true,
+  jumpLabel = "Go to",
+  confirmLabel = "Confirm",
+  jumpInputClassName = "h-8 w-20 rounded-md border bg-background px-2",
+  confirmButtonClassName = "h-8 rounded-md border px-3",
+}: UnifiedPaginationProps) {
+  const [jumpPage, setJumpPage] = useState("")
+
+  const visiblePages = useMemo(() => {
+    const out: number[] = []
+    const start = Math.max(1, page - 2)
+    const end = Math.min(totalPages, start + 4)
+    for (let i = start; i <= end; i += 1) {
+      out.push(i)
+    }
+    return out
+  }, [page, totalPages])
+
+  const goToPage = (nextPage: number) => {
+    const target = Math.min(totalPages, Math.max(1, nextPage))
+    if (target !== page) {
+      onPageChange(target)
+    }
+  }
+
+  return (
+    <div className={containerClassName}>
+      <Pagination className={paginationClassName}>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationFirst
+              href="#"
+              onClick={(e) => {
+                e.preventDefault()
+                goToPage(1)
+              }}
+              className={page <= 1 ? "pointer-events-none opacity-50" : undefined}
+            />
+          </PaginationItem>
+
+          <PaginationItem>
+            <PaginationPrevious
+              href="#"
+              onClick={(e) => {
+                e.preventDefault()
+                goToPage(page - 1)
+              }}
+              className={page <= 1 ? "pointer-events-none opacity-50" : undefined}
+            />
+          </PaginationItem>
+
+          {visiblePages.map((p) => (
+            <PaginationItem key={p}>
+              <PaginationLink
+                href="#"
+                isActive={p === page}
+                onClick={(e) => {
+                  e.preventDefault()
+                  goToPage(p)
+                }}
+              >
+                {p}
+              </PaginationLink>
+            </PaginationItem>
+          ))}
+
+          <PaginationItem>
+            <PaginationNext
+              href="#"
+              onClick={(e) => {
+                e.preventDefault()
+                goToPage(page + 1)
+              }}
+              className={
+                page >= totalPages ? "pointer-events-none opacity-50" : undefined
+              }
+            />
+          </PaginationItem>
+
+          <PaginationItem>
+            <PaginationLast
+              href="#"
+              onClick={(e) => {
+                e.preventDefault()
+                goToPage(totalPages)
+              }}
+              className={
+                page >= totalPages ? "pointer-events-none opacity-50" : undefined
+              }
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+
+      {showJump && (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">{jumpLabel}</span>
+          <input
+            type="number"
+            min={1}
+            max={totalPages}
+            value={jumpPage}
+            onChange={(e) => setJumpPage(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                const n = Number(jumpPage)
+                if (!Number.isNaN(n)) {
+                  goToPage(n)
+                }
+              }
+            }}
+            className={jumpInputClassName}
+            placeholder={`1-${totalPages}`}
+          />
+          <button
+            type="button"
+            className={confirmButtonClassName}
+            onClick={() => {
+              const n = Number(jumpPage)
+              if (!Number.isNaN(n)) {
+                goToPage(n)
+              }
+            }}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Files/FileViewContainer.tsx
+++ b/frontend/src/components/Files/FileViewContainer.tsx
@@ -27,16 +27,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
-import {
-  Pagination,
-  PaginationContent,
-  PaginationFirst,
-  PaginationItem,
-  PaginationLast,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination"
+import { UnifiedPagination } from "@/components/Common/UnifiedPagination"
 import { useFileExplorerKeyboard } from "@/hooks/useFileExplorerKeyboard"
 import { useFileNavigation } from "@/hooks/useFileNavigation"
 import { useFileOperations } from "@/hooks/useFileOperations"
@@ -204,14 +195,6 @@ export function FileViewContainer({
   const pageSize = pagination?.pageSize ?? sortedItems.length
   const totalPages = Math.max(1, Math.ceil(sortedItems.length / pageSize))
   const normalizedPage = Math.min(Math.max(currentPage, 1), totalPages)
-  const visiblePages = useMemo(() => {
-    const out: number[] = []
-    const start = Math.max(1, normalizedPage - 2)
-    const end = Math.min(totalPages, start + 4)
-    for (let i = start; i <= end; i += 1) out.push(i)
-    return out
-  }, [normalizedPage, totalPages])
-
   const goToPage = useCallback(
     (nextPage: number) => {
       if (!pagination) return
@@ -250,7 +233,6 @@ export function FileViewContainer({
     useState<CompressAction>("zip-folder")
   const [confirmFavoriteOpen, setConfirmFavoriteOpen] = useState(false)
   const [confirmAlreadyReadOpen, setConfirmAlreadyReadOpen] = useState(false)
-  const [jumpPage, setJumpPage] = useState("")
   // 当前操作的目标项
   const [contextItem, setContextItem] = useState<FileSystemItem | null>(null)
 
@@ -849,99 +831,12 @@ export function FileViewContainer({
         isPending={operations.moveToAlreadyReadMutation.isPending}
       />
       {pagination && sortedItems.length > 0 && (
-        <div className="flex flex-col items-center gap-3 pt-2">
-          <Pagination>
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationFirst
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(1)
-                  }}
-                  className={normalizedPage <= 1 ? "pointer-events-none opacity-50" : undefined}
-                />
-              </PaginationItem>
-
-              <PaginationItem>
-                <PaginationPrevious
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(normalizedPage - 1)
-                  }}
-                  className={normalizedPage <= 1 ? "pointer-events-none opacity-50" : undefined}
-                />
-              </PaginationItem>
-
-              {visiblePages.map((p) => (
-                <PaginationItem key={p}>
-                  <PaginationLink
-                    href="#"
-                    isActive={p === normalizedPage}
-                    onClick={(e) => {
-                      e.preventDefault()
-                      goToPage(p)
-                    }}
-                  >
-                    {p}
-                  </PaginationLink>
-                </PaginationItem>
-              ))}
-
-              <PaginationItem>
-                <PaginationNext
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(normalizedPage + 1)
-                  }}
-                  className={normalizedPage >= totalPages ? "pointer-events-none opacity-50" : undefined}
-                />
-              </PaginationItem>
-
-              <PaginationItem>
-                <PaginationLast
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(totalPages)
-                  }}
-                  className={normalizedPage >= totalPages ? "pointer-events-none opacity-50" : undefined}
-                />
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
-
-          <div className="flex items-center gap-2 text-sm">
-            <span className="text-muted-foreground">Go to</span>
-            <input
-              type="number"
-              min={1}
-              max={totalPages}
-              value={jumpPage}
-              onChange={(e) => setJumpPage(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  const n = Number(jumpPage)
-                  if (!Number.isNaN(n)) goToPage(n)
-                }
-              }}
-              className="h-8 w-20 rounded-md border bg-background px-2"
-              placeholder={`1-${totalPages}`}
-            />
-            <button
-              type="button"
-              className="h-8 rounded-md border px-3"
-              onClick={() => {
-                const n = Number(jumpPage)
-                if (!Number.isNaN(n)) goToPage(n)
-              }}
-            >
-              Confirm
-            </button>
-          </div>
-        </div>
+        <UnifiedPagination
+          page={normalizedPage}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          containerClassName="flex flex-col items-center gap-3 pt-2"
+        />
       )}
     </div>
   )

--- a/frontend/src/routes/_layout/history.tsx
+++ b/frontend/src/routes/_layout/history.tsx
@@ -7,7 +7,6 @@ import {
   LayoutGrid,
   List,
 } from "lucide-react"
-import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 
@@ -22,16 +21,7 @@ import {
   formatFileType,
 } from "@/components/Files/utils"
 import { Button } from "@/components/ui/button"
-import {
-  Pagination,
-  PaginationContent,
-  PaginationFirst,
-  PaginationItem,
-  PaginationLast,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination"
+import { UnifiedPagination } from "@/components/Common/UnifiedPagination"
 import { Skeleton } from "@/components/ui/skeleton"
 import { buildNavigationTarget } from "@/hooks/useFileNavigation"
 import { useIsMobile } from "@/hooks/useMobile"
@@ -76,7 +66,6 @@ function HistoryPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const isMobile = useIsMobile()
-  const [jumpPage, setJumpPage] = useState("")
   const { page, view, sort_order } = Route.useSearch()
   const pageSize = view === "grid" ? 24 : 50
 
@@ -96,16 +85,8 @@ function HistoryPage() {
     },
   })
 
-  const visiblePages = useMemo(() => {
-    const totalPages = Math.max(1, data?.total_pages ?? 1)
-    const out: number[] = []
-    const start = Math.max(1, page - 2)
-    const end = Math.min(totalPages, start + 4)
-    for (let i = start; i <= end; i += 1) out.push(i)
-    return out
-  }, [data?.total_pages, page])
-
   const totalPages = Math.max(1, data?.total_pages ?? 1)
+
 
   const goToPage = (nextPage: number) => {
     const target = Math.min(totalPages, Math.max(1, nextPage))
@@ -290,111 +271,13 @@ function HistoryPage() {
       )}
 
       {(data?.total ?? 0) > 0 && (
-        <div className="flex flex-col items-center gap-3">
-          <Pagination>
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationFirst
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(1)
-                  }}
-                  className={
-                    page <= 1 ? "pointer-events-none opacity-50" : undefined
-                  }
-                />
-              </PaginationItem>
-
-              <PaginationItem>
-                <PaginationPrevious
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(page - 1)
-                  }}
-                  className={
-                    page <= 1 ? "pointer-events-none opacity-50" : undefined
-                  }
-                />
-              </PaginationItem>
-
-              {visiblePages.map((p) => (
-                <PaginationItem key={p}>
-                  <PaginationLink
-                    href="#"
-                    isActive={p === page}
-                    onClick={(e) => {
-                      e.preventDefault()
-                      goToPage(p)
-                    }}
-                  >
-                    {p}
-                  </PaginationLink>
-                </PaginationItem>
-              ))}
-
-              <PaginationItem>
-                <PaginationNext
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(page + 1)
-                  }}
-                  className={
-                    page >= totalPages
-                      ? "pointer-events-none opacity-50"
-                      : undefined
-                  }
-                />
-              </PaginationItem>
-
-              <PaginationItem>
-                <PaginationLast
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    goToPage(totalPages)
-                  }}
-                  className={
-                    page >= totalPages
-                      ? "pointer-events-none opacity-50"
-                      : undefined
-                  }
-                />
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
-
-          <div className="flex items-center gap-2 text-sm">
-            <span className="text-muted-foreground">{t("history.goTo")}</span>
-            <input
-              type="number"
-              min={1}
-              max={totalPages}
-              value={jumpPage}
-              onChange={(e) => setJumpPage(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  const n = Number(jumpPage)
-                  if (!Number.isNaN(n)) goToPage(n)
-                }
-              }}
-              className="h-8 w-20 rounded-md border bg-background px-2"
-              placeholder={`1-${totalPages}`}
-            />
-            <button
-              type="button"
-              className="h-8 rounded-md border px-3"
-              onClick={() => {
-                const n = Number(jumpPage)
-                if (!Number.isNaN(n)) goToPage(n)
-              }}
-            >
-              {t("history.confirm")}
-            </button>
-          </div>
-        </div>
+        <UnifiedPagination
+          page={page}
+          totalPages={totalPages}
+          onPageChange={goToPage}
+          jumpLabel={t("history.goTo")}
+          confirmLabel={t("history.confirm")}
+        />
       )}
     </div>
   )

--- a/frontend/src/routes/_layout/search.tsx
+++ b/frontend/src/routes/_layout/search.tsx
@@ -10,16 +10,7 @@ import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Pagination,
-  PaginationContent,
-  PaginationFirst,
-  PaginationItem,
-  PaginationLast,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination"
+import { UnifiedPagination } from "@/components/Common/UnifiedPagination"
 import {
   Select,
   SelectContent,
@@ -90,7 +81,6 @@ function SearchPage() {
   const [presenceFilter, setPresenceFilter] = useState<PresenceFilter>(
     search.presenceFilter,
   )
-  const [jumpPage, setJumpPage] = useState("")
 
   const pageSize = 24
 
@@ -143,14 +133,6 @@ function SearchPage() {
     if (!data?.items) return 1
     return Math.max(1, Math.ceil(data.items.length / pageSize))
   }, [data?.items])
-
-  const visiblePages = useMemo(() => {
-    const out: number[] = []
-    const start = Math.max(1, search.page - 2)
-    const end = Math.min(totalPages, start + 4)
-    for (let i = start; i <= end; i += 1) out.push(i)
-    return out
-  }, [totalPages, search.page])
 
   const goToPage = (nextPage: number) => {
     const target = Math.min(totalPages, Math.max(1, nextPage))
@@ -302,118 +284,15 @@ function SearchPage() {
             emptyText={t("search.noResults")}
           />
           {(data?.total ?? 0) > pageSize && (
-            <div className="flex flex-col items-center gap-3">
-              <Pagination>
-                <PaginationContent>
-                  <PaginationItem>
-                    <PaginationFirst
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault()
-                        goToPage(1)
-                      }}
-                      className={
-                        search.page <= 1
-                          ? "pointer-events-none opacity-50"
-                          : undefined
-                      }
-                    />
-                  </PaginationItem>
-
-                  <PaginationItem>
-                    <PaginationPrevious
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault()
-                        goToPage(search.page - 1)
-                      }}
-                      className={
-                        search.page <= 1
-                          ? "pointer-events-none opacity-50"
-                          : undefined
-                      }
-                    />
-                  </PaginationItem>
-
-                  {visiblePages.map((p) => (
-                    <PaginationItem key={p}>
-                      <PaginationLink
-                        href="#"
-                        isActive={p === search.page}
-                        onClick={(e) => {
-                          e.preventDefault()
-                          goToPage(p)
-                        }}
-                      >
-                        {p}
-                      </PaginationLink>
-                    </PaginationItem>
-                  ))}
-
-                  <PaginationItem>
-                    <PaginationNext
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault()
-                        goToPage(search.page + 1)
-                      }}
-                      className={
-                        search.page >= totalPages
-                          ? "pointer-events-none opacity-50"
-                          : undefined
-                      }
-                    />
-                  </PaginationItem>
-
-                  <PaginationItem>
-                    <PaginationLast
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault()
-                        goToPage(totalPages)
-                      }}
-                      className={
-                        search.page >= totalPages
-                          ? "pointer-events-none opacity-50"
-                          : undefined
-                      }
-                    />
-                  </PaginationItem>
-                </PaginationContent>
-              </Pagination>
-
-              <div className="flex items-center gap-2 text-sm">
-                <span className="text-muted-foreground">
-                  {t("search.goTo")}
-                </span>
-                <Input
-                  type="number"
-                  min={1}
-                  max={totalPages}
-                  value={jumpPage}
-                  onChange={(e) => setJumpPage(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      const n = Number(jumpPage)
-                      if (!Number.isNaN(n)) goToPage(n)
-                    }
-                  }}
-                  className="h-8 w-20"
-                  placeholder={`1-${totalPages}`}
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    const n = Number(jumpPage)
-                    if (!Number.isNaN(n)) goToPage(n)
-                  }}
-                >
-                  {t("search.confirm")}
-                </Button>
-              </div>
-            </div>
+            <UnifiedPagination
+              page={search.page}
+              totalPages={totalPages}
+              onPageChange={goToPage}
+              jumpLabel={t("search.goTo")}
+              confirmLabel={t("search.confirm")}
+              jumpInputClassName="h-8 w-20"
+              confirmButtonClassName="inline-flex items-center justify-center rounded-md border border-input bg-background px-3 text-sm font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground h-8"
+            />
           )}
         </div>
       ) : null}


### PR DESCRIPTION
### Motivation
- 多处不同布局重复实现分页控件导致代码冗长、行为不统一，需要抽出可复用的分页组件以简化维护。

### Description
- 新增 `UnifiedPagination` 组件，位于 `frontend/src/components/Common/UnifiedPagination.tsx`，封装了首页/上一页/页码/下一页/末页及可选的跳页输入与确认按钮，并支持样式和文案定制（通过 `paginationClassName` / `containerClassName` / `jumpLabel` 等属性）。
- 将原先在 `EntityGrid` 的内联分页替换为 `UnifiedPagination`（修改文件：`frontend/src/components/Common/EntityGrid.tsx`）。
- 将 `FileViewContainer` 中的分页渲染替换为 `UnifiedPagination`，同时保留容器内的分页计算与 `goToPage` 回调（修改文件：`frontend/src/components/Files/FileViewContainer.tsx`）。
- 将 `/history` 与 `/search` 页面的重复分页逻辑替换为 `UnifiedPagination`，并传入原有的 i18n 文案与样式参数以保持行为一致（修改文件：`frontend/src/routes/_layout/history.tsx`，`frontend/src/routes/_layout/search.tsx`）。

### Testing
- 在修改的文件上运行了 Biome 检查：`cd frontend && npx biome check src/components/Common/UnifiedPagination.tsx src/components/Common/EntityGrid.tsx src/routes/_layout/history.tsx src/routes/_layout/search.tsx src/components/Files/FileViewContainer.tsx`，针对修改文件未报告问题（命令执行正常）。
- 尝试运行项目构建：`npm --prefix frontend run build`，但当前环境缺少前端依赖导致 TypeScript 在项目级别报出大量与本次变更无关的缺少模块错误，构建未完成。 
- 尝试用 Playwright 捕获页面截图以验证 UI，但本地前端服务未启动（`http://127.0.0.1:5173` 返回 `ERR_EMPTY_RESPONSE`），因此未能在运行时截图验证组件外观。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ca65394c8325935eaae6a55f6cce)