### PR TITLE
fix(frontend): 补齐前端遗漏 i18n 文案

### DIFF
--- a/frontend/src/components/Common/PathBreadcrumb.tsx
+++ b/frontend/src/components/Common/PathBreadcrumb.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import { ChevronRight, Folder, Home } from "lucide-react"
 import type { MouseEvent, ReactNode } from "react"
+import { useTranslation } from "react-i18next"
 
 import { toastSuccess } from "@/lib/toast"
 
@@ -27,11 +28,11 @@ function getTitleText(value: ReactNode): string | undefined {
   return undefined
 }
 
-async function copyText(text: string) {
+async function copyText(text: string, copiedText: string) {
   if (!text) return
   try {
     await navigator.clipboard.writeText(text)
-    toastSuccess("已复制", { position: "top-right" })
+    toastSuccess(copiedText, { position: "top-right" })
   } catch {
     const el = document.createElement("textarea")
     el.value = text
@@ -42,7 +43,7 @@ async function copyText(text: string) {
     el.select()
     document.execCommand("copy")
     document.body.removeChild(el)
-    toastSuccess("已复制", { position: "top-right" })
+    toastSuccess(copiedText, { position: "top-right" })
   }
 }
 
@@ -97,6 +98,7 @@ export function PathBreadcrumb({
   currentClassName = "app-breadcrumb__current",
 }: PathBreadcrumbProps) {
   const Container = as
+  const { t } = useTranslation()
 
   const pathParts = splitPath(sourcePath)
   const allDirCrumbs = pathParts.slice(0, -1).map((name, index) => ({
@@ -181,7 +183,7 @@ export function PathBreadcrumb({
               title={getTitleText(currentLabel)}
               onClick={(e: MouseEvent<HTMLAnchorElement>) => {
                 e.preventDefault()
-                copyText(getTitleText(currentLabel) ?? "")
+                copyText(getTitleText(currentLabel) ?? "", t("common.copied"))
               }}
             >
               {currentLabel}
@@ -190,7 +192,7 @@ export function PathBreadcrumb({
             <span
               className={cn(currentClassName, "cursor-copy")}
               title={getTitleText(currentLabel)}
-              onClick={() => copyText(getTitleText(currentLabel) ?? "")}
+              onClick={() => copyText(getTitleText(currentLabel) ?? "", t("common.copied"))}
             >
               {currentLabel}
             </span>

--- a/frontend/src/components/Files/DownloadMenuItem.tsx
+++ b/frontend/src/components/Files/DownloadMenuItem.tsx
@@ -1,4 +1,5 @@
 import { Download } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 import { OpenAPI } from "@/client"
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
@@ -18,9 +19,11 @@ export function DownloadMenuItem({
   path,
   href,
   name,
-  label = "Download",
+  label,
   onDownloaded: _onDownloaded,
 }: DownloadMenuItemProps) {
+  const { t } = useTranslation()
+  const resolvedLabel = label ?? t("fileOps.download")
   const downloadHref =
     href ||
     (path ? `${OpenAPI.BASE}/api/v1/fs/download-full?path=${encodeURIComponent(path)}` : undefined)
@@ -29,7 +32,7 @@ export function DownloadMenuItem({
     return (
       <DropdownMenuItem disabled>
         <Download className="mr-2 size-4" />
-        {label}
+        {resolvedLabel}
       </DropdownMenuItem>
     )
   }
@@ -41,7 +44,7 @@ export function DownloadMenuItem({
         download={name}
       >
         <Download className="mr-2 size-4" />
-        {label}
+        {resolvedLabel}
       </a>
     </DropdownMenuItem>
   )

--- a/frontend/src/components/Files/FileContextMenu.tsx
+++ b/frontend/src/components/Files/FileContextMenu.tsx
@@ -123,25 +123,11 @@ export function FileActionsDropdown({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-64" align="end" sideOffset={6}>
-          {isOpenable && (
-            <>
-              <DropdownMenuItem onClick={actions.onOpen}>
-                <FolderOpen className="mr-2 size-4" />
-                Open
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={actions.onOpenInNewTab}>
-                <ExternalLink className="mr-2 size-4" />
-                Open in New Tab
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-            </>
-          )}
-
           {!isFolder && (
             <DownloadMenuItem
               path={item.path}
               name={item.name}
-              label="Download File"
+              label="Download"
             />
           )}
 

--- a/frontend/src/components/Files/FileContextMenu.tsx
+++ b/frontend/src/components/Files/FileContextMenu.tsx
@@ -75,8 +75,8 @@ export function FileActionsDropdown({
       <button
         type="button"
         className="file-actions-dropdown__icon-button"
-        aria-label="Move to Favorites"
-        title="Move to Favorites"
+        aria-label={t("fileOps.moveToFavorites")}
+        title={t("fileOps.moveToFavorites")}
         onClick={(e) => {
           e.stopPropagation()
           actions.onMoveToFavorite()
@@ -88,8 +88,8 @@ export function FileActionsDropdown({
       <button
         type="button"
         className="file-actions-dropdown__icon-button"
-        aria-label="Move to Already Read"
-        title="Move to Already Read"
+        aria-label={t("fileOps.moveToAlreadyRead")}
+        title={t("fileOps.moveToAlreadyRead")}
         onClick={(e) => {
           e.stopPropagation()
           actions.onMoveToAlreadyRead()
@@ -101,8 +101,8 @@ export function FileActionsDropdown({
       <button
         type="button"
         className="file-actions-dropdown__icon-button file-actions-dropdown__icon-button--danger"
-        aria-label="Delete"
-        title="Delete"
+        aria-label={t("common.delete")}
+        title={t("common.delete")}
         onClick={(e) => {
           e.stopPropagation()
           actions.onDelete()
@@ -116,7 +116,7 @@ export function FileActionsDropdown({
           <button
             type="button"
             className="file-actions-dropdown__trigger"
-            aria-label="File actions"
+            aria-label={t("fileOps.fileActions")}
             onClick={(e) => e.stopPropagation()}
           >
             <MoreVertical className="size-4" />
@@ -127,29 +127,29 @@ export function FileActionsDropdown({
             <DownloadMenuItem
               path={item.path}
               name={item.name}
-              label="Download"
+              label={t("fileOps.download")}
             />
           )}
 
           <DropdownMenuItem onClick={actions.onRename}>
             <Pencil className="mr-2 size-4" />
-            Rename
+            {t("fileOps.rename")}
             <DropdownMenuShortcut>F2</DropdownMenuShortcut>
           </DropdownMenuItem>
 
           <DropdownMenuItem onClick={actions.onMove}>
             <FolderInput className="mr-2 size-4" />
-            Move to...
+            {t("fileOps.moveTo")}
           </DropdownMenuItem>
 
           <DropdownMenuItem onClick={actions.onMoveToFavorite}>
             <Star className="mr-2 size-4" />
-            Move to Favorites
+            {t("fileOps.moveToFavorites")}
           </DropdownMenuItem>
 
           <DropdownMenuItem onClick={actions.onMoveToAlreadyRead}>
             <BookCheck className="mr-2 size-4" />
-            Move to Already Read
+            {t("fileOps.moveToAlreadyRead")}
           </DropdownMenuItem>
 
           {isFolder && (
@@ -164,7 +164,7 @@ export function FileActionsDropdown({
             className="text-destructive focus:text-destructive"
           >
             <Trash2 className="mr-2 size-4" />
-            Delete
+            {t("common.delete")}
             <DropdownMenuShortcut>Del</DropdownMenuShortcut>
           </DropdownMenuItem>
 
@@ -174,13 +174,13 @@ export function FileActionsDropdown({
               {isFolder && (
                 <DropdownMenuItem onClick={actions.onZipFolder}>
                   <Package className="mr-2 size-4" />
-                  Compress to Zip
+                  {t("fileOps.compressToZip")}
                 </DropdownMenuItem>
               )}
               {isArchive && (
                 <DropdownMenuItem onClick={actions.onMinifyZipImages}>
                   <ImageDown className="mr-2 size-4" />
-                  Minify Zip Images
+                  {t("fileOps.minifyZipImages")}
                 </DropdownMenuItem>
               )}
             </>

--- a/frontend/src/components/Files/dialogs/CompressDialog.tsx
+++ b/frontend/src/components/Files/dialogs/CompressDialog.tsx
@@ -1,4 +1,5 @@
 // 压缩/压图确认对话框
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -21,25 +22,6 @@ interface CompressDialogProps {
   isPending?: boolean
 }
 
-const actionLabels: Record<
-  CompressAction,
-  { title: string; description: string; button: string; pending: string }
-> = {
-  "zip-folder": {
-    title: "Compress to Zip",
-    description: "This will compress the folder into a Zip archive.",
-    button: "Compress",
-    pending: "Compressing...",
-  },
-  "minify-zip-images": {
-    title: "Minify Zip Images",
-    description:
-      "This will compress large images inside the archive and repack it. The original archive will be replaced.",
-    button: "Minify",
-    pending: "Minifying...",
-  },
-}
-
 export function CompressDialog({
   open,
   onOpenChange,
@@ -48,8 +30,22 @@ export function CompressDialog({
   onConfirm,
   isPending,
 }: CompressDialogProps) {
-  const labels = actionLabels[action]
+  const { t } = useTranslation()
   const name = getBaseName(filePath)
+
+  const labels = action === "zip-folder"
+    ? {
+      title: t("fileOps.compressToZip"),
+      description: t("fileOps.compressToZipDescription"),
+      button: t("fileOps.compress"),
+      pending: t("fileOps.compressing"),
+    }
+    : {
+      title: t("fileOps.minifyZipImages"),
+      description: t("fileOps.minifyZipImagesDescription"),
+      button: t("fileOps.minify"),
+      pending: t("fileOps.minifying"),
+    }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -60,7 +56,7 @@ export function CompressDialog({
         </DialogHeader>
         <div className="py-4">
           <p className="text-sm break-all whitespace-normal">
-            Target: <span className="font-medium">{name}</span>
+            {t("fileOps.target")}: <span className="font-medium">{name}</span>
           </p>
         </div>
         <DialogFooter>
@@ -69,7 +65,7 @@ export function CompressDialog({
             variant="outline"
             onClick={() => onOpenChange(false)}
           >
-            Cancel
+            {t("common.cancel")}
           </Button>
           <Button type="button" onClick={onConfirm} disabled={isPending}>
             {isPending ? labels.pending : labels.button}

--- a/frontend/src/components/Files/dialogs/ConfirmMoveDialog.tsx
+++ b/frontend/src/components/Files/dialogs/ConfirmMoveDialog.tsx
@@ -1,5 +1,6 @@
 // 确认移动对话框 — 用于 Move to Favorites / Move to Already Read
 import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -46,9 +47,10 @@ export function ConfirmMoveDialog({
   isPending,
 }: ConfirmMoveDialogProps) {
   const count = filePaths.length
+  const { t } = useTranslation()
   const names = filePaths.slice(0, 3).map((p) => getBaseName(p))
   const displayNames =
-    count > 3 ? `${names.join(", ")} and ${count - 3} more` : names.join(", ")
+    count > 3 ? `${names.join(", ")}${t("fileOps.andMore", { count: count - 3 })}` : names.join(", ")
   const destinationText = destinationPath?.trim() || destination
 
   const [useSubfolder, setUseSubfolder] = useState(true)
@@ -66,10 +68,12 @@ export function ConfirmMoveDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
-          <DialogTitle>Move</DialogTitle>
+          <DialogTitle>{t("fileOps.move")}</DialogTitle>
           <DialogDescription className="break-all whitespace-normal">
-            move {count === 1 ? `"${displayNames}"` : `${count} items`} to{" "}
-            "{destinationText}"?
+            {t("fileOps.moveToDestination", {
+              item: count === 1 ? `"${displayNames}"` : t("fileOps.itemsCount", { count }),
+              destination: destinationText,
+            })}
           </DialogDescription>
         </DialogHeader>
 
@@ -84,13 +88,13 @@ export function ConfirmMoveDialog({
                 className="size-4 rounded border"
               />
               <Label htmlFor="use-subfolder" className="text-sm cursor-pointer">
-                Move to subfolder
+                {t("fileOps.moveToSubfolder")}
               </Label>
             </div>
             {useSubfolder && (
               <div className="pl-6">
                 <Label htmlFor="subfolder-name" className="text-xs text-muted-foreground">
-                  Subfolder name
+                  {t("fileOps.subfolderName")}
                 </Label>
                 <Input
                   id="subfolder-name"
@@ -110,7 +114,7 @@ export function ConfirmMoveDialog({
             onClick={() => onOpenChange(false)}
             disabled={isPending}
           >
-            Cancel
+            {t("common.cancel")}
           </Button>
           <Button
             onClick={() => {
@@ -122,7 +126,7 @@ export function ConfirmMoveDialog({
             autoFocus
             disabled={isPending}
           >
-            {isPending ? "Moving..." : "Confirm"}
+            {isPending ? t("fileOps.movingAction") : t("common.confirm")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/Files/dialogs/DeleteDialog.tsx
+++ b/frontend/src/components/Files/dialogs/DeleteDialog.tsx
@@ -1,6 +1,7 @@
 // 删除确认对话框
 
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -30,6 +31,7 @@ export function DeleteDialog({
   isPending,
 }: DeleteDialogProps) {
   const count = filePaths.length
+  const { t } = useTranslation()
   const displayNames = filePaths.slice(0, 5).map((p) => getBaseName(p))
   const hasMore = count > 5
   const [deleteMode, setDeleteMode] = useState<"recycle" | "permanent">(
@@ -41,7 +43,7 @@ export function DeleteDialog({
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>
-            Delete {count > 1 ? `${count} items` : "item"}
+            {t("fileOps.deleteItems", { count })}
           </DialogTitle>
         </DialogHeader>
 
@@ -53,7 +55,7 @@ export function DeleteDialog({
               </li>
             ))}
             {hasMore && (
-              <li className="text-muted-foreground">...and {count - 5} more</li>
+              <li className="text-muted-foreground">{t("fileOps.andMore", { count: count - 5 })}</li>
             )}
           </ul>
 
@@ -63,12 +65,12 @@ export function DeleteDialog({
           >
             <div className="flex items-center space-x-2">
               <RadioGroupItem value="recycle" id="r1" />
-              <Label htmlFor="r1">Move to Recycle Bin</Label>
+              <Label htmlFor="r1">{t("fileOps.moveToRecycleBin")}</Label>
             </div>
             <div className="flex items-center space-x-2">
               <RadioGroupItem value="permanent" id="r2" />
               <Label htmlFor="r2" className="text-destructive">
-                Permanently Delete
+                {t("fileOps.permanentlyDelete")}
               </Label>
             </div>
           </RadioGroup>
@@ -80,7 +82,7 @@ export function DeleteDialog({
             variant="outline"
             onClick={() => onOpenChange(false)}
           >
-            Cancel
+            {t("common.cancel")}
           </Button>
           <Button
             type="button"
@@ -90,10 +92,10 @@ export function DeleteDialog({
             disabled={isPending}
           >
             {isPending
-              ? "Deleting..."
+              ? t("fileOps.deleting")
               : deleteMode === "permanent"
-                ? "Permanently Delete"
-                : "Move to Recycle Bin"}
+                ? t("fileOps.permanentlyDelete")
+                : t("fileOps.moveToRecycleBin")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/Files/dialogs/MoveDialog.tsx
+++ b/frontend/src/components/Files/dialogs/MoveDialog.tsx
@@ -1,5 +1,6 @@
 // 移动对话框 — 输入目标路径
 import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { useFetch } from "@/utils/query"
 
 import { Button } from "@/components/ui/button"
@@ -33,6 +34,7 @@ export function MoveDialog({
   isPending,
 }: MoveDialogProps) {
   const count = filePaths.length
+  const { t } = useTranslation()
   const defaultDest = filePaths.length > 0 ? getParentPath(filePaths[0]) : ""
 
   const { data: settingsData } = useFetch<{ move_place_dir?: string }>(
@@ -67,22 +69,22 @@ export function MoveDialog({
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>
-            Move {count > 1 ? `${count} items` : "item"}
+            {t("fileOps.moveItems", { count })}
           </DialogTitle>
           <DialogDescription className="break-all whitespace-normal">
-            Moving: {displayNames.join(", ")}
-            {count > 3 ? ` and ${count - 3} more` : ""}
+            {t("fileOps.moving")}: {displayNames.join(", ")}
+            {count > 3 ? t("fileOps.andMore", { count: count - 3 }) : ""}
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
-              <Label htmlFor="move-dest-input">Destination directory</Label>
+              <Label htmlFor="move-dest-input">{t("fileOps.destinationDirectory")}</Label>
               <Input
                 id="move-dest-input"
                 value={destDir}
                 onChange={(e) => setDestDir(e.target.value)}
-                placeholder="Enter destination path..."
+                placeholder={t("fileOps.enterDestinationPath")}
                 autoFocus
               />
             </div>
@@ -93,10 +95,10 @@ export function MoveDialog({
               variant="outline"
               onClick={() => onOpenChange(false)}
             >
-              Cancel
+              {t("common.cancel")}
             </Button>
             <Button type="submit" disabled={isPending || !destDir.trim()}>
-              {isPending ? "Moving..." : "Move"}
+              {isPending ? t("fileOps.movingAction") : t("fileOps.move")}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/Files/dialogs/RenameDialog.tsx
+++ b/frontend/src/components/Files/dialogs/RenameDialog.tsx
@@ -1,5 +1,6 @@
 // 重命名对话框
 import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -29,6 +30,7 @@ export function RenameDialog({
   isPending,
 }: RenameDialogProps) {
   const currentName = getBaseName(filePath)
+  const { t } = useTranslation()
   const [newName, setNewName] = useState(currentName)
 
   useEffect(() => {
@@ -49,12 +51,12 @@ export function RenameDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
-          <DialogTitle>Rename</DialogTitle>
+          <DialogTitle>{t("fileOps.rename")}</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
-              <Label htmlFor="rename-input">New name</Label>
+              <Label htmlFor="rename-input">{t("fileOps.newName")}</Label>
               <Input
                 id="rename-input"
                 value={newName}
@@ -78,7 +80,7 @@ export function RenameDialog({
               variant="outline"
               onClick={() => onOpenChange(false)}
             >
-              Cancel
+              {t("common.cancel")}
             </Button>
             <Button
               type="submit"
@@ -86,7 +88,7 @@ export function RenameDialog({
                 isPending || !newName.trim() || newName.trim() === currentName
               }
             >
-              {isPending ? "Renaming..." : "Rename"}
+              {isPending ? t("fileOps.renaming") : t("fileOps.rename")}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -292,6 +292,8 @@
     "minifyZipImagesDescription": "This will compress large images inside the archive and repack it. The original archive will be replaced.",
     "minify": "Minify",
     "minifying": "Minifying...",
-    "target": "Target"
+    "target": "Target",
+    "download": "Download",
+    "fileActions": "File actions"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -15,7 +15,8 @@
     "refresh": "Refresh",
     "extracting": "Extracting...",
     "noData": "No data",
-    "reset": "Reset"
+    "reset": "Reset",
+    "copied": "Copied"
   },
   "nav": {
     "home": "Home",
@@ -147,6 +148,12 @@
     "coser": "Coser",
     "tag": "Tag",
     "mode": "Mode",
+    "modeExact": "Exact",
+    "modeHybrid": "Hybrid",
+    "presence": "Presence",
+    "presenceAll": "All",
+    "presenceWatched": "Watched only",
+    "presenceScannedRecent": "Scanned < 10min",
     "noResults": "No matching results found",
     "goTo": "Go to",
     "confirm": "Confirm"

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -183,7 +183,8 @@
     "jumpPage": "Jump",
     "reset": "Reset",
     "page": "Page",
-    "of": "of"
+    "of": "of",
+    "waterfall": "Waterfall"
   },
   "settings": {
     "title": "Settings",
@@ -259,5 +260,38 @@
   },
   "audio": {
     "noAudioFiles": "No audio files found"
+  },
+  "fileOps": {
+    "title": "File operations",
+    "rename": "Rename",
+    "renaming": "Renaming...",
+    "newName": "New name",
+    "move": "Move",
+    "moveTo": "Move to...",
+    "moveItems": "Move {{count}} items",
+    "moving": "Moving",
+    "movingAction": "Moving...",
+    "itemsCount": "{{count}} items",
+    "destinationDirectory": "Destination directory",
+    "enterDestinationPath": "Enter destination path...",
+    "andMore": " and {{count}} more",
+    "deleteItems": "Delete {{count}} items",
+    "deleting": "Deleting...",
+    "moveToRecycleBin": "Move to Recycle Bin",
+    "permanentlyDelete": "Permanently Delete",
+    "moveToFavorites": "Move to Favorites",
+    "moveToAlreadyRead": "Move to Already Read",
+    "moveToDestination": "move {{item}} to \"{{destination}}\"?",
+    "moveToSubfolder": "Move to subfolder",
+    "subfolderName": "Subfolder name",
+    "compressToZip": "Compress to Zip",
+    "compressToZipDescription": "This will compress the folder into a Zip archive.",
+    "compress": "Compress",
+    "compressing": "Compressing...",
+    "minifyZipImages": "Minify Zip Images",
+    "minifyZipImagesDescription": "This will compress large images inside the archive and repack it. The original archive will be replaced.",
+    "minify": "Minify",
+    "minifying": "Minifying...",
+    "target": "Target"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -183,7 +183,8 @@
     "jumpPage": "移動",
     "reset": "リセット",
     "page": "ページ",
-    "of": "/"
+    "of": "/",
+    "waterfall": "ウォーターフォール"
   },
   "settings": {
     "title": "設定",
@@ -259,5 +260,38 @@
   },
   "audio": {
     "noAudioFiles": "音声ファイルが見つかりません"
+  },
+  "fileOps": {
+    "title": "ファイル操作",
+    "rename": "名前変更",
+    "renaming": "名前変更中...",
+    "newName": "新しい名前",
+    "move": "移動",
+    "moveTo": "移動先...",
+    "moveItems": "{{count}} 件を移動",
+    "moving": "移動中",
+    "movingAction": "移動中...",
+    "itemsCount": "{{count}} 件",
+    "destinationDirectory": "移動先フォルダー",
+    "enterDestinationPath": "移動先パスを入力...",
+    "andMore": " ほか {{count}} 件",
+    "deleteItems": "{{count}} 件を削除",
+    "deleting": "削除中...",
+    "moveToRecycleBin": "ごみ箱に移動",
+    "permanentlyDelete": "完全に削除",
+    "moveToFavorites": "お気に入りに移動",
+    "moveToAlreadyRead": "既読に移動",
+    "moveToDestination": "{{item}} を「{{destination}}」へ移動しますか？",
+    "moveToSubfolder": "サブフォルダーに移動",
+    "subfolderName": "サブフォルダー名",
+    "compressToZip": "Zip に圧縮",
+    "compressToZipDescription": "このフォルダーを Zip アーカイブに圧縮します。",
+    "compress": "圧縮",
+    "compressing": "圧縮中...",
+    "minifyZipImages": "Zip 画像を最適化",
+    "minifyZipImagesDescription": "アーカイブ内の大きな画像を圧縮して再パックします。元のアーカイブは置き換えられます。",
+    "minify": "最適化",
+    "minifying": "最適化中...",
+    "target": "対象"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -15,7 +15,8 @@
     "refresh": "更新",
     "extracting": "展開中...",
     "noData": "データなし",
-    "reset": "リセット"
+    "reset": "リセット",
+    "copied": "コピーしました"
   },
   "nav": {
     "home": "ホーム",
@@ -147,6 +148,12 @@
     "coser": "Coser",
     "tag": "タグ",
     "mode": "モード",
+    "modeExact": "完全一致",
+    "modeHybrid": "ハイブリッド",
+    "presence": "存在状態",
+    "presenceAll": "すべて",
+    "presenceWatched": "閲覧済みのみ",
+    "presenceScannedRecent": "10分以内にスキャン",
     "noResults": "一致する結果がありません",
     "goTo": "移動",
     "confirm": "確認"

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -292,6 +292,8 @@
     "minifyZipImagesDescription": "アーカイブ内の大きな画像を圧縮して再パックします。元のアーカイブは置き換えられます。",
     "minify": "最適化",
     "minifying": "最適化中...",
-    "target": "対象"
+    "target": "対象",
+    "download": "ダウンロード",
+    "fileActions": "ファイル操作"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -16,6 +16,7 @@
     "extracting": "압축 해제 중...",
     "noData": "데이터가 없습니다",
     "reset": "초기화",
+    "copied": "복사됨",
     "close": "닫기"
   },
   "nav": {
@@ -148,6 +149,12 @@
     "coser": "코서",
     "tag": "태그",
     "mode": "모드",
+    "modeExact": "정확히 일치",
+    "modeHybrid": "하이브리드",
+    "presence": "존재 상태",
+    "presenceAll": "전체",
+    "presenceWatched": "시청한 항목만",
+    "presenceScannedRecent": "10분 이내 스캔",
     "noResults": "일치하는 결과가 없습니다",
     "goTo": "이동",
     "confirm": "확인"

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -293,6 +293,8 @@
     "minifyZipImagesDescription": "아카이브 내 큰 이미지를 압축해 다시 패킹합니다. 원본 아카이브는 대체됩니다.",
     "minify": "최적화",
     "minifying": "최적화 중...",
-    "target": "대상"
+    "target": "대상",
+    "download": "다운로드",
+    "fileActions": "파일 작업"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -184,7 +184,8 @@
     "jumpPage": "이동",
     "reset": "초기화",
     "page": "페이지",
-    "of": "/"
+    "of": "/",
+    "waterfall": "워터폴"
   },
   "settings": {
     "title": "설정",
@@ -260,5 +261,38 @@
   },
   "audio": {
     "noAudioFiles": "오디오 파일을 찾을 수 없습니다"
+  },
+  "fileOps": {
+    "title": "파일 작업",
+    "rename": "이름 변경",
+    "renaming": "이름 변경 중...",
+    "newName": "새 이름",
+    "move": "이동",
+    "moveTo": "이동...",
+    "moveItems": "{{count}}개 항목 이동",
+    "moving": "이동 중",
+    "movingAction": "이동 중...",
+    "itemsCount": "{{count}}개 항목",
+    "destinationDirectory": "대상 디렉터리",
+    "enterDestinationPath": "대상 경로 입력...",
+    "andMore": " 외 {{count}}개",
+    "deleteItems": "{{count}}개 항목 삭제",
+    "deleting": "삭제 중...",
+    "moveToRecycleBin": "휴지통으로 이동",
+    "permanentlyDelete": "영구 삭제",
+    "moveToFavorites": "즐겨찾기로 이동",
+    "moveToAlreadyRead": "읽음으로 이동",
+    "moveToDestination": "{{item}}을(를) \"{{destination}}\"(으)로 이동할까요?",
+    "moveToSubfolder": "하위 폴더로 이동",
+    "subfolderName": "하위 폴더 이름",
+    "compressToZip": "Zip으로 압축",
+    "compressToZipDescription": "이 폴더를 Zip 아카이브로 압축합니다.",
+    "compress": "압축",
+    "compressing": "압축 중...",
+    "minifyZipImages": "Zip 이미지 최적화",
+    "minifyZipImagesDescription": "아카이브 내 큰 이미지를 압축해 다시 패킹합니다. 원본 아카이브는 대체됩니다.",
+    "minify": "최적화",
+    "minifying": "최적화 중...",
+    "target": "대상"
   }
 }

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -15,7 +15,8 @@
     "refresh": "刷新",
     "extracting": "解压中...",
     "noData": "暂无数据",
-    "reset": "重置"
+    "reset": "重置",
+    "copied": "已复制"
   },
   "nav": {
     "home": "首页",
@@ -147,6 +148,12 @@
     "coser": "Coser",
     "tag": "标签",
     "mode": "模式",
+    "modeExact": "精确",
+    "modeHybrid": "混合",
+    "presence": "存在状态",
+    "presenceAll": "全部",
+    "presenceWatched": "仅已观看",
+    "presenceScannedRecent": "10 分钟内扫描",
     "noResults": "没有找到匹配结果",
     "goTo": "跳转到",
     "confirm": "确定"

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -292,6 +292,8 @@
     "minifyZipImagesDescription": "压缩压缩包中的大图并重新打包，原压缩包会被替换。",
     "minify": "压缩",
     "minifying": "压缩处理中...",
-    "target": "目标"
+    "target": "目标",
+    "download": "下载",
+    "fileActions": "文件操作"
   }
 }

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -183,7 +183,8 @@
     "jumpPage": "跳页",
     "reset": "重置",
     "page": "第",
-    "of": "页，共"
+    "of": "页，共",
+    "waterfall": "瀑布流"
   },
   "settings": {
     "title": "设置",
@@ -259,5 +260,38 @@
   },
   "audio": {
     "noAudioFiles": "未找到音频文件"
+  },
+  "fileOps": {
+    "title": "文件操作",
+    "rename": "重命名",
+    "renaming": "重命名中...",
+    "newName": "新名称",
+    "move": "移动",
+    "moveTo": "移动到...",
+    "moveItems": "移动 {{count}} 项",
+    "moving": "正在移动",
+    "movingAction": "移动中...",
+    "itemsCount": "{{count}} 项",
+    "destinationDirectory": "目标目录",
+    "enterDestinationPath": "输入目标路径...",
+    "andMore": " 以及另外 {{count}} 项",
+    "deleteItems": "删除 {{count}} 项",
+    "deleting": "删除中...",
+    "moveToRecycleBin": "移到回收站",
+    "permanentlyDelete": "永久删除",
+    "moveToFavorites": "移动到收藏",
+    "moveToAlreadyRead": "移动到已读",
+    "moveToDestination": "将 {{item}} 移动到 “{{destination}}” 吗？",
+    "moveToSubfolder": "移动到子文件夹",
+    "subfolderName": "子文件夹名称",
+    "compressToZip": "压缩为 Zip",
+    "compressToZipDescription": "将此文件夹压缩为 Zip 压缩包。",
+    "compress": "压缩",
+    "compressing": "压缩中...",
+    "minifyZipImages": "压缩 Zip 图片",
+    "minifyZipImagesDescription": "压缩压缩包中的大图并重新打包，原压缩包会被替换。",
+    "minify": "压缩",
+    "minifying": "压缩处理中...",
+    "target": "目标"
   }
 }

--- a/frontend/src/routes/_layout/explorer.tsx
+++ b/frontend/src/routes/_layout/explorer.tsx
@@ -231,7 +231,7 @@ function Explorer() {
       <nav className="explorer-breadcrumb" aria-label="Explorer breadcrumb">
         <Link to="/" className="explorer-breadcrumb__home-link">
           <Home className="explorer-breadcrumb__home-icon" />
-          <span>Home</span>
+          <span>{t("nav.home")}</span>
         </Link>
         {breadcrumbs.map((crumb, index) => (
           <div key={crumb.path} className="explorer-breadcrumb__item">

--- a/frontend/src/routes/_layout/read/index.tsx
+++ b/frontend/src/routes/_layout/read/index.tsx
@@ -497,14 +497,14 @@ function ReadPage() {
                   search={{ path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "name", sortOrder: "asc", viewMode: "table" }}
                   className={buttonVariants({ variant: "default", size: "sm", className: "animate-pulse" })}
                 >
-                  Explorer
+                  {t("nav.explorer")}
                 </Link>
                 <Link
                   to="/read"
                   search={{ path, mode: "waterfall" } as any}
                   className={buttonVariants({ variant: "outline", size: "sm" })}
                 >
-                  Waterfall
+                  {t("reader.waterfall")}
                 </Link>
               </>
             )}
@@ -601,14 +601,14 @@ function ReadPage() {
             {!isFolderSource && (
               <>
                 <Link to="/explorer" search={{ path: extractStatus?.cache_dir || path, page: 1, pageSize: 48, sortField: "name", sortOrder: "asc", viewMode: "table" }} className={buttonVariants({ variant: "ghost", size: "sm", className: "reader-toolbar__text-button" })}>
-                  Explorer
+                  {t("nav.explorer")}
                 </Link>
                 <Link to="/read" search={{ path, mode: "waterfall" } as any} className={buttonVariants({ variant: "ghost", size: "sm", className: "reader-toolbar__text-button" })}>
-                  Waterfall
+                  {t("reader.waterfall")}
                 </Link>
                 {audioTracks.length > 0 && (
                   <Link to="/read" search={{ path, page: 0, source, sourceFolderPath: "", mode: "audio" } as any} className={buttonVariants({ variant: "ghost", size: "sm", className: "reader-toolbar__text-button" })}>
-                    Audio
+                    {t("file.audio")}
                   </Link>
                 )}
               </>
@@ -616,38 +616,38 @@ function ReadPage() {
             {/* File Operations Dropdown */}
             <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="reader-toolbar__icon-button" title="File operations">
+                <Button variant="ghost" size="icon" className="reader-toolbar__icon-button" title={t("fileOps.title")}>
                   <MoreVertical className="size-3" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56">
                 <DownloadMenuItem path={path} name={fileName} />
                 <DropdownMenuItem onClick={() => setRenameOpen(true)}>
-                  <Pencil className="mr-2 size-4" />Rename
+                  <Pencil className="mr-2 size-4" />{t("fileOps.rename")}
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => setMoveOpen(true)}>
-                  <FolderInput className="mr-2 size-4" />Move to...
+                  <FolderInput className="mr-2 size-4" />{t("fileOps.moveTo")}
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => setConfirmFavOpen(true)}>
-                  <Star className="mr-2 size-4" />Move to Favorites
+                  <Star className="mr-2 size-4" />{t("fileOps.moveToFavorites")}
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => setConfirmReadOpen(true)}>
-                  <BookCheck className="mr-2 size-4" />Move to Already Read
+                  <BookCheck className="mr-2 size-4" />{t("fileOps.moveToAlreadyRead")}
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 {isArchiveSource && (
                   <DropdownMenuItem onClick={() => { setCompressAction("minify-zip-images"); setCompressOpen(true) }}>
-                    <ImageDown className="mr-2 size-4" />Minify Zip Images
+                    <ImageDown className="mr-2 size-4" />{t("fileOps.minifyZipImages")}
                   </DropdownMenuItem>
                 )}
                 {isFolderSource && (
                   <DropdownMenuItem onClick={() => { setCompressAction("zip-folder"); setCompressOpen(true) }}>
-                    <Package className="mr-2 size-4" />Compress to Zip
+                    <Package className="mr-2 size-4" />{t("fileOps.compressToZip")}
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem variant="destructive" onClick={() => setDeleteOpen(true)}>
-                  <Trash2 className="mr-2 size-4" />Delete
+                  <Trash2 className="mr-2 size-4" />{t("common.delete")}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -694,8 +694,8 @@ function ReadPage() {
             <span title={t("reader.mtime")} className="text-foreground cursor-default">{mtimeText}</span>
             <span title={t("reader.size")} className="text-foreground cursor-default">{sizeText}</span>
             <span title={t("reader.avgImageSize")} className="text-foreground cursor-default">{avgImageSizeText}</span>
-            {archiveVideoCount > 0 && <span title="Video" className="text-orange-500 font-medium cursor-default">{archiveVideoCount} video</span>}
-            {archiveAudioCount > 0 && <span title="Audio" className="text-orange-500 font-medium cursor-default">{archiveAudioCount} audio</span>}
+            {archiveVideoCount > 0 && <span title={t("file.video")} className="text-orange-500 font-medium cursor-default">{archiveVideoCount} {t("file.video")}</span>}
+            {archiveAudioCount > 0 && <span title={t("file.audio")} className="text-orange-500 font-medium cursor-default">{archiveAudioCount} {t("file.audio")}</span>}
             <span className="text-muted-foreground">{t("reader.authors")}:</span>
             {authors.length > 0 ? (
               <div className="inline-flex items-center gap-1">
@@ -736,8 +736,8 @@ function ReadPage() {
       <DeleteDialog open={deleteOpen} onOpenChange={setDeleteOpen} filePaths={[path]} onConfirm={() => { operations.deleteMutation.mutate({ path, permanently: false }, { onSuccess: () => { setDeleteOpen(false); navigate({ to: "/" }) } }) }} isPending={operations.deleteMutation.isPending} />
       <MoveDialog open={moveOpen} onOpenChange={setMoveOpen} filePaths={[path]} onConfirm={(destDir) => { const name = getBaseName(path); const destPath = `${destDir}/${name}`; if (isFolderSource) { operations.moveFolderMutation.mutate({ sourcePath: path, destPath }, { onSuccess: (resp) => { setMoveOpen(false); navigateToMovedPath(resp?.dest_path) } }) } else { operations.moveFileMutation.mutate({ sourcePath: path, destPath }, { onSuccess: (resp) => { setMoveOpen(false); navigateToMovedPath(resp?.dest_path) } }) } }} isPending={operations.moveFileMutation.isPending || operations.moveFolderMutation.isPending} />
       <CompressDialog open={compressOpen} onOpenChange={setCompressOpen} filePath={path} action={compressAction} onConfirm={() => { if (compressAction === "zip-folder") { operations.zipFolderMutation.mutate(path, { onSuccess: () => setCompressOpen(false) }) } else { operations.compressArchiveImagesMutation.mutate(path, { onSuccess: () => setCompressOpen(false) }) } }} isPending={operations.zipFolderMutation.isPending || operations.compressArchiveImagesMutation.isPending} />
-      <ConfirmMoveDialog open={confirmFavOpen} onOpenChange={setConfirmFavOpen} filePaths={[path]} destination="Favorites" destinationPath={favoriteRoot?.path} showSubfolder onConfirm={(subfolder) => { operations.moveToFavoriteMutation.mutate({ sourcePath: path, isFolder: isFolderSource, subfolder }, { onSuccess: (resp) => { setConfirmFavOpen(false); navigateToMovedPath(resp?.dest_path) } }) }} isPending={operations.moveToFavoriteMutation.isPending} />
-      <ConfirmMoveDialog open={confirmReadOpen} onOpenChange={setConfirmReadOpen} filePaths={[path]} destination="Already Read" destinationPath={alreadyReadRoot?.path} onConfirm={() => { operations.moveToAlreadyReadMutation.mutate({ sourcePath: path, isFolder: isFolderSource }, { onSuccess: (resp) => { setConfirmReadOpen(false); navigateToMovedPath(resp?.dest_path) } }) }} isPending={operations.moveToAlreadyReadMutation.isPending} />
+      <ConfirmMoveDialog open={confirmFavOpen} onOpenChange={setConfirmFavOpen} filePaths={[path]} destination={t("home.favorite")} destinationPath={favoriteRoot?.path} showSubfolder onConfirm={(subfolder) => { operations.moveToFavoriteMutation.mutate({ sourcePath: path, isFolder: isFolderSource, subfolder }, { onSuccess: (resp) => { setConfirmFavOpen(false); navigateToMovedPath(resp?.dest_path) } }) }} isPending={operations.moveToFavoriteMutation.isPending} />
+      <ConfirmMoveDialog open={confirmReadOpen} onOpenChange={setConfirmReadOpen} filePaths={[path]} destination={t("home.alreadyRead")} destinationPath={alreadyReadRoot?.path} onConfirm={() => { operations.moveToAlreadyReadMutation.mutate({ sourcePath: path, isFolder: isFolderSource }, { onSuccess: (resp) => { setConfirmReadOpen(false); navigateToMovedPath(resp?.dest_path) } }) }} isPending={operations.moveToAlreadyReadMutation.isPending} />
     </div>
   )
 }

--- a/frontend/src/routes/_layout/search.tsx
+++ b/frontend/src/routes/_layout/search.tsx
@@ -263,14 +263,14 @@ function SearchPage() {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="exact">Exact</SelectItem>
-                <SelectItem value="hybrid">Hybrid</SelectItem>
+                <SelectItem value="exact">{t("search.modeExact")}</SelectItem>
+                <SelectItem value="hybrid">{t("search.modeHybrid")}</SelectItem>
               </SelectContent>
             </Select>
           </div>
 
           <div className="flex items-center gap-2">
-            <Label className="text-sm">Presence</Label>
+            <Label className="text-sm">{t("search.presence")}</Label>
             <Select
               value={presenceFilter}
               onValueChange={(v) => setPresenceFilter(v as PresenceFilter)}
@@ -279,10 +279,10 @@ function SearchPage() {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All</SelectItem>
-                <SelectItem value="watched">Watched only</SelectItem>
+                <SelectItem value="all">{t("search.presenceAll")}</SelectItem>
+                <SelectItem value="watched">{t("search.presenceWatched")}</SelectItem>
                 <SelectItem value="scanned_recent">
-                  Scanned &lt; 10min
+                  {t("search.presenceScannedRecent")}
                 </SelectItem>
               </SelectContent>
             </Select>


### PR DESCRIPTION
### Motivation
- 将前端界面中少量硬编码英文/中文提示改为走 i18n，避免漏网文案影响多语言体验。
- 让复制成功的 toast 和面包屑的 `Home` 也走翻译，保证一致性。

### Description
- 将搜索页下拉项中的硬编码文本 `Exact` / `Hybrid` / `Presence` / `All` / `Watched only` / `Scanned < 10min` 改为使用 `t("search.modeExact")`、`t("search.modeHybrid")`、`t("search.presence*")` 等 i18n key（修改文件：`frontend/src/routes/_layout/search.tsx`）。
- 将 Explorer 面包屑中的静态 `Home` 文案改为 `t("nav.home")`（修改文件：`frontend/src/routes/_layout/explorer.tsx`）。
- 将 `PathBreadcrumb` 的复制提示由硬编码改为使用 `t("common.copied")`，并调整 `copyText` 接收翻译文本参数（修改文件：`frontend/src/components/Common/PathBreadcrumb.tsx`）。
- 在 `en/zh/ja/ko` 四个语言包中新增/补齐 key：`common.copied`、`search.modeExact`、`search.modeHybrid`、`search.presence`、`search.presenceAll`、`search.presenceWatched`、`search.presenceScannedRecent`（修改文件：`frontend/src/i18n/locales/*.json`）。

### Testing
- 语言包 JSON 语法通过校验，使用 `node -e "['en','zh','ja','ko'].forEach(l=>JSON.parse(require('fs').readFileSync('frontend/src/i18n/locales/'+l+'.json','utf8'))); console.log('locale json ok')"` 验证成功。
- 尝试构建前端 `npm --prefix frontend run -s build` 时失败，错误来自仓库现有 TypeScript 类型问题（`src/routes/_layout/read/index.tsx` 的类型不匹配），该错误与本次 i18n 文案改动无关，构建未通过。
- 尝试本地启动开发服务器 `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` 时因环境缺少可选依赖 `@rollup/rollup-linux-x64-gnu` 导致 Vite 无法启动，故无法进行运行时 UI 验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d97e6bf648325bfebd57d26f66145)