### PR TITLE
修复: 将 Move to favorite 默认子文件夹改为当月 1 号

### DIFF
--- a/frontend/src/components/Files/dialogs/ConfirmMoveDialog.tsx
+++ b/frontend/src/components/Files/dialogs/ConfirmMoveDialog.tsx
@@ -14,12 +14,12 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { getBaseName } from "@/lib/path-utils"
 
-/** 生成默认子文件夹名：good_YYYY_MM_DD */
+/** 生成默认子文件夹名：good_YYYY_MM_01（固定当月1号） */
 function defaultSubfolder(): string {
   const now = new Date()
   const y = now.getFullYear()
   const m = String(now.getMonth() + 1).padStart(2, "0")
-  const d = String(now.getDate()).padStart(2, "0")
+  const d = "01"
   return `good_${y}_${m}_${d}`
 }
 


### PR DESCRIPTION
### Motivation
- 将 `Move to favorite` 的默认子文件夹从“当天日期”改为“当月 1 号”，以便同月内的收藏统一落入 `good_YYYY_MM_01`（例如 `good_2026_02_01`）。

### Description
- 在 `frontend/src/components/Files/dialogs/ConfirmMoveDialog.tsx` 中修改 `defaultSubfolder()`，将日固定为 `"01"`，使其返回 `good_${y}_${m}_01`。

### Testing
- 尝试运行 `pnpm -s eslint`、`pnpm -s tsc --noEmit` 以及通过 Playwright 截图本地页面，但均因前端依赖/配置缺失或本地 dev server 未启动而无法完成（均为失败）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998510fc100832598c7cde79b763cf4)