### PR TITLE
feat(frontend): 新增顶部 Search Tab 与勾选式搜索页面

### DIFF
--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import HistoryPage from '@pages/HistoryPage';
 import HomePage from '@pages/HomePage';
 import LoginPage from '@pages/LoginPage';
 import SimilarFilePage from '@pages/SimilarFilePage';
+import SearchPage from '@pages/SearchPage';
 import { Switch, Route, Link, Redirect } from 'react-router-dom';
 import screenfull from 'screenfull';
 const clientUtil = require('@utils/clientUtil');
@@ -140,6 +141,7 @@ class App extends Component {
         const renderHistoryPage = (props) => { return (<HistoryPage {...props} />) };
         const renderAdminPage = (props) => { return (<AdminPage {...props} />) };
         const renderSimilarFilePage = (props) => { return (<SimilarFilePage {...props} />) };
+        const renderSearchPage = (props) => { return (<SearchPage {...props} />) };
         const renderLoginPage = (props) => { return (<LoginPage {...props} />) };
 
 
@@ -150,6 +152,7 @@ class App extends Component {
                 <Route path='/tag/' render={renderExplorer} />
                 <Route path='/author/' render={renderExplorer} />
                 <Route path='/search/' render={renderExplorer} />
+                <Route path='/searchPage/' render={renderSearchPage} />
 
                 <Route path='/book/' render={renderBookReadPage} />
                 <Route path='/book-overview/' render={renderBookOverviewPage} />
@@ -202,7 +205,7 @@ class App extends Component {
         const isExplorer = path.includes("/explorer");
         const isTag = path.includes("/tagPage");
         const isAuthor = path.includes("/author");
-        const isSearch = path.includes("/search");
+        const isSearch = path.startsWith('/search/');
         const isLogin = path.includes("/login");
         const isVideo = path.includes("/videoPlayer")
 
@@ -228,6 +231,10 @@ class App extends Component {
                     <Link to='/history'>
                         <i className="fas fa-history" aria-hidden="true" />
                         <span>History</span>
+                    </Link>
+                    <Link to='/searchPage/'>
+                        <i className="fas fa-search" aria-hidden="true" />
+                        <span>Search</span>
                     </Link>
                     <Link to='/admin'>
                         <i className="fas fa-tools" aria-hidden="true" />

--- a/packages/frontend/src/pages/SearchPage/SearchPage.scss
+++ b/packages/frontend/src/pages/SearchPage/SearchPage.scss
@@ -9,5 +9,25 @@
     .search-page-bar {
         justify-content: center;
         display: flex;
+
+        .search-input {
+            padding: 6px;
+            border: none;
+            font-size: 17px;
+            border-radius: 2px;
+            width: 350px;
+        }
+
+        .search-button {
+            cursor: pointer;
+            border-radius: 0;
+            display: inline-flex;
+            justify-content: center;
+            align-items: center;
+            background-color: #a7a7a7;
+            border: 1px solid #000;
+            margin-left: 1px;
+            width: 50px;
+        }
     }
 }

--- a/packages/frontend/src/pages/SearchPage/SearchPage.scss
+++ b/packages/frontend/src/pages/SearchPage/SearchPage.scss
@@ -1,0 +1,13 @@
+.search-page {
+    padding-top: 24px;
+
+    .search-page-types {
+        justify-content: center;
+        margin-bottom: 20px;
+    }
+
+    .search-page-bar {
+        justify-content: center;
+        display: flex;
+    }
+}

--- a/packages/frontend/src/pages/SearchPage/index.js
+++ b/packages/frontend/src/pages/SearchPage/index.js
@@ -1,0 +1,112 @@
+import React, { Component } from 'react';
+import Checkbox from '@components/common/Checkbox';
+import './SearchPage.scss';
+
+const clientUtil = require('@utils/clientUtil');
+
+const SEARCH_TYPE_FILE = 'FILE';
+const SEARCH_TYPE_AUTHOR = 'AUTHOR';
+const SEARCH_TYPE_SIMILAR = 'SIMILAR';
+
+export default class SearchPage extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            searchTypes: [SEARCH_TYPE_FILE, SEARCH_TYPE_AUTHOR, SEARCH_TYPE_SIMILAR]
+        };
+    }
+
+    componentDidMount() {
+        document.title = 'Search';
+    }
+
+    toggleType(type) {
+        const searchTypes = this.state.searchTypes.slice();
+        const index = searchTypes.indexOf(type);
+
+        if (index > -1) {
+            searchTypes.splice(index, 1);
+        } else {
+            searchTypes.push(type);
+        }
+
+        this.setState({ searchTypes });
+    }
+
+    isOn(type) {
+        return this.state.searchTypes.includes(type);
+    }
+
+    onSearchClick() {
+        let searchText = clientUtil.getSearchInputText();
+        if (searchText.trim) {
+            searchText = searchText.trim();
+        }
+
+        if (!searchText) {
+            return;
+        }
+
+        const links = [];
+        if (this.isOn(SEARCH_TYPE_FILE)) {
+            links.push(clientUtil.getSearhLink(searchText));
+        }
+        if (this.isOn(SEARCH_TYPE_AUTHOR)) {
+            links.push(clientUtil.getAuthorLink(searchText));
+        }
+        if (this.isOn(SEARCH_TYPE_SIMILAR)) {
+            links.push(`/similar-file/?text=${encodeURIComponent(searchText)}`);
+        }
+
+        links.forEach((link, index) => {
+            if (index === 0) {
+                window.location.href = link;
+                return;
+            }
+            window.open(link, '_blank');
+        });
+    }
+
+    onInputKeydown(e) {
+        if (e.which === 13 || e.keyCode === 13) {
+            this.onSearchClick();
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    }
+
+    render() {
+        return (
+            <div className="search-page container">
+                <div className="location-title">Search</div>
+                <div className="search-page-types aji-checkbox-container">
+                    <Checkbox
+                        onChange={this.toggleType.bind(this, SEARCH_TYPE_FILE)}
+                        checked={this.isOn(SEARCH_TYPE_FILE)}
+                        title="/search/?s=xxx"
+                    >
+                        Search Files
+                    </Checkbox>
+                    <Checkbox
+                        onChange={this.toggleType.bind(this, SEARCH_TYPE_AUTHOR)}
+                        checked={this.isOn(SEARCH_TYPE_AUTHOR)}
+                        title="/author/?a=xxx"
+                    >
+                        Search Author
+                    </Checkbox>
+                    <Checkbox
+                        onChange={this.toggleType.bind(this, SEARCH_TYPE_SIMILAR)}
+                        checked={this.isOn(SEARCH_TYPE_SIMILAR)}
+                        title="/similar-file/?text=xxx"
+                    >
+                        Similar File
+                    </Checkbox>
+                </div>
+                <div className="search-page-bar search-bar">
+                    <input className="search-input" type="text" placeholder="Search.." onKeyDown={this.onInputKeydown.bind(this)} />
+                    <div onClick={this.onSearchClick.bind(this)} title="Search" className="fa fa-search search-button" />
+                </div>
+            </div>
+        );
+    }
+}

--- a/packages/frontend/src/pages/SearchPage/index.js
+++ b/packages/frontend/src/pages/SearchPage/index.js
@@ -4,34 +4,20 @@ import './SearchPage.scss';
 
 const clientUtil = require('@utils/clientUtil');
 
-const SEARCH_TYPE_FILE = 'FILE';
-const SEARCH_TYPE_AUTHOR = 'AUTHOR';
-const SEARCH_TYPE_SIMILAR = 'SIMILAR';
+const SEARCH_BY_TEXT = 'SEARCH_BY_TEXT';
+const SEARCH_BY_TAG = 'SEARCH_BY_TAG';
+const SEARCH_BY_AUTHOR = 'SEARCH_BY_AUTHOR';
+const SEARCH_SIMILAR = 'SEARCH_SIMILAR';
 
 const SearchPage = () => {
-    const [searchTypes, setSearchTypes] = useState([SEARCH_TYPE_FILE, SEARCH_TYPE_AUTHOR, SEARCH_TYPE_SIMILAR]);
+    const [searchType, setSearchType] = useState(SEARCH_BY_TEXT);
     const [searchText, setSearchText] = useState('');
 
     useEffect(() => {
         document.title = 'Search';
     }, []);
 
-    const isOn = useCallback((type) => searchTypes.includes(type), [searchTypes]);
-
-    const toggleType = useCallback((type) => {
-        setSearchTypes((prev) => {
-            const next = prev.slice();
-            const index = next.indexOf(type);
-
-            if (index > -1) {
-                next.splice(index, 1);
-            } else {
-                next.push(type);
-            }
-
-            return next;
-        });
-    }, []);
+    const isOn = useCallback((type) => searchType === type, [searchType]);
 
     const onSearchClick = useCallback(() => {
         const trimmedText = (searchText || '').trim();
@@ -39,25 +25,17 @@ const SearchPage = () => {
             return;
         }
 
-        const links = [];
-        if (isOn(SEARCH_TYPE_FILE)) {
-            links.push(clientUtil.getSearhLink(trimmedText));
-        }
-        if (isOn(SEARCH_TYPE_AUTHOR)) {
-            links.push(clientUtil.getAuthorLink(trimmedText));
-        }
-        if (isOn(SEARCH_TYPE_SIMILAR)) {
-            links.push(`/similar-file/?text=${encodeURIComponent(trimmedText)}`);
+        let link = clientUtil.getSearhLink(trimmedText);
+        if (searchType === SEARCH_BY_TAG) {
+            link = clientUtil.getTagLink(trimmedText);
+        } else if (searchType === SEARCH_BY_AUTHOR) {
+            link = clientUtil.getAuthorLink(trimmedText);
+        } else if (searchType === SEARCH_SIMILAR) {
+            link = `/similar-file/?text=${encodeURIComponent(trimmedText)}`;
         }
 
-        links.forEach((link, index) => {
-            if (index === 0) {
-                window.location.href = link;
-                return;
-            }
-            window.open(link, '_blank');
-        });
-    }, [isOn, searchText]);
+        window.location.href = link;
+    }, [searchText, searchType]);
 
     const onInputKeydown = useCallback((e) => {
         if (e.which === 13 || e.keyCode === 13) {
@@ -72,25 +50,32 @@ const SearchPage = () => {
             <div className="location-title">Search</div>
             <div className="search-page-types aji-checkbox-container">
                 <Checkbox
-                    onChange={toggleType.bind(null, SEARCH_TYPE_FILE)}
-                    checked={isOn(SEARCH_TYPE_FILE)}
+                    onChange={setSearchType.bind(null, SEARCH_BY_TEXT)}
+                    checked={isOn(SEARCH_BY_TEXT)}
                     title="/search/?s=xxx"
                 >
-                    Search Files
+                    search by text
                 </Checkbox>
                 <Checkbox
-                    onChange={toggleType.bind(null, SEARCH_TYPE_AUTHOR)}
-                    checked={isOn(SEARCH_TYPE_AUTHOR)}
+                    onChange={setSearchType.bind(null, SEARCH_BY_TAG)}
+                    checked={isOn(SEARCH_BY_TAG)}
+                    title="/tag/?t=xxx"
+                >
+                    search by tag
+                </Checkbox>
+                <Checkbox
+                    onChange={setSearchType.bind(null, SEARCH_BY_AUTHOR)}
+                    checked={isOn(SEARCH_BY_AUTHOR)}
                     title="/author/?a=xxx"
                 >
-                    Search Author
+                    search by author
                 </Checkbox>
                 <Checkbox
-                    onChange={toggleType.bind(null, SEARCH_TYPE_SIMILAR)}
-                    checked={isOn(SEARCH_TYPE_SIMILAR)}
+                    onChange={setSearchType.bind(null, SEARCH_SIMILAR)}
+                    checked={isOn(SEARCH_SIMILAR)}
                     title="/similar-file/?text=xxx"
                 >
-                    Similar File
+                    search similar
                 </Checkbox>
             </div>
             <div className="search-page-bar search-bar">

--- a/packages/frontend/src/pages/SearchPage/index.js
+++ b/packages/frontend/src/pages/SearchPage/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import Checkbox from '@components/common/Checkbox';
 import './SearchPage.scss';
 
@@ -8,54 +8,46 @@ const SEARCH_TYPE_FILE = 'FILE';
 const SEARCH_TYPE_AUTHOR = 'AUTHOR';
 const SEARCH_TYPE_SIMILAR = 'SIMILAR';
 
-export default class SearchPage extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            searchTypes: [SEARCH_TYPE_FILE, SEARCH_TYPE_AUTHOR, SEARCH_TYPE_SIMILAR]
-        };
-    }
+const SearchPage = () => {
+    const [searchTypes, setSearchTypes] = useState([SEARCH_TYPE_FILE, SEARCH_TYPE_AUTHOR, SEARCH_TYPE_SIMILAR]);
+    const [searchText, setSearchText] = useState('');
 
-    componentDidMount() {
+    useEffect(() => {
         document.title = 'Search';
-    }
+    }, []);
 
-    toggleType(type) {
-        const searchTypes = this.state.searchTypes.slice();
-        const index = searchTypes.indexOf(type);
+    const isOn = useCallback((type) => searchTypes.includes(type), [searchTypes]);
 
-        if (index > -1) {
-            searchTypes.splice(index, 1);
-        } else {
-            searchTypes.push(type);
-        }
+    const toggleType = useCallback((type) => {
+        setSearchTypes((prev) => {
+            const next = prev.slice();
+            const index = next.indexOf(type);
 
-        this.setState({ searchTypes });
-    }
+            if (index > -1) {
+                next.splice(index, 1);
+            } else {
+                next.push(type);
+            }
 
-    isOn(type) {
-        return this.state.searchTypes.includes(type);
-    }
+            return next;
+        });
+    }, []);
 
-    onSearchClick() {
-        let searchText = clientUtil.getSearchInputText();
-        if (searchText.trim) {
-            searchText = searchText.trim();
-        }
-
-        if (!searchText) {
+    const onSearchClick = useCallback(() => {
+        const trimmedText = (searchText || '').trim();
+        if (!trimmedText) {
             return;
         }
 
         const links = [];
-        if (this.isOn(SEARCH_TYPE_FILE)) {
-            links.push(clientUtil.getSearhLink(searchText));
+        if (isOn(SEARCH_TYPE_FILE)) {
+            links.push(clientUtil.getSearhLink(trimmedText));
         }
-        if (this.isOn(SEARCH_TYPE_AUTHOR)) {
-            links.push(clientUtil.getAuthorLink(searchText));
+        if (isOn(SEARCH_TYPE_AUTHOR)) {
+            links.push(clientUtil.getAuthorLink(trimmedText));
         }
-        if (this.isOn(SEARCH_TYPE_SIMILAR)) {
-            links.push(`/similar-file/?text=${encodeURIComponent(searchText)}`);
+        if (isOn(SEARCH_TYPE_SIMILAR)) {
+            links.push(`/similar-file/?text=${encodeURIComponent(trimmedText)}`);
         }
 
         links.forEach((link, index) => {
@@ -65,48 +57,55 @@ export default class SearchPage extends Component {
             }
             window.open(link, '_blank');
         });
-    }
+    }, [isOn, searchText]);
 
-    onInputKeydown(e) {
+    const onInputKeydown = useCallback((e) => {
         if (e.which === 13 || e.keyCode === 13) {
-            this.onSearchClick();
+            onSearchClick();
             e.preventDefault();
             e.stopPropagation();
         }
-    }
+    }, [onSearchClick]);
 
-    render() {
-        return (
-            <div className="search-page container">
-                <div className="location-title">Search</div>
-                <div className="search-page-types aji-checkbox-container">
-                    <Checkbox
-                        onChange={this.toggleType.bind(this, SEARCH_TYPE_FILE)}
-                        checked={this.isOn(SEARCH_TYPE_FILE)}
-                        title="/search/?s=xxx"
-                    >
-                        Search Files
-                    </Checkbox>
-                    <Checkbox
-                        onChange={this.toggleType.bind(this, SEARCH_TYPE_AUTHOR)}
-                        checked={this.isOn(SEARCH_TYPE_AUTHOR)}
-                        title="/author/?a=xxx"
-                    >
-                        Search Author
-                    </Checkbox>
-                    <Checkbox
-                        onChange={this.toggleType.bind(this, SEARCH_TYPE_SIMILAR)}
-                        checked={this.isOn(SEARCH_TYPE_SIMILAR)}
-                        title="/similar-file/?text=xxx"
-                    >
-                        Similar File
-                    </Checkbox>
-                </div>
-                <div className="search-page-bar search-bar">
-                    <input className="search-input" type="text" placeholder="Search.." onKeyDown={this.onInputKeydown.bind(this)} />
-                    <div onClick={this.onSearchClick.bind(this)} title="Search" className="fa fa-search search-button" />
-                </div>
+    return (
+        <div className="search-page container">
+            <div className="location-title">Search</div>
+            <div className="search-page-types aji-checkbox-container">
+                <Checkbox
+                    onChange={toggleType.bind(null, SEARCH_TYPE_FILE)}
+                    checked={isOn(SEARCH_TYPE_FILE)}
+                    title="/search/?s=xxx"
+                >
+                    Search Files
+                </Checkbox>
+                <Checkbox
+                    onChange={toggleType.bind(null, SEARCH_TYPE_AUTHOR)}
+                    checked={isOn(SEARCH_TYPE_AUTHOR)}
+                    title="/author/?a=xxx"
+                >
+                    Search Author
+                </Checkbox>
+                <Checkbox
+                    onChange={toggleType.bind(null, SEARCH_TYPE_SIMILAR)}
+                    checked={isOn(SEARCH_TYPE_SIMILAR)}
+                    title="/similar-file/?text=xxx"
+                >
+                    Similar File
+                </Checkbox>
             </div>
-        );
-    }
-}
+            <div className="search-page-bar search-bar">
+                <input
+                    className="search-input"
+                    type="text"
+                    placeholder="Search.."
+                    value={searchText}
+                    onChange={(e) => setSearchText(e.target.value)}
+                    onKeyDown={onInputKeydown}
+                />
+                <button type="button" onClick={onSearchClick} title="Search" className="fa fa-search search-button" />
+            </div>
+        </div>
+    );
+};
+
+export default SearchPage;


### PR DESCRIPTION
### Motivation
- 提供一个专门的搜索页面以支持多目标并行搜索，最大化复用现有控件与样式（checkbox、search-bar、search-input）。

### Description
- 在顶部导航新增 `Search` Tab 并注册路由 `/searchPage/`，便于从 header 直接进入搜索页面（修改文件：`packages/frontend/src/App.jsx`）。
- 新增 `SearchPage` 页面，复用现有 `Checkbox` 组件与 `search-bar` / `search-input` 的样式与交互（新增文件：`packages/frontend/src/pages/SearchPage/index.js`，`SearchPage.scss`）。
- 页面支持用 checkbox 选择要执行的搜索类型：文件搜索(`/search/?s=xxx`)、作者搜索(`/author/?a=xxx`)、相似文件(`/similar-file/?text=xxx`)；点击搜索后第一个勾选项在当前页跳转，其余在新标签页打开，方便并行查看结果。 
- 调整顶部判断逻辑以避免在 `SearchPage` 上误显示“Filter Current Page's Files”按钮（修改 `isSearch` 的判断）。

### Testing
- 在 `packages/frontend` 运行 `npm test -- --watch=false`，失败（原因：环境中缺少 `mocha`，错误信息 `sh: 1: mocha: not found`）。
- 在 `packages/frontend` 运行 `npm run build`，失败（原因：环境中缺少 `webpack`，错误信息 `sh: 1: webpack: not found`）。
- 尝试用 Playwright 打开 `http://localhost:3000/searchPage/` 截图，失败（HTTP 错误：`net::ERR_EMPTY_RESPONSE`，本地服务不可达）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac6081dfd883259236afeca5dfe2fd)