### PR TITLE
feat(frontend): 在 Admin setting 增加路径快速打开输入区

### DIFF
--- a/packages/frontend/src/pages/AdminPage/AdminPage.scss
+++ b/packages/frontend/src/pages/AdminPage/AdminPage.scss
@@ -65,6 +65,10 @@
     color: $font_color_white_one;
     margin-bottom: 10px;
 
+    &.link {
+      color: $font_color_white_one;
+    }
+
     &:hover {
       @include hover_effect;
     }

--- a/packages/frontend/src/pages/AdminPage/AdminPage.scss
+++ b/packages/frontend/src/pages/AdminPage/AdminPage.scss
@@ -31,6 +31,10 @@
       margin: 8px auto 10px 10px;
       clear: both;
 
+      .admin-path-output {
+        margin: 6px 2px 8px;
+      }
+
       .admin-intput {
         display: block;
         margin-left: 2px;
@@ -63,6 +67,11 @@
 
     &:hover {
       @include hover_effect;
+    }
+
+    &.disabled {
+      pointer-events: none;
+      opacity: 0.6;
     }
   }
 

--- a/packages/frontend/src/pages/AdminPage/index.js
+++ b/packages/frontend/src/pages/AdminPage/index.js
@@ -172,7 +172,7 @@ export default class AdminPage extends Component {
         }
 
         if (util.isCompress(purePath)) {
-            return clientUtil.getBookOverviewLink(purePath);
+            return clientUtil.getBookReadLink(purePath);
         }
 
         if (util.isVideo(purePath)) {
@@ -194,10 +194,9 @@ export default class AdminPage extends Component {
                     <input
                         className="admin-intput"
                         value={rawPath}
-                        placeholder="输入 zip/video 文件路径或文件夹路径"
+                        placeholder="zip/video/folder path"
                         onChange={this.onQuickOpenPathChange.bind(this)} />
-                    <div className="admin-path-output">{path ? `FilePath: ${path}` : "FilePath: "}</div>
-                    <a className={classNames("submit-button", { disabled: !path })} href={path ? toUrl : undefined}>
+                    <a className={classNames("submit-button link")} href={path ? toUrl : undefined} target='_blank'>
                         Open
                     </a>
                 </div>

--- a/packages/frontend/src/pages/AdminPage/index.js
+++ b/packages/frontend/src/pages/AdminPage/index.js
@@ -11,6 +11,7 @@ const clientUtil = require("@utils/clientUtil");
 const ThumbnailGenerationUtil = require("@utils/ThumbnailGenerationUtil");
 import { GlobalContext } from '@context/GlobalContext';
 // const util = require("@common/util");
+const util = require("@common/util");
 const classNames = require('classnames');
 import {QRCodeSVG} from 'qrcode.react';
 import { toast } from 'react-toastify';
@@ -125,7 +126,7 @@ function LogoutSection(){
 export default class AdminPage extends Component {
     constructor(prop) {
         super(prop);
-        this.state = { prePath: null, dirs: [] };
+        this.state = { prePath: null, dirs: [], quickOpenPath: "" };
     }
 
     componentDidMount() {
@@ -152,6 +153,56 @@ export default class AdminPage extends Component {
         this.setState({
             prePath: _.isString(e) ? e : e.target.value
         })
+    }
+
+    onQuickOpenPathChange(e) {
+        this.setState({
+            quickOpenPath: e.target.value
+        });
+    }
+
+    getQuickOpenLink(path) {
+        if (!path) {
+            return "";
+        }
+
+        const purePath = path.trim();
+        if (!purePath) {
+            return "";
+        }
+
+        if (util.isCompress(purePath)) {
+            return clientUtil.getBookOverviewLink(purePath);
+        }
+
+        if (util.isVideo(purePath)) {
+            return clientUtil.getVideoPlayerLink(purePath);
+        }
+
+        return clientUtil.getExplorerLink(purePath);
+    }
+
+    renderQuickOpenSection() {
+        const rawPath = this.state.quickOpenPath || "";
+        const path = rawPath.trim();
+        const toUrl = this.getQuickOpenLink(path);
+
+        return (
+            <div className="admin-section">
+                <div className="admin-section-title"> Quick Open Path </div>
+                <div className="admin-section-content">
+                    <input
+                        className="admin-intput"
+                        value={rawPath}
+                        placeholder="输入 zip/video 文件路径或文件夹路径"
+                        onChange={this.onQuickOpenPathChange.bind(this)} />
+                    <div className="admin-path-output">{path ? `FilePath: ${path}` : "FilePath: "}</div>
+                    <a className={classNames("submit-button", { disabled: !path })} href={path ? toUrl : undefined}>
+                        Open
+                    </a>
+                </div>
+            </div>
+        );
     }
 
     getPasswordInput() {
@@ -296,6 +347,7 @@ export default class AdminPage extends Component {
             <div className="admin-container container">
                 {this.renderPasswordInput()}
                 {this.rendersRightAsNext()}
+                {this.renderQuickOpenSection()}
 
                 <div className="admin-section">
                     <div className="admin-section-title"> Pregenerate Thumbnail and Update Internal Database</div>


### PR DESCRIPTION
### Motivation
- 在 Admin（设置）页面新增一个便捷入口，允许用户输入任意本地路径并根据类型快速打开对应页面以提升调试与使用效率。

### Description
- 在 `AdminPage` 中新增 `Quick Open Path` section，添加输入框、`FilePath` 输出文本和 `Open` 按钮，样式复用现有的 `admin-section`、`admin-intput`、`submit-button`。修改文件：`packages/frontend/src/pages/AdminPage/index.js` 与 `packages/frontend/src/pages/AdminPage/AdminPage.scss`。
- 增加路径类型分流逻辑，使用 `@common/util` 的判断函数：压缩文件（如 `.zip`）跳转到 `book-overview`（通过 `clientUtil.getBookOverviewLink`），视频文件跳转到 `videoPlayer`（通过 `clientUtil.getVideoPlayerLink`），其他路径（如文件夹）跳转到 `explorer`（通过 `clientUtil.getExplorerLink`）。
- 对输入为空时禁用 `Open` 按钮并新增对应样式 `.submit-button.disabled`，同时显示 `FilePath` 输出，保持与现有 Admin 区块风格一致。

### Testing
- 在 `packages/frontend` 下运行 `npm test -- --watch=false`，命令失败，因为当前环境缺少前端测试依赖（`mocha`），测试无法执行。
- 运行 `npm run start` 以本地启动前端验证 UI，命令失败，因为缺少开发依赖（`webpack-dev-server`），无法在浏览器中验证渲染效果。
- 代码已提交，变更包含在提交中，相关文件为 `packages/frontend/src/pages/AdminPage/index.js` 与 `packages/frontend/src/pages/AdminPage/AdminPage.scss`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa76cc24508325808f3b673c75411e)