### PR TITLE
feat(explorer): 在缩略图 FileItem 的 hover tooltip 显示 mtime/likeScore/最后阅读时间

### DIFF
--- a/frontend/src/components/Files/FileItem.tsx
+++ b/frontend/src/components/Files/FileItem.tsx
@@ -5,6 +5,11 @@ import type { FileSystemItem } from "@/client"
 import { OpenAPI } from "@/client"
 import { ThumbnailImage } from "@/components/Common/ThumbnailImage"
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
   CardInfo,
   CardThumbnail,
   FileName,
@@ -15,7 +20,7 @@ import { getParentPath } from "@/lib/path-utils"
 import { cn } from "@/lib/utils"
 
 import { FileIcon } from "./FileIcon"
-import { formatFileSize } from "./utils"
+import { formatDateTime, formatFileSize } from "./utils"
 import "./FileItem.css"
 
 interface FileItemProps {
@@ -83,6 +88,14 @@ export function FileItem({
     </FileName>
   )
 
+  const likeScore = (item as any).likeScore ?? (item as any).recommendation_score
+  const lastReadAt = (item as any).last_read_at
+  const thumbnailTooltip = [
+    `${t("explorer.table.dateModified")}: ${item.mtime ? formatDateTime(item.mtime) : "-"}`,
+    `${t("explorer.table.likeScore")}: ${likeScore != null ? Number(likeScore).toFixed(3) : "-"}`,
+    `${t("explorer.table.lastReadAt")}: ${lastReadAt ? formatDateTime(lastReadAt) : "-"}`,
+  ].join("\n")
+
   const thumbcard = (<CardThumbnail className="file-card-thumbnail">
             {item.thumbnail_url ? (
               <ThumbnailImage
@@ -111,9 +124,30 @@ export function FileItem({
         {fileNameNode}
 
         {href ? (
-          <a href={href} className="file-item-thumbnail-link" draggable={false}>
-            {thumbcard}
-          </a>
+          item.thumbnail_url ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <a
+                  href={href}
+                  className="file-item-thumbnail-link"
+                  draggable={false}
+                >
+                  {thumbcard}
+                </a>
+              </TooltipTrigger>
+              <TooltipContent className="whitespace-pre-line">
+                {thumbnailTooltip}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <a
+              href={href}
+              className="file-item-thumbnail-link"
+              draggable={false}
+            >
+              {thumbcard}
+            </a>
+          )
         ) : (
           thumbcard
         )}


### PR DESCRIPTION
### Motivation
- 在文件浏览器的缩略图上快速展示关键信息（修改时间、like score、最后阅读时间），以便用户在不打开文件的情况下查看元数据。

### Description
- 在 `FileItem` 中引入 `Tooltip/TooltipTrigger/TooltipContent` 并使用现有的 `formatDateTime` 来构建 tooltip 内容，展示三行信息：修改时间（`mtime`）、like score（优先使用 `likeScore`，回退到 `recommendation_score`）和最后阅读时间（`last_read_at`）。
- 仅在 `thumbnail_url` 存在时将缩略图链接包裹为可悬停的 `Tooltip`，并通过 `whitespace-pre-line` 支持多行显示以保持格式化显示。
- 使用现有 i18n 文案键（`explorer.table.dateModified` / `explorer.table.likeScore` / `explorer.table.lastReadAt`）保持显示风格一致且可翻译。

### Testing
- 运行了 `npx biome check src/components/Files/FileItem.tsx`，类型/格式检查通过或未报阻塞性错误。
- 尝试通过 `npm run dev` 启动前端以做 UI 校验但 Vite 在当前环境中因 optional native 依赖解析问题无法启动，导致无法做运行时截图或交互验证。
- 为缓解问题尝试安装了缺失的本地 native 包（如 `@rollup/rollup-linux-x64-gnu` 和 `lightningcss-linux-x64-gnu`），但仍受限于环境的 optional dependency 解析问题，无法完全启动开发服务器进行实时验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e77f091c8325822807e055dbd57f)