### PR TITLE
refactor: 去掉 /api/v1/access/status，改为 401 触发登录页

### DIFF
--- a/backendnode/package-lock.json
+++ b/backendnode/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shigureader-backend-node",
       "version": "0.1.0",
       "dependencies": {
+        "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^10.0.2",
         "@fastify/static": "^8.1.0",
         "@fastify/swagger": "^9.7.0",
@@ -666,6 +667,26 @@
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
         "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/cookie": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.0.2.tgz",
+      "integrity": "sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.0",
+        "fastify-plugin": "^5.0.0"
       }
     },
     "node_modules/@fastify/cors": {

--- a/backendnode/package.json
+++ b/backendnode/package.json
@@ -11,6 +11,7 @@
     "lint": "biome check --no-errors-on-unmatched --files-ignore-unknown=true ./"
   },
   "dependencies": {
+    "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^10.0.2",
     "@fastify/static": "^8.1.0",
     "@fastify/swagger": "^9.7.0",

--- a/backendnode/src/app.ts
+++ b/backendnode/src/app.ts
@@ -1,5 +1,6 @@
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import cookie from "@fastify/cookie";
 import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import staticPlugin from "@fastify/static";
@@ -22,6 +23,16 @@ import { IndexRepository } from "./db/repository.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const ACCESS_COOKIE_NAME = "shigureader_access";
+const ACCESS_COOKIE_MAX_AGE_SECONDS = 5 * 24 * 60 * 60;
+
+function isAccessExemptPath(url: string): boolean {
+  if (url === "/health" || url.startsWith("/docs")) return true;
+  if (url.startsWith(`${config.API_V1_STR}/utils/health-check/`)) return true;
+  if (url === `${config.API_V1_STR}/access/login`) return true;
+  return false;
+}
+
 export function buildApp() {
   const app = Fastify({
     logger: { level: "warn" }, // 只保留 warn/error，屏蔽每次请求的 info 日志
@@ -29,6 +40,7 @@ export function buildApp() {
 
   // ── CORS ──────────────────────────────────────────────────────────────────
   app.register(cors, { origin: true, credentials: true });
+  app.register(cookie);
 
   // ── Swagger (API docs like FastAPI) ────────────────────────────────────────
   app.register(swagger, {
@@ -54,6 +66,35 @@ export function buildApp() {
   app.register(staticPlugin, {
     root: path.resolve(__dirname),   // 占位 root，实际调用时都会传 dirname 覆盖
     serve: false,
+  });
+
+  app.post(`${config.API_V1_STR}/access/login`, { schema: { summary: "访问密码登录", tags: ["系统"] } }, async (req, reply) => {
+    if (!config.ACCESS_PASSWORD) {
+      return { ok: true, disabled: true };
+    }
+
+    const { password } = (req.body ?? {}) as { password?: string };
+    if (!password || password !== config.ACCESS_PASSWORD) {
+      return reply.status(401).send({ error: "Invalid password" });
+    }
+
+    reply.setCookie(ACCESS_COOKIE_NAME, config.ACCESS_PASSWORD, {
+      path: "/",
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: ACCESS_COOKIE_MAX_AGE_SECONDS,
+    });
+    return { ok: true };
+  });
+
+  app.addHook("onRequest", async (req, reply) => {
+    if (!config.ACCESS_PASSWORD) return;
+    if (isAccessExemptPath(req.url)) return;
+
+    const accessCookie = req.cookies[ACCESS_COOKIE_NAME];
+    if (accessCookie === config.ACCESS_PASSWORD) return;
+
+    return reply.status(401).send({ error: "Unauthorized" });
   });
 
   // ── API routes ─────────────────────────────────────────────────────────────

--- a/backendnode/src/config.ts
+++ b/backendnode/src/config.ts
@@ -53,6 +53,9 @@ export const config = {
   THUMB_JPEG_QUALITY: envInt("THUMB_JPEG_QUALITY", 70),
 
   PROJECT_NAME: env("PROJECT_NAME", "ShiguReader"),
+
+  // Simple access check
+  ACCESS_PASSWORD: env("ACCESS_PASSWORD", ""),
 } as const;
 
 export const DB_FILE_PATH = resolveProjectPath(config.INDEX_SQLITE_PATH);

--- a/backendnode/tests/integration/api.integration.test.ts
+++ b/backendnode/tests/integration/api.integration.test.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import { initDb, closeDb } from "../../src/db/client.js";
 import { IndexRepository } from "../../src/db/repository.js";
 import { buildApp } from "../../src/app.js";
+import { config } from "../../src/config.js";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -335,5 +336,42 @@ describe("authors + tags listing — integration", () => {
     const t1 = res.json().items.find((t: { name: string }) => t.name === "tag1");
     expect(t1).toBeDefined();
     expect(t1.file_count).toBe(2);
+  });
+});
+
+
+describe("access password guard — integration", () => {
+  it("returns unauthorized without cookie when ACCESS_PASSWORD is set", async () => {
+    (config as { ACCESS_PASSWORD: string }).ACCESS_PASSWORD = "secret";
+    const app = buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/api/v1/history/list" });
+    expect(res.statusCode).toBe(401);
+
+    (config as { ACCESS_PASSWORD: string }).ACCESS_PASSWORD = "";
+  });
+
+  it("login sets cookie and then can access protected api", async () => {
+    (config as { ACCESS_PASSWORD: string }).ACCESS_PASSWORD = "secret";
+    const app = buildApp();
+
+    const loginRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/access/login",
+      payload: { password: "secret" },
+    });
+    expect(loginRes.statusCode).toBe(200);
+
+    const setCookie = loginRes.cookies.find(c => c.name === "shigureader_access");
+    expect(setCookie).toBeTruthy();
+
+    const protectedRes = await app.inject({
+      method: "GET",
+      url: "/api/v1/history/list",
+      cookies: { shigureader_access: "secret" },
+    });
+    expect(protectedRes.statusCode).toBe(200);
+
+    (config as { ACCESS_PASSWORD: string }).ACCESS_PASSWORD = "";
   });
 });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -51,6 +51,95 @@ const resolveApiBase = () => {
 }
 
 OpenAPI.BASE = resolveApiBase()
+OpenAPI.WITH_CREDENTIALS = true
+
+let loginPageShown = false
+
+function toRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input
+  if (input instanceof URL) return input.toString()
+  return input.url
+}
+
+function mountApp() {
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+      <RouterProvider router={router} />
+      <Toaster richColors closeButton />
+    </ThemeProvider>,
+  )
+}
+
+function showLoginPage() {
+  if (loginPageShown) return
+  loginPageShown = true
+
+  const root = document.getElementById("root")
+  if (!root) return
+
+  root.innerHTML = `
+    <div style="min-height:100vh;display:flex;align-items:center;justify-content:center;background:#111827;color:#f9fafb;font-family:system-ui,sans-serif;">
+      <form id="access-login-form" style="width:320px;display:flex;flex-direction:column;gap:12px;padding:24px;border:1px solid #374151;border-radius:12px;background:#1f2937;">
+        <h2 style="margin:0 0 8px 0;font-size:20px;">访问验证</h2>
+        <input id="access-password-input" type="password" placeholder="请输入访问密码" style="padding:10px 12px;border-radius:8px;border:1px solid #4b5563;background:#111827;color:#f9fafb;" autofocus />
+        <button type="submit" style="padding:10px 12px;border-radius:8px;border:none;background:#2563eb;color:white;cursor:pointer;">登录</button>
+        <div id="access-login-error" style="color:#fca5a5;min-height:20px;font-size:13px;"></div>
+      </form>
+    </div>
+  `
+
+  const form = document.getElementById("access-login-form") as HTMLFormElement | null
+  const input = document.getElementById("access-password-input") as HTMLInputElement | null
+  const error = document.getElementById("access-login-error") as HTMLDivElement | null
+
+  form?.addEventListener("submit", async (event) => {
+    event.preventDefault()
+    const password = input?.value?.trim()
+    if (!password) {
+      if (error) error.textContent = "请输入密码"
+      return
+    }
+
+    const response = await fetch(`${OpenAPI.BASE}/api/v1/access/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+      credentials: "include",
+    })
+
+    if (response.ok) {
+      window.location.reload()
+      return
+    }
+
+    if (error) error.textContent = "密码错误，请重试"
+    if (input) input.value = ""
+  })
+}
+
+const nativeFetch = window.fetch.bind(window)
+window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const response = await nativeFetch(input, {
+    credentials: "include",
+    ...init,
+  })
+
+  const url = toRequestUrl(input)
+  const isLoginApi = url.includes("/api/v1/access/login")
+  if (response.status === 401 && !isLoginApi) {
+    showLoginPage()
+  }
+
+  return response
+}
+
+OpenAPI.interceptors.response.use((response) => {
+  const url = String(response.config?.url ?? "")
+  if (response.status === 401 && !url.includes("/api/v1/access/login")) {
+    showLoginPage()
+  }
+  return response
+})
 
 /**
  * 为什么要自定义 parseSearch？
@@ -77,9 +166,4 @@ declare module "@tanstack/react-router" {
   }
 }
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-      <RouterProvider router={router} />
-      <Toaster richColors closeButton />
-  </ThemeProvider>,
-)
+mountApp()


### PR DESCRIPTION
### Motivation
- 根据反馈移除多余的 `GET /api/v1/access/status`，简化启动探测逻辑。 
- 前端不再在启动时探测状态，而改为任何接口返回 `401` 时直接进入登录流程以减少额外请求。 

### Description
- 后端：删除 `GET /api/v1/access/status`，在白名单中移除了 `access/status` 并保留 `access/login`，新增 `POST /api/v1/access/login` 登录接口与基于 Cookie 的简单认证 (`shigureader_access`)，并通过 `onRequest` 全局钩子在 `ACCESS_PASSWORD` 生效时对请求做 `401` 拦截（文件：`backendnode/src/app.ts`）。
- 后端：把 `ACCESS_PASSWORD` 配置项加入 `backendnode/src/config.ts`。
- 后端：新增依赖 `@fastify/cookie` 并更新 `backendnode/package.json` / `package-lock.json` 以支持 Cookie 操作。 
- 前端：移除启动探测 `access/status` 的逻辑，改为在全局 `fetch` 包装器与 `OpenAPI` 响应拦截器中捕获 `401`（排除 `/api/v1/access/login`）并展示内置登录页；登录页提交到 `POST /api/v1/access/login`，登录成功后 `window.location.reload()`（文件：`frontend/src/main.tsx`）。
- 测试：新增集成测试覆盖访问保护行为（`backendnode/tests/integration/api.integration.test.ts`），包含未带 Cookie 被拒绝与登录后可访问两种场景。 

### Testing
- 已运行 `npm --prefix backendnode run build`，构建通过。 
- 已运行 `npm --prefix frontend run build`，构建失败，原因为分支上已有的前端类型错误（`qs` 类型缺失 与 read 页面类型不匹配），与本次鉴权逻辑变更无直接关系。 
- 新增的后端集成测试已提交，但未在当前环境完整运行（测试在某些环境依赖本地 SQLite 模块/环境限制），因此未在本次流水线中全部通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d986b6c508325bf9791953047deb1)