### PR TITLE
fix(backend): 强制输出 image-magick 压缩过程日志

### DIFF
--- a/packages/backend/src/services/image-magick.js
+++ b/packages/backend/src/services/image-magick.js
@@ -30,6 +30,12 @@ img_convert_min_threshold *= 1024 * 1024;
 
 function logFail(filePath, e) {
     logger.error("[imageMagickHelp]", filePath, e);
+    console.error("[imageMagickHelp]", filePath, e);
+}
+
+function forceLog(...args) {
+    logger.info(...args);
+    console.log(...args);
 }
 
 global._has_magick_ = false;
@@ -156,7 +162,7 @@ module.exports.minifyOneFile = async function (filePath) {
         }
 
         //do a brand new extract
-        logger.info("[minifyOneFile] extractAll....");
+        forceLog("[minifyOneFile] extractAll....");
         const { pathes, error } = await extractAll(filePath, extractOutputPath, true);
         if (error) {
             logFail(filePath, "failed to extractAll", error);
@@ -166,8 +172,8 @@ module.exports.minifyOneFile = async function (filePath) {
         await moveSubfolderContentsToParent(extractOutputPath)
 
 
-        logger.info("[minifyOneFile] begin images convertion --------------");
-        logger.info(filePath);
+        forceLog("[minifyOneFile] begin images convertion --------------");
+        forceLog(filePath);
 
         const { saveSpace } = await minifyFolder(extractOutputPath);
 
@@ -208,7 +214,7 @@ module.exports.minifyOneFile = async function (filePath) {
     } finally {
         //maybe let user to delete file manually?
         deleteCache(extractOutputPath);
-        logger.info("----------------------------------------------------------------");
+        forceLog("----------------------------------------------------------------");
     }
 }
 
@@ -248,7 +254,7 @@ const isNewZipSameWithOriginalFiles = module.exports.isNewZipSameWithOriginalFil
 const userful_percent = 20;
 const fileiterator = require('../utils/file-iterator');
 const minifyFolder = module.exports.minifyFolder = async function (filePath) {
-    logger.info("-----begin images convertion --------------");
+    forceLog("-----begin images convertion --------------");
  
     const { pathes, infos } = await fileiterator(filePath, {});
 
@@ -286,13 +292,13 @@ const minifyFolder = module.exports.minifyFolder = async function (filePath) {
                     saveSpace += (oldSize - newStat.size);
                 }
             }
-            logger.info(`${ii + 1}/${total} ${filePath}`);
+            forceLog(`${ii + 1}/${total} ${filePath}`);
         } catch (e) {
             logger.error(e);
         }
     }
 
-    logger.info("size reduce ", filesizeUitl(saveSpace, { base: 2 }));
+    forceLog("size reduce ", filesizeUitl(saveSpace, { base: 2 }));
     return {
         saveSpace
     }


### PR DESCRIPTION
### Motivation
- 当前 `image-magick` 处理流程在某些 logger 配置下输出不可见，需要保证无论 logger 配置如何都能看到关键过程和错误日志。
- 在压缩/转换长过程里，为了排查问题，需要在控制台强制输出进度和错误信息以便定位故障。

### Description
- 在 `packages/backend/src/services/image-magick.js` 中新增 `forceLog(...args)`，同时调用 `logger.info` 和 `console.log` 来强制输出信息到控制台。
- 在 `logFail` 中补充 `console.error`，确保错误不会被日志配置吞掉。
- 将关键日志点从 `logger.info` 替换为 `forceLog`，包含 `minifyOneFile` 的解压开始、转换开始、文件路径、结束分隔线，以及 `minifyFolder` 的开始、逐文件进度和最终节省体积输出。

### Testing
- 在 `packages/backend` 目录运行了 `npm test`；测试命令可以执行。 
- 测试结果显示用例执行完毕但存在仓库内已有的 10 个 `Path Util` 相关失败（与本次改动无直接关联），其余用例通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b61ac5888325be26e41e8dd9d0b1)