### PR TITLE
fix: expose avg_image_size in /archive/extract response schema

### DIFF
--- a/backendnode/src/schemas/common.ts
+++ b/backendnode/src/schemas/common.ts
@@ -275,6 +275,7 @@ export const ExtractStatus = Type.Object(
     extracted_count: Type.Integer(),
     total_count: Type.Integer(),
     cache_dir: Type.String(),
+    avg_image_size: Type.Optional(Nullable(Type.Integer())),
     entries: Type.Optional(Nullable(Type.Array(Type.Ref(ArchiveEntry)))),
     mtime: Type.Optional(Nullable(Type.Integer())),
     filesize: Type.Optional(Nullable(Type.Integer())),


### PR DESCRIPTION
### Motivation
- 前端阅读页依赖 `extractStatus.avg_image_size` 显示“平均图片大小”，但后端 `extract` 接口的响应 schema 未声明该字段，Fastify 在序列化时会把未声明字段裁掉，导致前端无法获取到该值。

### Description
- 在 `backendnode/src/schemas/common.ts` 的 `ExtractStatus` schema 中添加 `avg_image_size: Type.Optional(Nullable(Type.Integer()))`，确保 `POST /api/v1/fs/archive/extract` 返回的 JSON 包含该字段并能被 Fastify 正确序列化。

### Testing
- 尝试运行 `npm --prefix backendnode run build` 进行 TypeScript 构建校验，构建在当前环境中因缺少依赖 `@sinclair/typebox` 而失败（为环境依赖问题，与本次 schema 变更无关）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2fad75eb083259009a444c84908cb)