### PR TITLE
feat(settings): 设置页显示 .env 路径并新增 `move_place_dir` 用于 Move to 预填

### DIFF
--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -13,12 +13,15 @@ class SettingsResponse(BaseModel):
     favorite_dir: str
     fs_roots: str
     already_read_dir: str
+    move_place_dir: str
+    env_file_path: str
 
 
 class SettingsUpdate(BaseModel):
     favorite_dir: str | None = None
     fs_roots: str | None = None
     already_read_dir: str | None = None
+    move_place_dir: str | None = None
 
 
 def _validate_dir_path(path_str: str, field_name: str) -> None:
@@ -56,6 +59,8 @@ def get_settings() -> Any:
         favorite_dir=settings.FAVORITE_DIR,
         fs_roots=settings.FS_ROOTS,
         already_read_dir=settings.ALREADY_READ_DIR,
+        move_place_dir=settings.MOVE_PLACE_DIR,
+        env_file_path=settings.ENV_FILE_PATH,
     )
 
 
@@ -63,7 +68,7 @@ def get_settings() -> Any:
 @router.put("/settings", response_model=SettingsResponse)
 def update_settings(settings_update: SettingsUpdate) -> Any:
     """Update settings in .env file."""
-    env_path = Path(__file__).parent.parent.parent.parent.parent / ".env"
+    env_path = Path(settings.ENV_FILE_PATH)
 
     if not env_path.exists():
         raise HTTPException(status_code=500, detail=".env file not found")
@@ -95,11 +100,20 @@ def update_settings(settings_update: SettingsUpdate) -> Any:
             _validate_dir_path(already_read_dir, "already_read_dir")
         updates["ALREADY_READ_DIR"] = already_read_dir
 
+    # --- move_place_dir ---
+    if settings_update.move_place_dir is not None:
+        move_place_dir = settings_update.move_place_dir.strip()
+        if move_place_dir:
+            _validate_dir_path(move_place_dir, "move_place_dir")
+        updates["MOVE_PLACE_DIR"] = move_place_dir
+
     if not updates:
         return SettingsResponse(
             favorite_dir=settings.FAVORITE_DIR,
             fs_roots=settings.FS_ROOTS,
             already_read_dir=settings.ALREADY_READ_DIR,
+            move_place_dir=settings.MOVE_PLACE_DIR,
+            env_file_path=settings.ENV_FILE_PATH,
         )
 
     try:
@@ -120,6 +134,8 @@ def update_settings(settings_update: SettingsUpdate) -> Any:
             favorite_dir=settings.FAVORITE_DIR,
             fs_roots=settings.FS_ROOTS,
             already_read_dir=settings.ALREADY_READ_DIR,
+            move_place_dir=settings.MOVE_PLACE_DIR,
+            env_file_path=settings.ENV_FILE_PATH,
         )
     except HTTPException:
         raise

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -69,6 +69,7 @@ class Settings(BaseSettings):
     FS_ROOTS: str = ""  # Comma-separated list of root directories
     FAVORITE_DIR: str = ""
     ALREADY_READ_DIR: str = ""
+    MOVE_PLACE_DIR: str = ""
     THUMB_CACHE_DIR: str = "../data/thumb_cache"
     THUMB_CONCURRENCY: int = 3
     THUMB_TIMEOUT_SEC: int = 10
@@ -81,6 +82,11 @@ class Settings(BaseSettings):
     IMAGE_COMPRESS_MIN_SIZE: int = 1048576  # 最小文件大小（1MB，小于此值不压缩）
     IMAGE_COMPRESS_QUALITY: int = 85  # JPEG 压缩质量（1-100）
     IMAGE_COMPRESS_FORMAT: str = "JPEG"  # 输出格式
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def ENV_FILE_PATH(self) -> str:
+        return self._resolve_env_file()
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/tests/api/routes/test_misc_routes.py
+++ b/backend/tests/api/routes/test_misc_routes.py
@@ -69,6 +69,8 @@ def test_settings_read(misc_client: TestClient) -> None:
     assert "favorite_dir" in data
     assert "fs_roots" in data
     assert "already_read_dir" in data
+    assert "move_place_dir" in data
+    assert "env_file_path" in data
 
 
 def test_private_create_user(client: TestClient) -> None:

