### PR TITLE
修复: 过滤隐藏/伪文件（如 ._2.jpg）在 listdir、archive list 与 thumbnail 流程中

### DIFF
--- a/backendnode/src/routes/fs.ts
+++ b/backendnode/src/routes/fs.ts
@@ -23,6 +23,7 @@ import { parseName } from "../utils/nameParser.js";
 import trash from "trash";
 import { refreshAllRecScores } from "../services/recService.js";
 import { logger } from "../logger.js";
+import { isHiddenFile } from "../utils/fileFilters.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -106,9 +107,10 @@ async function listDirectory(
 
   try {
     const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
+    const visibleEntries = entries.filter(entry => !isHiddenFile(entry.name));
     // Parallel stat for all entries
     const statResults = await Promise.all(
-      entries.map(async (entry) => {
+      visibleEntries.map(async (entry) => {
         const fullPath = path.join(dirPath, entry.name);
         try {
           const entryStat = await fs.promises.stat(fullPath);

--- a/backendnode/src/services/archiveService.ts
+++ b/backendnode/src/services/archiveService.ts
@@ -14,6 +14,7 @@ import { config } from "../config.js";
 import { IMAGE_SUFFIXES, VIDEO_SUFFIXES, AUDIO_SUFFIXES } from "../constants.js";
 import { logger } from "../logger.js";
 import { get7z, getMagick } from "../utils/tools.js";
+import { isHiddenFile } from "../utils/fileFilters.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -28,7 +29,7 @@ const IGNORE_PREFIXES = ["__MACOSX/", ".git/"];
 function shouldIgnore(entryPath: string): boolean {
   const name = path.basename(entryPath);
   if (IGNORE_NAMES.has(name)) return true;
-  if (name.startsWith(".")) return true;
+  if (isHiddenFile(name)) return true;
   for (const prefix of IGNORE_PREFIXES) {
     if (entryPath.startsWith(prefix) || entryPath.includes("/" + prefix)) return true;
   }

--- a/backendnode/src/services/thumbService.ts
+++ b/backendnode/src/services/thumbService.ts
@@ -17,6 +17,7 @@ import { config } from "../config.js";
 import { getFileType } from "../utils/fileType.js";
 import { IMAGE_SUFFIXES } from "../constants.js";
 import { get7z, getMagick, getFfmpeg } from "../utils/tools.js";
+import { isHiddenFile } from "../utils/fileFilters.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -70,7 +71,7 @@ async function generateArchiveThumb(archivePath: string, outputPath: string): Pr
         currentPath = pathMatch[1].trim();
       } else if (line.trim() === "" && currentPath !== null) {
         const ext = path.extname(currentPath).toLowerCase();
-        if (IMAGE_EXTS.has(ext)) {
+        if (IMAGE_EXTS.has(ext) && !isHiddenFile(currentPath)) {
           firstImageEntry = currentPath;
           break;
         }
@@ -80,7 +81,7 @@ async function generateArchiveThumb(archivePath: string, outputPath: string): Pr
     // Handle last entry without trailing blank line
     if (!firstImageEntry && currentPath !== null) {
       const ext = path.extname(currentPath).toLowerCase();
-      if (IMAGE_EXTS.has(ext)) firstImageEntry = currentPath;
+      if (IMAGE_EXTS.has(ext) && !isHiddenFile(currentPath)) firstImageEntry = currentPath;
     }
 
     if (!firstImageEntry) throw new Error(`No image found in archive: ${archivePath}`);
@@ -120,7 +121,7 @@ function findFirstImageInDir(dir: string): string | null {
     const sorted = entries.slice().sort((a, b) => a.name.localeCompare(b.name));
     for (const e of sorted) {
       const full = path.join(dir, e.name);
-      if (e.isFile() && IMAGE_EXTS.has(path.extname(e.name).toLowerCase())) return full;
+      if (e.isFile() && IMAGE_EXTS.has(path.extname(e.name).toLowerCase()) && !isHiddenFile(e.name)) return full;
       if (e.isDirectory()) {
         const found = findFirstImageInDir(full);
         if (found) return found;

--- a/backendnode/src/utils/fileFilters.ts
+++ b/backendnode/src/utils/fileFilters.ts
@@ -1,0 +1,8 @@
+import path from "node:path";
+
+/** 是否隐藏文件：basename 以 "." 开头（如 ._2.jpg / .DS_Store） */
+export function isHiddenFile(filePath: string): boolean {
+  const base = path.basename(filePath);
+  return Boolean(base) && base.startsWith(".");
+}
+

--- a/backendnode/tests/routes/fs.test.ts
+++ b/backendnode/tests/routes/fs.test.ts
@@ -69,6 +69,7 @@ const fakeStat = async (p: string): Promise<Partial<fs.Stats>> => {
   if (isTestChild(p, "sub"))         return { isDirectory: () => true,  isFile: () => false, size: 0,    mtimeMs: 1700000000000 };
   if (isTestChild(p, "file.zip"))    return { isDirectory: () => false, isFile: () => true,  size: 1024, mtimeMs: 1700000000000 };
   if (isTestChild(p, "img.jpg"))     return { isDirectory: () => false, isFile: () => true,  size: 512,  mtimeMs: 1700000000000 };
+  if (isTestChild(p, "._2.jpg"))     return { isDirectory: () => false, isFile: () => true,  size: 12,   mtimeMs: 1700000000000 };
   throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
 };
 
@@ -78,13 +79,14 @@ const fakeReaddir = async (p: string): Promise<unknown[]> => {
       { name: "sub",      isDirectory: () => true,  isFile: () => false, isSymbolicLink: () => false },
       { name: "file.zip", isDirectory: () => false, isFile: () => true,  isSymbolicLink: () => false },
       { name: "img.jpg",  isDirectory: () => false, isFile: () => true,  isSymbolicLink: () => false },
+      { name: "._2.jpg", isDirectory: () => false, isFile: () => true,  isSymbolicLink: () => false },
     ];
   }
   return [];
 };
 
 const fakeAccess = async (p: string): Promise<void> => {
-  if (isTestDir(p) || isTestChild(p, "sub") || isTestChild(p, "file.zip") || isTestChild(p, "img.jpg")) return;
+  if (isTestDir(p) || isTestChild(p, "sub") || isTestChild(p, "file.zip") || isTestChild(p, "img.jpg") || isTestChild(p, "._2.jpg")) return;
   throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
 };
 
@@ -147,6 +149,8 @@ describe("GET /api/v1/fs/listdir", () => {
     const names = body.items.map((i: { name: string }) => i.name);
     // folder "sub" should come before files
     expect(names.indexOf("sub")).toBeLessThan(names.indexOf("file.zip"));
+    // hidden file should be filtered
+    expect(names).not.toContain("._2.jpg");
   });
 
   it("assigns correct item_type and file_type", async () => {

--- a/backendnode/tests/services/archiveService.test.ts
+++ b/backendnode/tests/services/archiveService.test.ts
@@ -109,6 +109,7 @@ describe("listEntries", () => {
         ".DS_Store",
         "page001.jpg",
         ".hidden.jpg",
+        "._2.jpg",
       ]),
       stderr: "",
     });


### PR DESCRIPTION
### Motivation
- 避免生成缩略图或列出目录时把 macOS 等平台产生的伪隐藏文件（如 `._2.jpg`、`.DS_Store`）当作真实媒体文件处理。

### Description
- 新增 `isHiddenFile` 工具函数用于统一判断 basename 以 `.` 开头的隐藏/伪文件（`backendnode/src/utils/fileFilters.ts`）。
- 在 `GET /api/v1/fs/listdir` 中对 `readdir` 的结果先行过滤隐藏项，避免隐藏文件出现在接口返回（`backendnode/src/routes/fs.ts`）。
- 在归档条目解析/过滤逻辑中复用 `isHiddenFile`（`shouldIgnore`），确保 `listEntries` 不包含 `._*` 等伪条目（`backendnode/src/services/archiveService.ts`）。
- 缩略图生成流程中（归档首图选择与提取后递归查找）跳过隐藏图片，避免使用 `._*` 文件生成 thumbnail（`backendnode/src/services/thumbService.ts`）。
- 对应单元测试添加/更新了场景以覆盖 `._2.jpg` 的过滤：`backendnode/tests/routes/fs.test.ts` 与 `backendnode/tests/services/archiveService.test.ts`。

### Testing
- 运行了针对改动相关文件的测试：`npm test -- tests/services/archiveService.test.ts tests/routes/fs.test.ts`，测试执行结果为部分失败，其中 `tests/services/archiveService.test.ts` 出现若干断言失败并且 `tests/routes/fs.test.ts` 在当前测试配置下因 `settings` 路由的依赖导致一个 TypeError，测试总结为 15 个测试中 9 个通过、6 个失败。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699befa306848325beef1c38a2c8a21e)