### PR TITLE
fix(frontend): i18n sidebar titles and unify HomeFolderLinkCard path handling

### DIFF
--- a/frontend/src/components/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Sidebar/AppSidebar.tsx
@@ -29,7 +29,7 @@ const baseItems: Item[] = [
   { icon: UserRound, title: "authors", path: "/authors" },
   { icon: VenetianMask, title: "cosers", path: "/cosers" },
   { icon: Search, title: "search", path: "/search" },
-  { icon: Settings, title: "settings.title", path: "/settings" },
+  { icon: Settings, title: "settings", path: "/settings" },
 ]
 
 export function AppSidebar() {
@@ -37,7 +37,7 @@ export function AppSidebar() {
   const { state } = useSidebar()
   const items = baseItems.map((item) => ({
     ...item,
-    title: item.title.includes(".") ? t(item.title) : t(`nav.${item.title}`),
+    title: t(`nav.${item.title}`),
   }))
 
   return (

--- a/frontend/src/components/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Sidebar/AppSidebar.tsx
@@ -7,6 +7,7 @@ import {
   VenetianMask,
   UserRound,
 } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 import { SidebarAppearance } from "@/components/Common/Appearance"
 import { Logo } from "@/components/Common/Logo"
@@ -21,18 +22,24 @@ import {
 import { type Item, Main } from "./Main"
 
 const baseItems: Item[] = [
-  // { icon: Home, title: "Home", path: "/" },
-  { icon: FolderOpen, title: "Explorer", path: "/" },
-  { icon: History, title: "History", path: "/history" },
-  { icon: Tag, title: "Tags", path: "/tags" },
-  { icon: UserRound, title: "Authors", path: "/authors" },
-  { icon: VenetianMask, title: "Cosers", path: "/cosers" },
-  { icon: Search, title: "Search", path: "/search" },
-  { icon: Settings, title: "Settings", path: "/settings" },
+  // { icon: Home, title: "home", path: "/" },
+  { icon: FolderOpen, title: "explorer", path: "/" },
+  { icon: History, title: "history", path: "/history" },
+  { icon: Tag, title: "tags", path: "/tags" },
+  { icon: UserRound, title: "authors", path: "/authors" },
+  { icon: VenetianMask, title: "cosers", path: "/cosers" },
+  { icon: Search, title: "search", path: "/search" },
+  { icon: Settings, title: "settings.title", path: "/settings" },
 ]
 
 export function AppSidebar() {
+  const { t } = useTranslation()
   const { state } = useSidebar()
+  const items = baseItems.map((item) => ({
+    ...item,
+    title: item.title.includes(".") ? t(item.title) : t(`nav.${item.title}`),
+  }))
+
   return (
     <Sidebar collapsible="icon">
       <SidebarHeader className="px-4 py-6">
@@ -42,7 +49,7 @@ export function AppSidebar() {
         </div>
       </SidebarHeader>
       <SidebarContent>
-        <Main items={baseItems} />
+        <Main items={items} />
       </SidebarContent>
       <SidebarFooter>
         <SidebarAppearance />

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -25,7 +25,8 @@
     "authors": "Authors",
     "cosers": "Cosers (preview)",
     "search": "Search",
-    "admin": "Admin"
+    "admin": "Admin",
+    "settings": "Settings"
   },
   "home": {
     "drives": "Drives",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -25,7 +25,8 @@
     "authors": "作者",
     "cosers": "Coser (preview)",
     "search": "検索",
-    "admin": "管理"
+    "admin": "管理",
+    "settings": "設定"
   },
   "home": {
     "drives": "ドライブ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -26,7 +26,8 @@
     "authors": "작가",
     "cosers": "코서 (preview)",
     "search": "검색",
-    "admin": "관리"
+    "admin": "관리",
+    "settings": "설정"
   },
   "home": {
     "drives": "드라이브",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -25,7 +25,8 @@
     "authors": "作者",
     "cosers": "Coser (preview)",
     "search": "搜索",
-    "admin": "管理"
+    "admin": "管理",
+    "settings": "设置"
   },
   "home": {
     "drives": "硬盘驱动器",

--- a/frontend/src/routes/_layout/index.tsx
+++ b/frontend/src/routes/_layout/index.tsx
@@ -7,6 +7,7 @@ import { Folder, HardDrive, Heart, BookOpen, Film, Image, Music2, type LucideIco
 import { useTranslation } from "react-i18next"
 
 import { FilesystemService, OpenAPI } from "@/client"
+import { getBaseName, getParentPath } from "@/lib/path-utils"
 
 import { HomeCard } from "@/components/Home/HomeCard"
 import { RecentActivityPanel, type ActivityItem } from "@/components/Home/RecentActivityPanel"
@@ -40,15 +41,14 @@ function parseGoodFolderMonth(name: string): number | null {
 
 function HomeFolderLinkCard({
   path,
-  name,
   icon,
-  subtitle,
 }: {
   path: string
-  name: string
   icon: typeof Folder | typeof Heart
-  subtitle?: string
 }) {
+  const name = getBaseName(path, path)
+  const subtitle = getParentPath(path)
+
   return (
     <Link
       to="/explorer"
@@ -56,7 +56,7 @@ function HomeFolderLinkCard({
       className="home-card-link"
       title={name}
     >
-      <HomeCard icon={icon} title={name} subtitle={subtitle} />
+      <HomeCard icon={icon} title={name} subtitle={subtitle || undefined} />
     </Link>
   )
 }
@@ -221,7 +221,6 @@ function Dashboard() {
           {favoriteRoot ? (
             <HomeFolderLinkCard
               path={favoriteRoot.path}
-              name={favoriteRoot.dirname}
               icon={Heart}
             />
           ) : null}
@@ -230,16 +229,13 @@ function Dashboard() {
             <HomeFolderLinkCard
               key={folder.path}
               path={folder.path}
-              name={folder.name}
               icon={Folder}
-              subtitle={favoriteRoot?.dirname}
             />
           ))}
 
           {alreadyReadRoot ? (
             <HomeFolderLinkCard
               path={alreadyReadRoot.path}
-              name={alreadyReadRoot.dirname}
               icon={Folder}
             />
           ) : null}
@@ -255,7 +251,6 @@ function Dashboard() {
             <HomeFolderLinkCard
               key={root.path}
               path={root.path}
-              name={root.dirname}
               icon={Folder}
             />
           ))}
@@ -270,9 +265,7 @@ function Dashboard() {
             <HomeFolderLinkCard
               key={folderPath}
               path={folderPath}
-              name={folderPath.split(/[\\/]/).filter(Boolean).at(-1) ?? folderPath}
               icon={Folder}
-              subtitle={folderPath}
             />
           ))}
           {topOpenedFolders && topOpenedFolders.folder_ids.length === 0 ? <div className="home-empty">{t("home.noTopOpenedFolders")}</div> : null}


### PR DESCRIPTION
### Motivation
- 修复 Sidebar 菜单标题未使用现有 i18n 的问题，使标题随语言切换。
- 统一 Home 页面不同位置对文件夹卡片的参数调用，避免部分卡片有 `subtitle`、部分没有的不一致情况。
- 要求传入文件夹 `path` 并在卡片内部计算 folder name 和 dirpath，提升复用性和一致性。

### Description
- 在 `frontend/src/components/Sidebar/AppSidebar.tsx` 中引入 `useTranslation`，将 `baseItems` 的 `title` 改为 i18n key（使用 `nav.*` 或 `settings.title`），并在组件内通过 `t(...)` 生成传给 `Main` 的 `items`。
- 在 `frontend/src/routes/_layout/index.tsx` 中引入 `getBaseName` 与 `getParentPath`，将 `HomeFolderLinkCard` 重构为只接收 `path` 与 `icon`，在内部计算 `name`（`getBaseName(path, path)`）与 `subtitle`（`getParentPath(path)`），并在 `subtitle` 为空时传 `undefined` 给 `HomeCard`。
- 更新 Home 页面所有调用处（special folders / favorite subfolders / already read / quick access / top opened folders）只传入 `path` 与 `icon`，移除外部传入的 `name`/`subtitle`，保证 subtitle 渲染规则由卡片内部统一决定。

### Testing
- 运行 `npm -C frontend run build` 时因当前环境未安装前端依赖导致 TypeScript/Vite 报大量缺失模块错误，构建未通过，但这些错误来自依赖缺失，与本次改动无关。
- 运行 `npm -C frontend run dev -- --host 0.0.0.0 --port 4173` 时因 `vite` 二进制不可用无法启动，本地页面验证未能完成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995df3b10548325b5fb280a558cd1df)