--- a/frontend/src/components/Files/dialogs/MoveDialog.tsx
+++ b/frontend/src/components/Files/dialogs/MoveDialog.tsx
@@ -1,5 +1,6 @@
 // 移动对话框 — 输入目标路径
 import { useEffect, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -12,6 +13,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { OpenAPI } from "@/client"
 import { getBaseName, getParentPath } from "@/lib/path-utils"
 
 interface MoveDialogProps {
@@ -21,7 +23,6 @@ interface MoveDialogProps {
   filePaths: string[]
   onConfirm: (destDir: string) => void
   isPending?: boolean
-  initialDestDir?: string
 }
 
 export function MoveDialog({
@@ -30,17 +31,28 @@ export function MoveDialog({
   filePaths,
   onConfirm,
   isPending,
-  initialDestDir,
 }: MoveDialogProps) {
   const count = filePaths.length
   const defaultDest = filePaths.length > 0 ? getParentPath(filePaths[0]) : ""
-  const [destDir, setDestDir] = useState(initialDestDir?.trim() || defaultDest)
+
+  const { data: settingsData } = useQuery<{ move_place_dir?: string }>({
+    queryKey: ["settings", "move-dialog-default-dest"],
+    queryFn: async () => {
+      const response = await fetch(`${OpenAPI.BASE}/api/v1/settings`)
+      if (!response.ok) return {}
+      return response.json()
+    },
+    retry: false,
+  })
+
+  const preferredDest = settingsData?.move_place_dir?.trim() || defaultDest
+  const [destDir, setDestDir] = useState(preferredDest)
 
   useEffect(() => {
     if (open) {
-      setDestDir(initialDestDir?.trim() || defaultDest)
+      setDestDir(preferredDest)
     }
-  }, [open, defaultDest, initialDestDir])
+  }, [open, preferredDest])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()

--- a/frontend/src/components/Files/dialogs/MoveDialog.tsx
+++ b/frontend/src/components/Files/dialogs/MoveDialog.tsx
@@ -21,6 +21,7 @@ interface MoveDialogProps {
   filePaths: string[]
   onConfirm: (destDir: string) => void
   isPending?: boolean
+  initialDestDir?: string
 }
 
 export function MoveDialog({
@@ -29,16 +30,17 @@ export function MoveDialog({
   filePaths,
   onConfirm,
   isPending,
+  initialDestDir,
 }: MoveDialogProps) {
   const count = filePaths.length
   const defaultDest = filePaths.length > 0 ? getParentPath(filePaths[0]) : ""
-  const [destDir, setDestDir] = useState(defaultDest)
+  const [destDir, setDestDir] = useState(initialDestDir?.trim() || defaultDest)
 
   useEffect(() => {
     if (open) {
-      setDestDir(defaultDest)
+      setDestDir(initialDestDir?.trim() || defaultDest)
     }
-  }, [open, defaultDest])
+  }, [open, defaultDest, initialDestDir])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -229,7 +229,12 @@
     "completed": "Completed",
     "error": "Error",
     "japanese": "Japanese",
-    "korean": "Korean"
+    "korean": "Korean",
+    "movePlaceDir": "Move To default directory",
+    "movePlaceDirDesc": "Default destination prefilled when opening \"Move to...\"",
+    "movePlaceDirPlaceholder": "Enter directory path, e.g., E:\\_To_Sort",
+    "envFilePath": ".env file path",
+    "envFilePathDesc": "The currently used .env file location for manual editing"
   },
   "archive": {
     "unknownError": "Unknown error"

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -229,7 +229,12 @@
     "running": "実行中",
     "completed": "完了",
     "error": "エラー",
-    "korean": "한국어"
+    "korean": "한국어",
+    "movePlaceDir": "Move To の既定ディレクトリ",
+    "movePlaceDirDesc": "「Move to...」を開いたときに事前入力する移動先ディレクトリ",
+    "movePlaceDirPlaceholder": "ディレクトリパスを入力（例：E:\\_To_Sort）",
+    "envFilePath": ".env ファイルパス",
+    "envFilePathDesc": "現在使用中の .env ファイルの場所（手動編集用）"
   },
   "archive": {
     "unknownError": "不明なエラー"

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -230,7 +230,12 @@
     "endTime": "종료 시각",
     "running": "실행 중",
     "completed": "완료",
-    "error": "오류"
+    "error": "오류",
+    "movePlaceDir": "Move To 기본 디렉터리",
+    "movePlaceDirDesc": "\"Move to...\"를 열 때 미리 채워질 기본 대상 디렉터리",
+    "movePlaceDirPlaceholder": "디렉터리 경로 입력 (예: E:\\_To_Sort)",
+    "envFilePath": ".env 파일 경로",
+    "envFilePathDesc": "수동 편집을 위한 현재 사용 중인 .env 파일 위치"
   },
   "archive": {
     "unknownError": "알 수 없는 오류"

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -229,7 +229,12 @@
     "completed": "已完成",
     "error": "出错",
     "japanese": "日本語",
-    "korean": "한국어"
+    "korean": "한국어",
+    "movePlaceDir": "Move To 默认目录",
+    "movePlaceDirDesc": "点击“Move to...”时默认填充的目标目录",
+    "movePlaceDirPlaceholder": "输入目录路径，例如：E:\\_To_Sort",
+    "envFilePath": ".env 文件路径",
+    "envFilePathDesc": "当前正在使用的 .env 文件位置，方便手动编辑"
   },
   "archive": {
     "unknownError": "未知错误"

--- a/frontend/src/routes/_layout/read.tsx
+++ b/frontend/src/routes/_layout/read.tsx
@@ -136,16 +136,6 @@ function ReadPage() {
   })
 
 
-  const { data: readerSettings } = useQuery<{ move_place_dir?: string }>({
-    queryKey: ["settings", "reader-move-place-dir"],
-    queryFn: async () => {
-      const response = await fetch(`${OpenAPI.BASE}/api/v1/settings`)
-      if (!response.ok) return {}
-      return response.json()
-    },
-    retry: false,
-  })
-
   const { data: parseMeta } = useQuery({
     queryKey: ["reader-parse-meta", path],
     queryFn: async () => {
@@ -1055,7 +1045,6 @@ function ReadPage() {
           operations.moveFileMutation.isPending ||
           operations.moveFolderMutation.isPending
         }
-        initialDestDir={readerSettings?.move_place_dir?.trim() || undefined}
       />
       <CompressDialog
         open={compressOpen}

--- a/frontend/src/routes/_layout/read.tsx
+++ b/frontend/src/routes/_layout/read.tsx
@@ -135,6 +135,17 @@ function ReadPage() {
     retry: false,
   })
 
+
+  const { data: readerSettings } = useQuery<{ move_place_dir?: string }>({
+    queryKey: ["settings", "reader-move-place-dir"],
+    queryFn: async () => {
+      const response = await fetch(`${OpenAPI.BASE}/api/v1/settings`)
+      if (!response.ok) return {}
+      return response.json()
+    },
+    retry: false,
+  })
+
   const { data: parseMeta } = useQuery({
     queryKey: ["reader-parse-meta", path],
     queryFn: async () => {
@@ -1044,6 +1055,7 @@ function ReadPage() {
           operations.moveFileMutation.isPending ||
           operations.moveFolderMutation.isPending
         }
+        initialDestDir={readerSettings?.move_place_dir?.trim() || undefined}
       />
       <CompressDialog
         open={compressOpen}

--- a/frontend/src/routes/_layout/settings.tsx
+++ b/frontend/src/routes/_layout/settings.tsx
@@ -44,12 +44,15 @@ interface SettingsResponse {
   favorite_dir: string
   fs_roots: string
   already_read_dir: string
+  move_place_dir: string
+  env_file_path: string
 }
 
 interface SettingsUpdate {
   favorite_dir?: string
   fs_roots?: string
   already_read_dir?: string
+  move_place_dir?: string
 }
 
 interface ClearCacheResponse {
@@ -180,6 +183,7 @@ function SettingsPage() {
   const [fsRootList, setFsRootList] = useState<string[]>([""])
   const [favoriteDir, setFavoriteDir] = useState("")
   const [alreadyReadDir, setAlreadyReadDir] = useState("")
+  const [movePlaceDir, setMovePlaceDir] = useState("")
 
   const handleTabChange = (value: string) => {
     navigate({ search: (prev) => ({ ...prev, tab: value as any }) })
@@ -199,6 +203,7 @@ function SettingsPage() {
     setFsRootList(parseFsRoots(settings.fs_roots || ""))
     setFavoriteDir(settings.favorite_dir || "")
     setAlreadyReadDir(settings.already_read_dir || "")
+    setMovePlaceDir(settings.move_place_dir || "")
   }, [settings])
 
   const updateMutation = useMutation({
@@ -236,6 +241,7 @@ function SettingsPage() {
 
   const currentFavoriteDir = settings?.favorite_dir || ""
   const currentAlreadyReadDir = settings?.already_read_dir || ""
+  const currentMovePlaceDir = settings?.move_place_dir || ""
 
   const saveFsRootsIfChanged = () => {
     if (updateMutation.isPending || normalizedFsRoots === currentFsRoots) return
@@ -252,6 +258,12 @@ function SettingsPage() {
     const normalized = alreadyReadDir.trim()
     if (updateMutation.isPending || normalized === currentAlreadyReadDir) return
     updateMutation.mutate({ already_read_dir: normalized })
+  }
+
+  const saveMovePlaceDirIfChanged = () => {
+    const normalized = movePlaceDir.trim()
+    if (updateMutation.isPending || normalized === currentMovePlaceDir) return
+    updateMutation.mutate({ move_place_dir: normalized })
   }
 
   const handleFsRootItemChange = (index: number, value: string) => {
@@ -428,6 +440,30 @@ function SettingsPage() {
             }}
             t={t}
           />
+
+          <SinglePathSection
+            title={t("settings.movePlaceDir")}
+            description={t("settings.movePlaceDirDesc")}
+            value={movePlaceDir}
+            placeholder={t("settings.movePlaceDirPlaceholder")}
+            id="movePlaceDir"
+            colorClass="settings-section--blue"
+            onChange={setMovePlaceDir}
+            onSave={saveMovePlaceDirIfChanged}
+            onReset={() => {
+              setMovePlaceDir("")
+              setTimeout(saveMovePlaceDirIfChanged, 0)
+            }}
+            t={t}
+          />
+
+          <section className="settings-section settings-section--white">
+            <div className="settings-section__heading">
+              <h2>{t("settings.envFilePath")}</h2>
+              <p>{t("settings.envFilePathDesc")}</p>
+            </div>
+            <Input value={settings?.env_file_path || ""} readOnly />
+          </section>
 
           <SinglePathSection
             title={t("settings.favoriteDir")}


### PR DESCRIPTION
### Motivation
- 在设置页显示当前使用的 `.env` 文件路径，方便用户手动编辑和排查配置问题。
- 新增 `move_place_dir` 配置，打开 "Move to..." 时能预填目标目录以提升使用体验。

### Description
- 在后端配置中新增 `MOVE_PLACE_DIR` 字段并在 `Settings` 中增加 `ENV_FILE_PATH` 计算属性以统一获取实际 `.env` 路径（`backend/app/core/config.py`）。
- 扩展 `/api/v1/settings` 的响应与更新接口，返回并持久化 `move_place_dir` 和 `env_file_path`，并改为使用 `settings.ENV_FILE_PATH` 读写 `.env`（`backend/app/api/routes/settings.py`）。
- 前端设置页新增 `Move To 默认目录` 可编辑项与只读显示的 `.env` 路径，并接入保存逻辑（`frontend/src/routes/_layout/settings.tsx`）。
- 阅读页在打开 `Move to...` 时优先从设置接口读取 `move_place_dir` 进行预填，并为 `MoveDialog` 增加 `initialDestDir` 参数支持预填（`frontend/src/routes/_layout/read.tsx`，`frontend/src/components/Files/dialogs/MoveDialog.tsx`）。
- 补充中/英/日/韩多语言文案，并更新 smoke test 校验新增字段（`frontend/src/i18n/locales/*`，`backend/tests/api/routes/test_misc_routes.py`）。

### Testing
- 已运行 `python -m py_compile backend/app/core/config.py backend/app/api/routes/settings.py`，结果：成功。
- 运行 `pytest -q backend/tests/api/routes/test_misc_routes.py::test_settings_read` 时失败，原因：当前运行环境缺少 `fastapi` 依赖（测试未在容器内通过）。
- 运行 `npm --prefix frontend run -s typecheck` 未通过，原因：仓库内未定义该 script（无法完成前端类型检查）。
- 尝试用 Playwright 访问 `http://127.0.0.1:5173/settings` 截图失败，原因：当前未运行前端服务（`ERR_EMPTY_RESPONSE`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996a5ac7a4c8325ad3f09e46118fe5d)