### PR TITLE
启动时清理解压缓存、缩短解压缓存哈希、Reader 跳转 Explorer 默认 table+按名排序

### DIFF
--- a/backendnode/src/server.ts
+++ b/backendnode/src/server.ts
@@ -12,11 +12,23 @@ async function main() {
   const dbPath = path.resolve(__dirname, "../../", config.INDEX_SQLITE_PATH);
   initDb(dbPath);
 
+  // 启动前清理解压缓存，避免复用旧缓存导致 reader / explorer 状态不一致
+  try {
+    const { clearExtractCache } = await import("./services/archiveService.js");
+    const cacheResult = clearExtractCache();
+    console.log(`[startup] extract cache cleared: files=${cacheResult.deleted_files}, freed=${cacheResult.freed_size_readable}`);
+  } catch (error) {
+    console.log(`[startup] clear extract cache failed: ${error}`);
+  }
+
   // 写入 startup 日志，用于 listActivityLogsSinceLatestStartup 过滤本次启动后的活动
   try {
     const repo = new IndexRepository(getDb());
     repo.logActivity("startup", "Server started", "started", "startup");
-  } catch { /* ignore */ }
+    console.log("[startup] activity log inserted");
+  } catch (error) {
+    console.log(`[startup] failed to write activity log: ${error}`);
+  }
 
   const app = buildApp();
 

