### PR TITLE
fix(ci): 修复 backend action 失败的两个回归点

### DIFF
--- a/backendnode/src/routes/settings.ts
+++ b/backendnode/src/routes/settings.ts
@@ -9,7 +9,7 @@ import { IndexRepository } from "../db/repository.js";
 const __filename = fileURLToPath(import.meta.url);
 const __routeDir = path.dirname(__filename);
 const ENV_FILE = path.resolve(__routeDir, "../../../.env");
-const DB_FILE = path.resolve(__routeDir, "../../../", config.INDEX_SQLITE_PATH);
+const DB_FILE = path.resolve(__routeDir, "../../../", config.INDEX_SQLITE_PATH || "../data/index_node.db");
 
 function buildResponse() {
   return {

--- a/backendnode/src/services/archiveService.ts
+++ b/backendnode/src/services/archiveService.ts
@@ -97,6 +97,10 @@ export async function listEntries(archivePath: string): Promise<ArchiveEntry[]> 
     const sizeMatch = line.match(/^Size = (\d+)$/);
 
     if (pathMatch) {
+      // 若上一条 entry 尚未遇到空行，先提交，兼容精简/模拟输出（仅 Path 行）
+      if (currentPath !== null) {
+        rawEntries.push({ entryPath: currentPath, size: currentSize });
+      }
       // 新 entry 开始（Path 行总是在 Size 行之前）
       currentPath = pathMatch[1].trim();
       currentSize = 0;


### PR DESCRIPTION
### Motivation
- 修复后端测试中两个导致 CI（Test Backend / vitest）失败的回归点，保证在模拟/精简环境下单元测试通过。 
- 避免在某些测试 mock 环境下因为 `config.INDEX_SQLITE_PATH` 为 `undefined` 导致的路径解析异常，阻止路由相关测试启动。 

### Description
- 在 `src/services/archiveService.ts` 中的 `listEntries` 解析逻辑里，遇到新的 `Path = ...` 行时若上一条 entry 尚未提交则先提交上一条，兼容仅包含 `Path` 行的精简/模拟 7z 输出。 
- 在 `src/routes/settings.ts` 中为 `DB_FILE` 的计算增加兜底值，改为 `path.resolve(__routeDir, "../../../", config.INDEX_SQLITE_PATH || "../data/index_node.db")`，以避免 `config.INDEX_SQLITE_PATH` 为 `undefined` 时抛错。 
- 修改文件：`backendnode/src/services/archiveService.ts`、`backendnode/src/routes/settings.ts`。 

### Testing
- 在修改前，运行 `npx vitest --run` 会导致 `tests/services/archiveService.test.ts` 等用例失败（解析只保留最后一条 entry）。 
- 在修改后，运行 `cd backendnode && npx vitest --run tests/services/archiveService.test.ts tests/routes/search.test.ts tests/routes/parse.test.ts tests/routes/history.test.ts`，上述测试集合全部通过。 
- 全量 `cd backendnode && npx vitest --run` 在当前本地 Node 20 环境仍有 5 个 suite 因 `node:sqlite` 内建模块缺失失败，这与本次修改无关且 CI 配置使用 Node 22。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1abf8ddc8325a008b5179ee8fce0)