### PR TITLE
feat: 在作者/标签页使用 like score 排序并在缩略图 tooltip 显示

### DIFF
--- a/packages/backend/src/routes/all-info.js
+++ b/packages/backend/src/routes/all-info.js
@@ -39,13 +39,16 @@ function getSql(tableName){
         tt.subtype,
         MAX(ft.mTime) AS maxTime, 
         COUNT(tt.tag) AS count, 
-        MAX(th.thumbnailFileName) AS thumbnailFileName
+        MAX(th.thumbnailFileName) AS thumbnailFileName,
+        COALESCE(MAX(tg.score), 0) AS likeScore
     FROM 
         ${tableName} tt
     INNER JOIN 
         file_table ft ON tt.filePath = ft.filePath
     LEFT JOIN 
         thumbnail_table th ON ft.filePath = th.filePath AND th.thumbnailFileName IS NOT NULL
+    LEFT JOIN
+        tag_table tg ON tg.tag = tt.tag AND tg.type = tt.type AND tg.subtype = tt.subtype
     GROUP BY 
         tt.tag, tt.type, tt.subtype
     HAVING 

--- a/packages/frontend/src/pages/TagPage/index.js
+++ b/packages/frontend/src/pages/TagPage/index.js
@@ -135,6 +135,8 @@ export default class TagPage extends Component {
     let rows = [];
     // rows.push([tag]);
     const tag = item.tag;
+    const likeScore = this.getScore(item);
+    rows.push(["like score", likeScore]);
     rows.push(["     "]);
     if(this.isAuthorMode()){
       rows.push(...clientUtil.convertSimpleObj2tooltipRow(this.getAuthorCount(tag)));
@@ -236,8 +238,8 @@ export default class TagPage extends Component {
     }else  if (sortOrder == BY_GOOD_SCORE){
       // 再按喜好排序
       items.sort((a, b)=> {
-          const s1 = this.getScore(a.tag);
-          const s2 = this.getScore(b.tag);
+          const s1 = this.getScore(a);
+          const s2 = this.getScore(b);
           if(s1 === s2){
               return a.count - b.count;
           }else{
@@ -266,7 +268,15 @@ export default class TagPage extends Component {
     return items;
   }
 
-  getScore(tag) {
+  getScore(itemOrTag) {
+    if (_.isObject(itemOrTag) && itemOrTag.likeScore !== undefined) {
+      const rowScore = Number(itemOrTag.likeScore);
+      if (!Number.isNaN(rowScore)) {
+        return rowScore;
+      }
+    }
+
+    const tag = _.isObject(itemOrTag) ? itemOrTag.tag : itemOrTag;
     if(this.isAuthorMode()){
       return this.getAuthorCount(tag).score || 0;
     }else{


### PR DESCRIPTION
### Motivation
- 复用已有 recommendation 的评分数据，为每个 author/tag 条目提供一个可排序的 `like score` 并在界面上展示，提升按喜好排序与信息可见性。

### Description
- 后端：在 author/tag 聚合 SQL 中关联 `tag_table` 并返回 `likeScore` 字段（`COALESCE(MAX(tg.score), 0)`），将评分随 `author_rows` / `tag_rows` 一并下发（修改文件：`packages/backend/src/routes/all-info.js`）。
- 前端：把 `TagPage` 中的 `getScore` 扩展为支持传入整行数据（优先使用后端下发的 `likeScore`），并在按 `BY_GOOD_SCORE` 排序时使用该值进行比较（修改文件：`packages/frontend/src/pages/TagPage/index.js`）。
- 前端：在缩略图 `title` tooltip 中加入 `like score` 一项，使用与 Explorer 相同的 tooltip 方式展示，方便快速查看（修改文件：`packages/frontend/src/pages/TagPage/index.js`）。

### Testing
- 在前端包目录运行 `npm test`（`packages/frontend`），所有前端测试通过：`56 passing`。
- 在后端包目录运行 `npm test`（`packages/backend`），存在与本次改动无直接关联的基线失败（`Path Util Test` 有若干失败），因此后端测试在当前环境未完全通过。 
- 尝试运行前端 `npm start` 时受限于系统 watcher 配额导致 `ENOSPC` 错误，启动未能完成（与代码改动无关）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699715ac5acc832587ab6d35328b94f0)