--- a/backendnode/src/services/archiveService.ts
+++ b/backendnode/src/services/archiveService.ts
@@ -69,7 +69,8 @@ function getEntryType(entryPath: string): EntryType {
 export function getExtractCacheDir(archivePath: string): string {
   const hash = crypto.createHash("sha256").update(archivePath).digest("hex");
   const base = path.resolve(config.EXTRACT_CACHE_DIR);
-  return path.join(base, hash.slice(0, 2), hash.slice(2));
+  const shortHash = hash.slice(0, 10);
+  return path.join(base, shortHash.slice(0, 2), shortHash.slice(2));
 }
 
 // ── list entries ─────────────────────────────────────────────────────────────

--- a/frontend/src/components/Files/FileViewContainer.tsx
+++ b/frontend/src/components/Files/FileViewContainer.tsx
@@ -43,7 +43,7 @@ import { FileGridView } from "./FileGridView"
 import { FileIcon } from "./FileIcon"
 import { FileTableView, type SortField, type SortOrder } from "./FileTableView"
 
-type ViewMode = "grid" | "table" | "mixed"
+export type ViewMode = "grid" | "table" | "mixed"
 
 type PaginationState = {
   page: number

--- a/frontend/src/routes/_layout/explorer.tsx
+++ b/frontend/src/routes/_layout/explorer.tsx
@@ -11,7 +11,7 @@ import { toastError, toastSuccess } from "@/lib/toast"
 
 import { FilesystemService } from "@/client"
 import { FileNotFoundError } from "@/components/Common/FileNotFoundError"
-import { FileViewContainer } from "@/components/Files/FileViewContainer"
+import { FileViewContainer, type ViewMode } from "@/components/Files/FileViewContainer"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -51,10 +51,12 @@ export const Route = createFileRoute("/_layout/explorer")({
       "last_read_at",
     ]
     const sortOrderCandidates: SortOrder[] = ["asc", "desc"]
+    const viewModeCandidates: ViewMode[] = ["grid", "table", "mixed"]
     const rawSortField = String(search.sortField || "")
     const rawSortOrder = String(search.sortOrder || "")
+    const rawViewMode = String(search.viewMode || "")
 
-    return {
+    const validated = {
       path: (search.path as string) || "",
       page,
       pageSize,
@@ -65,6 +67,11 @@ export const Route = createFileRoute("/_layout/explorer")({
         ? (rawSortOrder as SortOrder)
         : "desc",
     }
+
+    if (viewModeCandidates.includes(rawViewMode as ViewMode)) {
+      return { ...validated, viewMode: rawViewMode as ViewMode }
+    }
+    return validated
   },
   head: () => ({
     meta: [
@@ -98,7 +105,9 @@ function FilterCheckbox({ id, label, checked, onChange }: FilterCheckboxProps) {
 function Explorer() {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { path, page, pageSize, sortField, sortOrder } = Route.useSearch()
+  const search = Route.useSearch()
+  const { path, page, pageSize, sortField, sortOrder } = search
+  const viewMode = "viewMode" in search ? search.viewMode : undefined
   const folderName = path
     ? getBaseName(path, t("nav.explorer"))
     : t("nav.explorer")
@@ -137,7 +146,7 @@ function Explorer() {
     (newPath) => {
       navigate({
         to: "/explorer",
-        search: { path: newPath, page: 1, pageSize, sortField, sortOrder },
+        search: { path: newPath, page: 1, pageSize, sortField, sortOrder, viewMode },
         replace: true,
       })
     },
@@ -149,6 +158,7 @@ function Explorer() {
     pageSize,
     sortField,
     sortOrder,
+    viewMode,
   })
 
   const filteredItems = useMemo(() => {
@@ -247,20 +257,20 @@ function Explorer() {
         items={filteredItems}
         isLoading={isLoading}
         currentPath={path}
-        initialViewMode="mixed"
+        initialViewMode={viewMode ?? "mixed"}
         sortField={sortField}
         sortOrder={sortOrder}
         onSortFieldChange={(nextSortField) =>
           navigate({
             to: "/explorer",
-            search: { path, page: 1, pageSize, sortField: nextSortField, sortOrder },
+            search: { path, page: 1, pageSize, sortField: nextSortField, sortOrder, viewMode },
             replace: true,
           })
         }
         onSortOrderChange={(nextSortOrder) =>
           navigate({
             to: "/explorer",
-            search: { path, page: 1, pageSize, sortField, sortOrder: nextSortOrder },
+            search: { path, page: 1, pageSize, sortField, sortOrder: nextSortOrder, viewMode },
             replace: true,
           })
         }
@@ -270,7 +280,7 @@ function Explorer() {
           onChange: ({ page: nextPage, pageSize: nextPageSize }) =>
             navigate({
               to: "/explorer",
-              search: { path, page: nextPage, pageSize: nextPageSize, sortField, sortOrder },
+              search: { path, page: nextPage, pageSize: nextPageSize, sortField, sortOrder, viewMode },
               replace: true,
             }),
         }}

--- a/frontend/src/routes/_layout/read.tsx
+++ b/frontend/src/routes/_layout/read.tsx
@@ -571,7 +571,7 @@ function ReadPage() {
               showFolderIcon={false}
               collapseDirCrumbsAfter={2}
               currentTo="/explorer"
-              currentSearch={{ path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "mtime", sortOrder: "desc" }}
+              currentSearch={{ path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "name", sortOrder: "asc", viewMode: "table" }}
               currentLabel={fileName}
               currentClassName="reader-toolbar__current-link"
             />
@@ -654,8 +654,8 @@ function ReadPage() {
           separatorClassName="size-4 text-muted-foreground"
             currentTo="/explorer"
             currentSearch={isFolderSource
-              ? { path, page: 1, pageSize: 48, sortField: "mtime", sortOrder: "desc" }
-              : { path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "mtime", sortOrder: "desc" }}
+              ? { path, page: 1, pageSize: 48, sortField: "name", sortOrder: "asc", viewMode: "table" }
+              : { path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "name", sortOrder: "asc", viewMode: "table" }}
           currentLabel={fileName}
         />
 
@@ -666,7 +666,7 @@ function ReadPage() {
               <>
                 <Link
                   to="/explorer"
-                  search={{ path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "mtime", sortOrder: "desc" }}
+                  search={{ path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "name", sortOrder: "asc", viewMode: "table" }}
                   className={buttonVariants({
                     variant: "default",
                     size: "sm",
@@ -788,8 +788,8 @@ function ReadPage() {
             collapseDirCrumbsAfter={2}
             currentTo="/explorer"
             currentSearch={isFolderSource
-              ? { path, page: 1, pageSize: 48, sortField: "mtime", sortOrder: "desc" }
-              : { path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "mtime", sortOrder: "desc" }}
+              ? { path, page: 1, pageSize: 48, sortField: "name", sortOrder: "asc", viewMode: "table" }
+              : { path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "name", sortOrder: "asc", viewMode: "table" }}
             currentLabel={fileName}
             currentClassName="reader-toolbar__current-link"
           />
@@ -859,7 +859,7 @@ function ReadPage() {
               <>
                 <Link
                   to="/explorer"
-                  search={{ path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "mtime", sortOrder: "desc" }}
+                  search={{ path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "name", sortOrder: "asc", viewMode: "table" }}
                   className={buttonVariants({
                     variant: "ghost",
                     size: "sm",


### PR DESCRIPTION
### Motivation

- 解决启动时复用旧解压缓存导致 Reader/Explorer 状态不一致的问题，同时在启动流程增加可见日志以便排查启动行为。 
- 后端缓存目录名过长，缩短哈希以便文件系统路径更可读且满足题主要求。 
- 从 Reader 打开 Explorer 时希望默认以表格（table）模式并按文件名排序，且能通过 URL 参数控制该模式。 

### Description

- 在 `backendnode/src/server.ts` 初始化 DB 后调用 `clearExtractCache` 做启动前的解压缓存清理，并打印清理结果与 activity log 写入状态。 
- 将 `backendnode/src/services/archiveService.ts` 中 `getExtractCacheDir` 改为仅使用 `sha256` 前 10 位（保留二级目录切分 2+8）。 
- 前端导出 `FileViewContainer` 的 `ViewMode` 类型并在 `frontend/src/routes/_layout/explorer.tsx` 中增加对可选 `viewMode` 查询参数的解析、验证与透传，且在分页/排序/面包屑跳转时保留该参数。 
- 将 `frontend/src/routes/_layout/read.tsx` 中多个从 Reader 跳转到 Explorer 的入口统一改为 `viewMode=table, sortField=name, sortOrder=asc`，并在无图/音频模式等处同步使用该默认参数。 

### Testing

- 运行 `npm run -C backendnode build`（`tsc`）时被仓库已有的类型测试错误阻断，错误与本次改动无关（若干测试使用了未在类型中声明的字段如 `fingerprint`）。 
- 运行 `npm run -C frontend build` 时 TypeScript 编译通过但 Vite 打包阶段因环境缺失可选原生依赖 `@rollup/rollup-linux-x64-gnu` 而失败，TS 部分的改动已通过本地类型检查。 
- 已将修改提交并生成 PR（包含涉及文件清单）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b27f8cbdc8325afdd47b1e7f9a8ac)